### PR TITLE
fix: change --name filter from exact match to substring search

### DIFF
--- a/internal/cmd/filters.go
+++ b/internal/cmd/filters.go
@@ -132,9 +132,9 @@ func buildFilterDSL(f *FilterFlags) string {
 		}
 	}
 
-	// Name filter (exact match via eq; use --filter for advanced name queries)
+	// Name filter (substring search)
 	if f.Name != "" {
-		parts = append(parts, fmt.Sprintf("eq(name, %q)", f.Name))
+		parts = append(parts, fmt.Sprintf("search(name, %q)", f.Name))
 	}
 
 	// Latency filters

--- a/internal/cmd/filters_test.go
+++ b/internal/cmd/filters_test.go
@@ -16,7 +16,7 @@ func TestBuildFilterDSL_Empty(t *testing.T) {
 func TestBuildFilterDSL_SingleName(t *testing.T) {
 	f := &FilterFlags{Name: "ChatOpenAI"}
 	result := buildFilterDSL(f)
-	expected := `eq(name, "ChatOpenAI")`
+	expected := `search(name, "ChatOpenAI")`
 	if result != expected {
 		t.Errorf("expected %q, got %q", expected, result)
 	}
@@ -92,7 +92,7 @@ func TestBuildFilterDSL_Combined(t *testing.T) {
 		Tags:       "prod",
 	}
 	result := buildFilterDSL(f)
-	expected := `and(eq(name, "ChatOpenAI"), gte(latency, 2.5), has(tags, "prod"))`
+	expected := `and(search(name, "ChatOpenAI"), gte(latency, 2.5), has(tags, "prod"))`
 	if result != expected {
 		t.Errorf("expected %q, got %q", expected, result)
 	}
@@ -249,7 +249,7 @@ func TestBuildRunQueryParams_FilterDSLWithName(t *testing.T) {
 	if !params.Filter.Present {
 		t.Fatal("expected Filter to be set")
 	}
-	expected := `eq(name, "ChatOpenAI")`
+	expected := `search(name, "ChatOpenAI")`
 	if params.Filter.Value != expected {
 		t.Errorf("expected %q, got %q", expected, params.Filter.Value)
 	}


### PR DESCRIPTION
## Problem

`--name` uses `eq(name, ...)` (exact match) but the README and langsmith-skills both describe it as substring search.

## Fix

Switch from `eq(name, ...)` to `search(name, ...)` DSL operator, which performs substring matching per the LangSmith filter DSL.