### PR TITLE
fix: thread commands respect LANGSMITH_PROJECT

### DIFF
--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -45,8 +45,9 @@ func newThreadListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List conversation threads in a project",
 		Run: func(cmd *cobra.Command, args []string) {
+			project = ResolveProject(project)
 			if project == "" {
-				exitError("--project is required for thread list")
+				exitError("--project is required for thread list (or set LANGSMITH_PROJECT)")
 			}
 
 			c := mustGetClient()
@@ -170,12 +171,11 @@ func newThreadListCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Project name (required)")
+	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
 	cmd.Flags().IntVarP(&limit, "limit", "n", 20, "Maximum number of threads to return")
 	cmd.Flags().StringVar(&rawFilter, "filter", "", "Raw LangSmith filter DSL string")
 	cmd.Flags().IntVar(&lastNMinutes, "last-n-minutes", 0, "Only include threads active in last N minutes")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
-	_ = cmd.MarkFlagRequired("project")
 
 	return cmd
 }
@@ -202,8 +202,9 @@ func newThreadGetCmd() *cobra.Command {
 				includeIO = true
 			}
 
+			project = ResolveProject(project)
 			if project == "" {
-				exitError("--project is required for thread get")
+				exitError("--project is required for thread get (or set LANGSMITH_PROJECT)")
 			}
 
 			c := mustGetClient()
@@ -250,13 +251,12 @@ func newThreadGetCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Project name (required)")
+	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, token_usage, costs, tags")
 	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, and error fields")
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io")
 	cmd.Flags().IntVarP(&limit, "limit", "n", 0, "Maximum number of runs (turns) to return")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
-	_ = cmd.MarkFlagRequired("project")
 
 	return cmd
 }

--- a/internal/cmd/thread_test.go
+++ b/internal/cmd/thread_test.go
@@ -58,18 +58,38 @@ func TestThreadListCmd_Flags(t *testing.T) {
 	}
 }
 
-func TestThreadListCmd_ProjectRequired(t *testing.T) {
+func TestThreadListCmd_ProjectNotCobraRequired(t *testing.T) {
 	cmd := newThreadListCmd()
 	f := cmd.Flags().Lookup("project")
 	if f == nil {
 		t.Fatal("--project flag not found")
 	}
+	// project should NOT be marked as cobra-required so that
+	// ResolveProject can fall back to LANGSMITH_PROJECT env var
 	ann := f.Annotations
-	if ann == nil {
-		t.Fatal("--project has no annotations (not marked required)")
+	if ann != nil {
+		if _, ok := ann["cobra_annotation_bash_completion_one_required_flag"]; ok {
+			t.Error("--project should not be marked as cobra-required; use ResolveProject instead")
+		}
 	}
-	if _, ok := ann["cobra_annotation_bash_completion_one_required_flag"]; !ok {
-		t.Error("--project not marked as required")
+}
+
+func TestThreadListCmd_ProjectEnvFallback(t *testing.T) {
+	t.Setenv("LANGSMITH_PROJECT", "env-project")
+	result := ResolveProject("")
+	if result != "env-project" {
+		t.Errorf("expected ResolveProject to return env-project, got %q", result)
+	}
+}
+
+func TestThreadListCmd_ProjectFlagHelpMentionsEnv(t *testing.T) {
+	cmd := newThreadListCmd()
+	f := cmd.Flags().Lookup("project")
+	if f == nil {
+		t.Fatal("--project flag not found")
+	}
+	if f.Usage != "Project name [env: LANGSMITH_PROJECT]" {
+		t.Errorf("expected project flag usage to mention env var, got %q", f.Usage)
 	}
 }
 
@@ -114,17 +134,29 @@ func TestThreadGetCmd_ExactArgs(t *testing.T) {
 	}
 }
 
-func TestThreadGetCmd_ProjectRequired(t *testing.T) {
+func TestThreadGetCmd_ProjectNotCobraRequired(t *testing.T) {
 	cmd := newThreadGetCmd()
 	f := cmd.Flags().Lookup("project")
 	if f == nil {
 		t.Fatal("--project flag not found")
 	}
+	// project should NOT be marked as cobra-required so that
+	// ResolveProject can fall back to LANGSMITH_PROJECT env var
 	ann := f.Annotations
-	if ann == nil {
-		t.Fatal("--project has no annotations (not marked required)")
+	if ann != nil {
+		if _, ok := ann["cobra_annotation_bash_completion_one_required_flag"]; ok {
+			t.Error("--project should not be marked as cobra-required; use ResolveProject instead")
+		}
 	}
-	if _, ok := ann["cobra_annotation_bash_completion_one_required_flag"]; !ok {
-		t.Error("--project not marked as required")
+}
+
+func TestThreadGetCmd_ProjectFlagHelpMentionsEnv(t *testing.T) {
+	cmd := newThreadGetCmd()
+	f := cmd.Flags().Lookup("project")
+	if f == nil {
+		t.Fatal("--project flag not found")
+	}
+	if f.Usage != "Project name [env: LANGSMITH_PROJECT]" {
+		t.Errorf("expected project flag usage to mention env var, got %q", f.Usage)
 	}
 }


### PR DESCRIPTION
thread commands will now respect `LANGSMITH_PROJECT` just like how run and trace respect it