### PR TITLE
fix: check self-hosted urls and append only if necessary

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -25,20 +25,30 @@ type Client struct {
 	sessionCache map[string]string
 }
 
+// NormalizeURL strips a trailing "/api/v1" suffix (with or without a trailing
+// slash) so that the SDK — which appends "api/v1" itself — does not double it.
+// Self-hosted users commonly set LANGSMITH_ENDPOINT to "https://host/api/v1".
+func NormalizeURL(apiURL string) string {
+	u := strings.TrimRight(apiURL, "/")
+	return strings.TrimSuffix(u, "/api/v1")
+}
+
 // New creates a new Client.
 func New(apiKey, apiURL string) *Client {
+	normalized := NormalizeURL(apiURL)
+
 	opts := []option.RequestOption{
 		option.WithAPIKey(apiKey),
 	}
 	// Only set base URL if not the default (the SDK reads LANGSMITH_ENDPOINT too).
-	if apiURL != "" {
-		opts = append(opts, option.WithBaseURL(apiURL))
+	if normalized != "" {
+		opts = append(opts, option.WithBaseURL(normalized))
 	}
 
 	return &Client{
 		SDK:          langsmith.NewClient(opts...),
 		apiKey:       apiKey,
-		apiURL:       strings.TrimRight(apiURL, "/"),
+		apiURL:       normalized,
 		sessionCache: make(map[string]string),
 	}
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -9,6 +9,28 @@ import (
 	"testing"
 )
 
+// ---------- NormalizeURL ----------
+
+func TestNormalizeURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no-op", "https://api.smith.langchain.com", "https://api.smith.langchain.com"},
+		{"strips /api/v1", "https://myhost.com/api/v1", "https://myhost.com"},
+		{"strips /api/v1/", "https://myhost.com/api/v1/", "https://myhost.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeURL(tt.in)
+			if got != tt.want {
+				t.Errorf("NormalizeURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 // ---------- New ----------
 
 func TestNew_CreatesClient(t *testing.T) {


### PR DESCRIPTION
Check the self-hosted URL - strip api/vi if present. The SDK adds this automatically