### PR TITLE
fix: implement pagination for datasets, examples, experiments, and projects

### DIFF
--- a/internal/cmd/dataset.go
+++ b/internal/cmd/dataset.go
@@ -54,19 +54,28 @@ func newDatasetListCmd() *cobra.Command {
 			c := mustGetClient()
 			ctx := context.Background()
 
+			pageSize := int64(20)
+			if limit > 0 && int64(limit) < pageSize {
+				pageSize = int64(limit)
+			}
 			params := langsmith.DatasetListParams{
-				Limit: langsmith.F(int64(limit)),
+				Limit: langsmith.F(pageSize),
 			}
 			if nameContains != "" {
 				params.NameContains = langsmith.F(nameContains)
 			}
 
-			resp, err := c.SDK.Datasets.List(ctx, params)
-			if err != nil {
+			var datasets []langsmith.Dataset
+			pager := c.SDK.Datasets.ListAutoPaging(ctx, params)
+			for pager.Next() {
+				datasets = append(datasets, pager.Current())
+				if limit > 0 && len(datasets) >= limit {
+					break
+				}
+			}
+			if err := pager.Err(); err != nil {
 				exitErrorf("listing datasets: %v", err)
 			}
-
-			datasets := resp.Items
 			fmt_ := getFormat()
 
 			if fmt_ == "pretty" {
@@ -257,28 +266,23 @@ func newDatasetExportCmd() *cobra.Command {
 				exitErrorf("%v", err)
 			}
 
+			exportPageSize := int64(20)
+			if limit > 0 && int64(limit) < exportPageSize {
+				exportPageSize = int64(limit)
+			}
 			var allExamples []langsmith.Example
-			remaining := limit
-			offset := 0
-			for remaining > 0 {
-				pageSize := remaining
-				if pageSize > 100 {
-					pageSize = 100
-				}
-				resp, err := c.SDK.Examples.List(ctx, langsmith.ExampleListParams{
-					Dataset: langsmith.F(ds.ID),
-					Limit:   langsmith.F(int64(pageSize)),
-					Offset:  langsmith.F(int64(offset)),
-				})
-				if err != nil {
-					exitErrorf("listing examples: %v", err)
-				}
-				allExamples = append(allExamples, resp.Items...)
-				if len(resp.Items) < pageSize {
+			pager := c.SDK.Examples.ListAutoPaging(ctx, langsmith.ExampleListParams{
+				Dataset: langsmith.F(ds.ID),
+				Limit:   langsmith.F(exportPageSize),
+			})
+			for pager.Next() {
+				allExamples = append(allExamples, pager.Current())
+				if limit > 0 && len(allExamples) >= limit {
 					break
 				}
-				remaining -= len(resp.Items)
-				offset += len(resp.Items)
+			}
+			if err := pager.Err(); err != nil {
+				exitErrorf("listing examples: %v", err)
 			}
 
 			var data []map[string]any

--- a/internal/cmd/example.go
+++ b/internal/cmd/example.go
@@ -54,28 +54,27 @@ func newExampleListCmd() *cobra.Command {
 				exitErrorf("%v", err)
 			}
 
+			pageSize := int64(20)
+			if limit > 0 && int64(limit) < pageSize {
+				pageSize = int64(limit)
+			}
+			params := langsmith.ExampleListParams{
+				Dataset: langsmith.F(ds.ID),
+				Limit:   langsmith.F(pageSize),
+			}
+			if offset > 0 {
+				params.Offset = langsmith.F(int64(offset))
+			}
 			var examples []langsmith.Example
-			remaining := limit
-			pageOffset := offset
-			for remaining > 0 {
-				pageSize := remaining
-				if pageSize > 100 {
-					pageSize = 100
-				}
-				resp, err := c.SDK.Examples.List(ctx, langsmith.ExampleListParams{
-					Dataset: langsmith.F(ds.ID),
-					Limit:   langsmith.F(int64(pageSize)),
-					Offset:  langsmith.F(int64(pageOffset)),
-				})
-				if err != nil {
-					exitErrorf("listing examples: %v", err)
-				}
-				examples = append(examples, resp.Items...)
-				if len(resp.Items) < pageSize {
+			pager := c.SDK.Examples.ListAutoPaging(ctx, params)
+			for pager.Next() {
+				examples = append(examples, pager.Current())
+				if limit > 0 && len(examples) >= limit {
 					break
 				}
-				remaining -= len(resp.Items)
-				pageOffset += len(resp.Items)
+			}
+			if err := pager.Err(); err != nil {
+				exitErrorf("listing examples: %v", err)
 			}
 			fmt_ := getFormat()
 

--- a/internal/cmd/experiment.go
+++ b/internal/cmd/experiment.go
@@ -43,8 +43,12 @@ func newExperimentListCmd() *cobra.Command {
 			c := mustGetClient()
 			ctx := context.Background()
 
+			pageSize := int64(20)
+			if limit > 0 && int64(limit) < pageSize {
+				pageSize = int64(limit)
+			}
 			params := langsmith.SessionListParams{
-				Limit:         langsmith.F(int64(limit)),
+				Limit:         langsmith.F(pageSize),
 				ReferenceFree: langsmith.F(false),
 				IncludeStats:  langsmith.F(true),
 			}
@@ -57,12 +61,17 @@ func newExperimentListCmd() *cobra.Command {
 				params.ReferenceDataset = langsmith.F([]string{ds.ID})
 			}
 
-			resp, err := c.SDK.Sessions.List(ctx, params)
-			if err != nil {
+			var projects []langsmith.TracerSession
+			pager := c.SDK.Sessions.ListAutoPaging(ctx, params)
+			for pager.Next() {
+				projects = append(projects, pager.Current())
+				if limit > 0 && len(projects) >= limit {
+					break
+				}
+			}
+			if err := pager.Err(); err != nil {
 				exitErrorf("listing experiments: %v", err)
 			}
-
-			projects := resp.Items
 			fmt_ := getFormat()
 
 			if fmt_ == "pretty" {

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -46,8 +46,12 @@ func newProjectListCmd() *cobra.Command {
 			c := mustGetClient()
 			ctx := context.Background()
 
+			pageSize := int64(20)
+			if limit > 0 && int64(limit) < pageSize {
+				pageSize = int64(limit)
+			}
 			params := langsmith.SessionListParams{
-				Limit:         langsmith.F(int64(limit)),
+				Limit:         langsmith.F(pageSize),
 				ReferenceFree: langsmith.F(true),
 				IncludeStats:  langsmith.F(true),
 			}
@@ -55,12 +59,17 @@ func newProjectListCmd() *cobra.Command {
 				params.NameContains = langsmith.F(nameContains)
 			}
 
-			resp, err := c.SDK.Sessions.List(ctx, params)
-			if err != nil {
+			var projects []langsmith.TracerSession
+			pager := c.SDK.Sessions.ListAutoPaging(ctx, params)
+			for pager.Next() {
+				projects = append(projects, pager.Current())
+				if limit > 0 && len(projects) >= limit {
+					break
+				}
+			}
+			if err := pager.Err(); err != nil {
 				exitErrorf("listing projects: %v", err)
 			}
-
-			projects := resp.Items
 			fmt_ := getFormat()
 
 			if fmt_ == "pretty" {


### PR DESCRIPTION
Previously, we weren't paginating resources properly, now we use the right go-sdk parameters for pagination