### PR TITLE
Add id field to experiment get output

### DIFF
--- a/internal/cmd/experiment.go
+++ b/internal/cmd/experiment.go
@@ -168,6 +168,7 @@ func newExperimentGetCmd() *cobra.Command {
 
 			// Build output
 			data := map[string]any{
+				"id":            p.ID,
 				"name":          p.Name,
 				"feedback_stats": p.FeedbackStats,
 				"run_stats": map[string]any{


### PR DESCRIPTION
## Summary
- `experiment get` currently omits the experiment `id`, making it impossible to construct comparison URLs programmatically (e.g. `https://smith.langchain.com/o/{org}/datasets/{name}/compare?selectedSessions={id}`)
- `experiment list` already returns `id` — this makes `get` consistent
- One-line change: adds `"id": p.ID` to the output map

## Test plan
- [x] Run `langsmith experiment get <name>` and verify `id` field is present in JSON output
- [x] Verify `id` matches the UUID from `langsmith experiment list`