### PR TITLE
feat: add named profile support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/langchain-ai/langsmith-cli
 go 1.25.0
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/yamux v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -96,6 +96,50 @@ func (c *Client) RawDelete(ctx context.Context, path string, result any) error {
 	return c.rawRequest(ctx, http.MethodDelete, path, nil, result)
 }
 
+// RawDo performs an arbitrary HTTP request and returns the raw response.
+// Unlike RawGet/RawPost/RawDelete, it does not unmarshal the response and
+// does not treat 4xx/5xx as errors — callers decide how to handle status codes.
+// body may be nil. extraHeaders are merged on top of the default auth headers.
+func (c *Client) RawDo(ctx context.Context, method, path string, body io.Reader, extraHeaders http.Header) (statusCode int, respHeaders http.Header, respBody []byte, err error) {
+	url := c.apiURL + path
+
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return 0, nil, nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("x-api-key", c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	if wsID := os.Getenv("LANGSMITH_WORKSPACE_ID"); wsID != "" {
+		req.Header.Set("x-tenant-id", wsID)
+	}
+	for k, vals := range extraHeaders {
+		for _, v := range vals {
+			req.Header.Set(k, v)
+		}
+	}
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, nil, nil, fmt.Errorf("HTTP %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	return resp.StatusCode, resp.Header, respBody, nil
+}
+
+// APIKey returns the client's API key.
+func (c *Client) APIKey() string { return c.apiKey }
+
+// APIURL returns the client's normalized API URL.
+func (c *Client) APIURL() string { return c.apiURL }
+
 func (c *Client) rawRequest(ctx context.Context, method, path string, body any, result any) error {
 	url := c.apiURL + path
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -224,8 +224,6 @@ func TestRawRequest_SetsAPIKeyHeader(t *testing.T) {
 }
 
 func TestRawRequest_SetsWorkspaceHeader(t *testing.T) {
-	t.Setenv("LANGSMITH_WORKSPACE_ID", "ws-123")
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("x-tenant-id"); got != "ws-123" {
 			t.Errorf("expected x-tenant-id=ws-123, got %q", got)
@@ -235,13 +233,12 @@ func TestRawRequest_SetsWorkspaceHeader(t *testing.T) {
 	}))
 	defer ts.Close()
 
+	t.Setenv("LANGSMITH_WORKSPACE_ID", "ws-123")
 	c := New("key", ts.URL)
 	_ = c.RawGet(context.Background(), "/test", nil)
 }
 
 func TestRawRequest_NoWorkspaceHeaderWhenUnset(t *testing.T) {
-	t.Setenv("LANGSMITH_WORKSPACE_ID", "")
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("x-tenant-id"); got != "" {
 			t.Errorf("expected empty x-tenant-id, got %q", got)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -313,5 +314,118 @@ func TestRawRequest_500Error(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "500") {
 		t.Errorf("expected 500 in error, got %q", err.Error())
+	}
+}
+
+// ---------- RawDo ----------
+
+func TestRawDo_ReturnsStatusAndBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PATCH" {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/sessions" {
+			t.Errorf("expected /api/v1/sessions, got %s", r.URL.Path)
+		}
+		if r.Header.Get("x-api-key") != "my-key" {
+			t.Errorf("expected x-api-key=my-key, got %q", r.Header.Get("x-api-key"))
+		}
+		w.Header().Set("X-Request-Id", "req-abc")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"id":"123"}`))
+	}))
+	defer ts.Close()
+
+	c := New("my-key", ts.URL)
+	status, hdr, body, err := c.RawDo(context.Background(), "PATCH", "/api/v1/sessions", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != 200 {
+		t.Errorf("expected status 200, got %d", status)
+	}
+	if hdr.Get("X-Request-Id") != "req-abc" {
+		t.Errorf("expected X-Request-Id=req-abc, got %q", hdr.Get("X-Request-Id"))
+	}
+	if string(body) != `{"id":"123"}` {
+		t.Errorf("expected body {\"id\":\"123\"}, got %q", string(body))
+	}
+}
+
+func TestRawDo_WithBodyReader(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, _ := io.ReadAll(r.Body)
+		w.WriteHeader(201)
+		_, _ = w.Write(data)
+	}))
+	defer ts.Close()
+
+	c := New("key", ts.URL)
+	status, _, body, err := c.RawDo(context.Background(), "POST", "/create", strings.NewReader(`{"name":"test"}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != 201 {
+		t.Errorf("expected 201, got %d", status)
+	}
+	if string(body) != `{"name":"test"}` {
+		t.Errorf("unexpected body: %s", body)
+	}
+}
+
+func TestRawDo_ExtraHeaders(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Custom") != "hello" {
+			t.Errorf("expected X-Custom=hello, got %q", r.Header.Get("X-Custom"))
+		}
+		if r.Header.Get("x-api-key") != "key" {
+			t.Errorf("expected x-api-key=key, got %q", r.Header.Get("x-api-key"))
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	c := New("key", ts.URL)
+	extra := http.Header{"X-Custom": []string{"hello"}}
+	_, _, _, err := c.RawDo(context.Background(), "GET", "/test", nil, extra)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRawDo_Returns4xxWithoutError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(422)
+		_, _ = w.Write([]byte(`{"detail":"invalid"}`))
+	}))
+	defer ts.Close()
+
+	c := New("key", ts.URL)
+	status, _, body, err := c.RawDo(context.Background(), "GET", "/test", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != 422 {
+		t.Errorf("expected 422, got %d", status)
+	}
+	if string(body) != `{"detail":"invalid"}` {
+		t.Errorf("unexpected body: %s", body)
+	}
+}
+
+// ---------- Accessors ----------
+
+func TestAPIKey(t *testing.T) {
+	c := New("secret", "http://localhost")
+	if c.APIKey() != "secret" {
+		t.Errorf("expected secret, got %q", c.APIKey())
+	}
+}
+
+func TestAPIURL(t *testing.T) {
+	c := New("key", "http://localhost:1234")
+	if c.APIURL() != "http://localhost:1234" {
+		t.Errorf("expected http://localhost:1234, got %q", c.APIURL())
 	}
 }

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCmd creates the top-level `langsmith api` command.
+func NewCmd() *cobra.Command {
+	var (
+		body    string
+		headers []string
+		include bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "api",
+		Short: "Browse API endpoints and make authenticated requests",
+		Long: `Browse LangSmith API endpoints and make authenticated HTTP requests.
+
+Browse endpoints:
+  langsmith api ls                              List all endpoints
+  langsmith api ls --tag datasets               Filter by tag
+  langsmith api ls --search "create"            Search endpoints
+  langsmith api info GET sessions               Show endpoint details
+
+Make requests:
+  langsmith api GET sessions?limit=5
+  langsmith api POST runs/query --body '{"session_id":"abc"}'
+  langsmith api DELETE sessions/abc-123
+  langsmith api POST datasets --body @body.json
+  echo '{"name":"x"}' | langsmith api POST sessions --body @-
+  langsmith api GET sessions --include`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 2 {
+				return cmd.Help()
+			}
+
+			method := strings.ToUpper(args[0])
+			if !isHTTPMethod(method) {
+				return fmt.Errorf("unknown subcommand or HTTP method: %q\nRun 'langsmith api --help' for usage", args[0])
+			}
+
+			path := args[1]
+
+			apiKey := resolveAPIKey(cmd)
+			if apiKey == "" {
+				return fmt.Errorf("LANGSMITH_API_KEY not set")
+			}
+			apiURL := resolveAPIURL(cmd)
+
+			w := cmd.OutOrStdout()
+			statusCode, err := runRequest(apiURL, apiKey, method, path, body, headers, include, w)
+			if err != nil {
+				return err
+			}
+			if statusCode >= 400 {
+				os.Exit(1)
+			}
+			return nil
+		},
+	}
+
+	// Flags for request mode
+	cmd.Flags().StringVar(&body, "body", "", `Request body (JSON string, @file, or @- for stdin)`)
+	cmd.Flags().StringArrayVarP(&headers, "header", "H", nil, "Additional headers (Key:Value, repeatable)")
+	cmd.Flags().BoolVarP(&include, "include", "i", false, "Include HTTP response headers in output")
+
+	// These persistent flags mirror root's so the api command works standalone
+	// in tests. When registered under root, cobra's flag inheritance means
+	// the root's values take precedence when set via CLI.
+	cmd.PersistentFlags().String("api-key", "", "LangSmith API key [env: LANGSMITH_API_KEY]")
+	cmd.PersistentFlags().String("api-url", "", "LangSmith API URL [env: LANGSMITH_ENDPOINT]")
+	cmd.PersistentFlags().String("format", "json", "Output format: json or pretty")
+
+	cmd.AddCommand(newLsCmd())
+	cmd.AddCommand(newInfoCmd())
+
+	return cmd
+}

--- a/internal/cmd/api/api_test.go
+++ b/internal/cmd/api/api_test.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewCmd_HasSubcommands(t *testing.T) {
+	cmd := NewCmd()
+	names := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		names[sub.Name()] = true
+	}
+	if !names["ls"] {
+		t.Error("missing subcommand 'ls'")
+	}
+	if !names["info"] {
+		t.Error("missing subcommand 'info'")
+	}
+}
+
+func TestNewCmd_UseField(t *testing.T) {
+	cmd := NewCmd()
+	if cmd.Use != "api" {
+		t.Errorf("expected Use='api', got %q", cmd.Use)
+	}
+}
+
+func TestNewCmd_RequestFlags(t *testing.T) {
+	cmd := NewCmd()
+	for _, name := range []string{"body", "header", "include"} {
+		f := cmd.Flags().Lookup(name)
+		if f == nil {
+			t.Errorf("flag --%s not found on api command", name)
+		}
+	}
+}
+
+func TestNewCmd_GETRequest(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/openapi.json" {
+			json.NewEncoder(w).Encode(map[string]any{"openapi": "3.1.0", "paths": map[string]any{}})
+			return
+		}
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/sessions" {
+			t.Errorf("expected /api/v1/sessions, got %s", r.URL.Path)
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	cmd := NewCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--api-key", "test-key", "--api-url", ts.URL, "GET", "sessions"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "ok") {
+		t.Errorf("expected JSON response, got %q", out.String())
+	}
+}
+
+func TestNewCmd_POSTWithBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/openapi.json" {
+			json.NewEncoder(w).Encode(map[string]any{"openapi": "3.1.0", "paths": map[string]any{}})
+			return
+		}
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"created":true}`))
+	}))
+	defer ts.Close()
+
+	cmd := NewCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--api-key", "test-key", "--api-url", ts.URL, "POST", "sessions", "--body", `{"name":"x"}`})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "created") {
+		t.Errorf("expected JSON response, got %q", out.String())
+	}
+}
+
+func TestNewCmd_NoArgsShowsHelp(t *testing.T) {
+	cmd := NewCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{})
+
+	// Should not error — shows help
+	_ = cmd.Execute()
+	if !strings.Contains(out.String(), "Browse") {
+		t.Errorf("expected help output, got %q", out.String())
+	}
+}
+
+func TestNewCmd_InvalidMethod(t *testing.T) {
+	cmd := NewCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--api-key", "key", "BOGUS", "sessions"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid method")
+	}
+	if !strings.Contains(err.Error(), "unknown subcommand or HTTP method") {
+		t.Errorf("expected helpful error, got %q", err.Error())
+	}
+}

--- a/internal/cmd/api/info.go
+++ b/internal/cmd/api/info.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Test overrides.
+var (
+	infoAPIURL   string
+	infoCacheDir string
+	infoFormat   string
+)
+
+func newInfoCmd() *cobra.Command {
+	var refresh bool
+
+	cmd := &cobra.Command{
+		Use:   "info METHOD PATH",
+		Short: "Show details for a specific API endpoint",
+		Long: `Show full details for a specific API endpoint including parameters,
+request body schema, and response schema.
+
+Examples:
+  langsmith api info GET /api/v1/sessions
+  langsmith api info GET sessions
+  langsmith api info POST runs/query`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			method := args[0]
+			path := args[1]
+
+			apiURL := infoAPIURL
+			if apiURL == "" {
+				apiURL = resolveAPIURL(cmd)
+			}
+			cacheDir := infoCacheDir
+			if cacheDir == "" {
+				cacheDir = defaultCacheDir()
+			}
+			format := infoFormat
+			if format == "" {
+				format = resolveFormat(cmd)
+			}
+
+			spec, err := loadSpec(apiURL, cacheDir, refresh)
+			if err != nil {
+				return err
+			}
+
+			detail, err := spec.LookupEndpoint(method, path)
+			if err != nil {
+				return err
+			}
+
+			w := cmd.OutOrStdout()
+
+			if format == "pretty" {
+				fmt.Fprintf(w, "%s %s\n", detail.Method, detail.Path)
+				fmt.Fprintf(w, "Tag: %s\n", detail.Tag)
+				fmt.Fprintf(w, "Summary: %s\n", detail.Summary)
+				if detail.Description != "" {
+					fmt.Fprintf(w, "Description: %s\n", detail.Description)
+				}
+				if len(detail.Parameters) > 0 {
+					fmt.Fprintf(w, "\nParameters:\n")
+					for _, p := range detail.Parameters {
+						req := ""
+						if p.Required {
+							req = " (required)"
+						}
+						fmt.Fprintf(w, "  %-20s %-10s %s%s\n", p.Name, p.Type, p.Description, req)
+					}
+				}
+				if detail.RequestBody != nil {
+					fmt.Fprintf(w, "\nRequest Body:\n")
+					b, _ := json.MarshalIndent(detail.RequestBody, "  ", "  ")
+					fmt.Fprintf(w, "  %s\n", b)
+				}
+				if detail.Response != nil {
+					fmt.Fprintf(w, "\nResponse Schema:\n")
+					b, _ := json.MarshalIndent(detail.Response, "  ", "  ")
+					fmt.Fprintf(w, "  %s\n", b)
+				}
+			} else {
+				data, _ := json.MarshalIndent(detail, "", "  ")
+				fmt.Fprintln(w, string(data))
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force re-fetch of the OpenAPI spec")
+
+	return cmd
+}

--- a/internal/cmd/api/info_test.go
+++ b/internal/cmd/api/info_test.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newDetailedSpecServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	spec := map[string]any{
+		"openapi": "3.1.0",
+		"paths": map[string]any{
+			"/api/v1/sessions": map[string]any{
+				"get": map[string]any{
+					"summary": "List sessions",
+					"tags":    []any{"tracer-sessions"},
+					"parameters": []any{
+						map[string]any{
+							"name": "limit", "in": "query", "required": false,
+							"schema": map[string]any{"type": "integer"},
+							"description": "Max results",
+						},
+					},
+					"responses": map[string]any{
+						"200": map[string]any{
+							"content": map[string]any{
+								"application/json": map[string]any{
+									"schema": map[string]any{"type": "array"},
+								},
+							},
+						},
+					},
+				},
+			},
+			"/api/v1/runs/query": map[string]any{
+				"post": map[string]any{
+					"summary": "Query runs",
+					"tags":    []any{"run"},
+					"requestBody": map[string]any{
+						"required": true,
+						"content": map[string]any{
+							"application/json": map[string]any{
+								"schema": map[string]any{
+									"type": "object",
+									"properties": map[string]any{
+										"session_id": map[string]any{"type": "string"},
+									},
+									"required": []any{"session_id"},
+								},
+							},
+						},
+					},
+					"responses": map[string]any{
+						"200": map[string]any{
+							"content": map[string]any{
+								"application/json": map[string]any{
+									"schema": map[string]any{"type": "object"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/openapi.json" {
+			json.NewEncoder(w).Encode(spec)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+}
+
+func TestInfoCmd_JSON(t *testing.T) {
+	ts := newDetailedSpecServer(t)
+	defer ts.Close()
+
+	cmd := newInfoCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"GET", "/api/v1/sessions"})
+
+	infoAPIURL = ts.URL
+	infoCacheDir = t.TempDir()
+	infoFormat = "json"
+	defer func() { infoAPIURL = ""; infoCacheDir = ""; infoFormat = "" }()
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var detail EndpointDetail
+	if err := json.Unmarshal(out.Bytes(), &detail); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
+	}
+	if detail.Method != "GET" {
+		t.Errorf("expected method GET, got %q", detail.Method)
+	}
+	if detail.Path != "/api/v1/sessions" {
+		t.Errorf("expected path /api/v1/sessions, got %q", detail.Path)
+	}
+	if len(detail.Parameters) != 1 {
+		t.Errorf("expected 1 parameter, got %d", len(detail.Parameters))
+	}
+	if detail.Parameters[0].Name != "limit" {
+		t.Errorf("expected param name 'limit', got %q", detail.Parameters[0].Name)
+	}
+}
+
+func TestInfoCmd_Shorthand(t *testing.T) {
+	ts := newDetailedSpecServer(t)
+	defer ts.Close()
+
+	cmd := newInfoCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"GET", "sessions"})
+
+	infoAPIURL = ts.URL
+	infoCacheDir = t.TempDir()
+	infoFormat = "json"
+	defer func() { infoAPIURL = ""; infoCacheDir = ""; infoFormat = "" }()
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var detail EndpointDetail
+	json.Unmarshal(out.Bytes(), &detail)
+	if detail.Path != "/api/v1/sessions" {
+		t.Errorf("expected resolved path /api/v1/sessions, got %q", detail.Path)
+	}
+}
+
+func TestInfoCmd_WithRequestBody(t *testing.T) {
+	ts := newDetailedSpecServer(t)
+	defer ts.Close()
+
+	cmd := newInfoCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"POST", "runs/query"})
+
+	infoAPIURL = ts.URL
+	infoCacheDir = t.TempDir()
+	infoFormat = "json"
+	defer func() { infoAPIURL = ""; infoCacheDir = ""; infoFormat = "" }()
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var detail EndpointDetail
+	json.Unmarshal(out.Bytes(), &detail)
+	if detail.RequestBody == nil {
+		t.Fatal("expected request_body to be non-nil")
+	}
+}
+
+func TestInfoCmd_NotFound(t *testing.T) {
+	ts := newDetailedSpecServer(t)
+	defer ts.Close()
+
+	cmd := newInfoCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"GET", "nonexistent"})
+
+	infoAPIURL = ts.URL
+	infoCacheDir = t.TempDir()
+	infoFormat = "json"
+	defer func() { infoAPIURL = ""; infoCacheDir = ""; infoFormat = "" }()
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for nonexistent endpoint")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got %q", err.Error())
+	}
+}

--- a/internal/cmd/api/ls.go
+++ b/internal/cmd/api/ls.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+// Test overrides — empty means "use real values from cobra flags".
+var (
+	lsAPIURL   string
+	lsCacheDir string
+	lsFormat   string
+)
+
+func newLsCmd() *cobra.Command {
+	var (
+		tag     string
+		search  string
+		refresh bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "ls",
+		Short: "List available API endpoints from the OpenAPI spec",
+		Long: `List all available LangSmith API endpoints.
+
+The endpoint list is fetched from the OpenAPI spec and cached locally for 24 hours.
+
+Examples:
+  langsmith api ls
+  langsmith api ls --tag datasets
+  langsmith api ls --search "create"
+  langsmith api ls --tag run --search query
+  langsmith api ls --refresh`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			apiURL := lsAPIURL
+			if apiURL == "" {
+				apiURL = resolveAPIURL(cmd)
+			}
+			cacheDir := lsCacheDir
+			if cacheDir == "" {
+				cacheDir = defaultCacheDir()
+			}
+			format := lsFormat
+			if format == "" {
+				format = resolveFormat(cmd)
+			}
+
+			spec, err := loadSpec(apiURL, cacheDir, refresh)
+			if err != nil {
+				return err
+			}
+
+			endpoints := spec.Endpoints()
+
+			// Apply filters
+			if tag != "" || search != "" {
+				var filtered []Endpoint
+				for _, e := range endpoints {
+					if tag != "" && e.Tag != tag {
+						continue
+					}
+					if search != "" {
+						q := strings.ToLower(search)
+						if !strings.Contains(strings.ToLower(e.Path), q) &&
+							!strings.Contains(strings.ToLower(e.Summary), q) &&
+							!strings.Contains(strings.ToLower(e.Tag), q) {
+							continue
+						}
+					}
+					filtered = append(filtered, e)
+				}
+				endpoints = filtered
+			}
+
+			w := cmd.OutOrStdout()
+
+			if format == "pretty" {
+				table := tablewriter.NewWriter(w)
+				table.SetHeader([]string{"Method", "Path", "Tag", "Summary"})
+				table.SetBorder(false)
+				table.SetColumnSeparator("  ")
+				table.SetHeaderLine(true)
+				table.SetAutoWrapText(false)
+				for _, e := range endpoints {
+					table.Append([]string{e.Method, e.Path, e.Tag, e.Summary})
+				}
+				table.Render()
+				fmt.Fprintf(w, "(%d endpoints)\n", len(endpoints))
+			} else {
+				data, _ := json.MarshalIndent(endpoints, "", "  ")
+				fmt.Fprintln(w, string(data))
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&tag, "tag", "t", "", "Filter by tag")
+	cmd.Flags().StringVarP(&search, "search", "s", "", "Search path, summary, or tag (case-insensitive)")
+	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force re-fetch of the OpenAPI spec")
+
+	return cmd
+}

--- a/internal/cmd/api/ls_test.go
+++ b/internal/cmd/api/ls_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestSpecServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	spec := map[string]any{
+		"openapi": "3.1.0",
+		"paths": map[string]any{
+			"/api/v1/sessions": map[string]any{
+				"get":  map[string]any{"summary": "List sessions", "tags": []any{"tracer-sessions"}},
+				"post": map[string]any{"summary": "Create session", "tags": []any{"tracer-sessions"}},
+			},
+			"/api/v1/datasets": map[string]any{
+				"get":  map[string]any{"summary": "List datasets", "tags": []any{"datasets"}},
+				"post": map[string]any{"summary": "Create dataset", "tags": []any{"datasets"}},
+			},
+			"/api/v1/runs/query": map[string]any{
+				"post": map[string]any{"summary": "Query runs", "tags": []any{"run"}},
+			},
+		},
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/openapi.json" {
+			json.NewEncoder(w).Encode(spec)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+}
+
+func TestLsCmd_JSON(t *testing.T) {
+	ts := newTestSpecServer(t)
+	defer ts.Close()
+
+	cmd := newLsCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--refresh"})
+
+	lsAPIURL = ts.URL
+	lsCacheDir = t.TempDir()
+	lsFormat = "json"
+	defer func() { lsAPIURL = ""; lsCacheDir = ""; lsFormat = "" }()
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var endpoints []Endpoint
+	if err := json.Unmarshal(out.Bytes(), &endpoints); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, out.String())
+	}
+	if len(endpoints) != 5 {
+		t.Errorf("expected 5 endpoints, got %d", len(endpoints))
+	}
+}
+
+func TestLsCmd_FilterByTag(t *testing.T) {
+	ts := newTestSpecServer(t)
+	defer ts.Close()
+
+	cmd := newLsCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--tag", "datasets", "--refresh"})
+
+	lsAPIURL = ts.URL
+	lsCacheDir = t.TempDir()
+	lsFormat = "json"
+	defer func() { lsAPIURL = ""; lsCacheDir = ""; lsFormat = "" }()
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var endpoints []Endpoint
+	json.Unmarshal(out.Bytes(), &endpoints)
+	if len(endpoints) != 2 {
+		t.Errorf("expected 2 dataset endpoints, got %d", len(endpoints))
+	}
+	for _, e := range endpoints {
+		if e.Tag != "datasets" {
+			t.Errorf("expected tag=datasets, got %q", e.Tag)
+		}
+	}
+}
+
+func TestLsCmd_Search(t *testing.T) {
+	ts := newTestSpecServer(t)
+	defer ts.Close()
+
+	cmd := newLsCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--search", "query", "--refresh"})
+
+	lsAPIURL = ts.URL
+	lsCacheDir = t.TempDir()
+	lsFormat = "json"
+	defer func() { lsAPIURL = ""; lsCacheDir = ""; lsFormat = "" }()
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var endpoints []Endpoint
+	json.Unmarshal(out.Bytes(), &endpoints)
+	if len(endpoints) != 1 {
+		t.Errorf("expected 1 match for 'query', got %d", len(endpoints))
+	}
+}
+
+func TestLsCmd_Pretty(t *testing.T) {
+	ts := newTestSpecServer(t)
+	defer ts.Close()
+
+	cmd := newLsCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--refresh"})
+
+	lsAPIURL = ts.URL
+	lsCacheDir = t.TempDir()
+	lsFormat = "pretty"
+	defer func() { lsAPIURL = ""; lsCacheDir = ""; lsFormat = "" }()
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "METHOD") {
+		t.Errorf("expected table header with METHOD, got %q", output)
+	}
+	if !strings.Contains(output, "/api/v1/sessions") {
+		t.Errorf("expected endpoint path in output, got %q", output)
+	}
+}

--- a/internal/cmd/api/request.go
+++ b/internal/cmd/api/request.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/langchain-ai/langsmith-cli/internal/client"
+)
+
+// runRequest executes an HTTP request and writes the response to w.
+// Returns the HTTP status code and any transport-level error.
+func runRequest(apiURL, apiKey, method, path, body string, headers []string, include bool, w io.Writer) (int, error) {
+	c := client.New(apiKey, apiURL)
+
+	fullURL := resolveEndpoint(apiURL, path)
+	// Compute relative path for RawDo (which prepends apiURL)
+	relPath := strings.TrimPrefix(fullURL, apiURL)
+
+	// Resolve body
+	bodyReader, err := resolveBody(body)
+	if err != nil {
+		return 0, err
+	}
+
+	// Parse extra headers
+	extraHeaders := make(http.Header)
+	for _, h := range headers {
+		k, v, ok := strings.Cut(h, ":")
+		if !ok {
+			return 0, fmt.Errorf("invalid header format %q (expected Key:Value)", h)
+		}
+		extraHeaders.Set(strings.TrimSpace(k), strings.TrimSpace(v))
+	}
+
+	statusCode, respHeaders, respBody, err := c.RawDo(context.Background(), method, relPath, bodyReader, extraHeaders)
+	if err != nil {
+		return 0, err
+	}
+
+	// Print response headers if --include
+	if include {
+		fmt.Fprintf(w, "HTTP/1.1 %d %s\n", statusCode, http.StatusText(statusCode))
+		for k, vals := range respHeaders {
+			for _, v := range vals {
+				fmt.Fprintf(w, "%s: %s\n", k, v)
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	// Pretty-print JSON if possible, otherwise print raw
+	var prettyBuf bytes.Buffer
+	if json.Indent(&prettyBuf, respBody, "", "  ") == nil {
+		fmt.Fprintln(w, prettyBuf.String())
+	} else {
+		w.Write(respBody)
+		fmt.Fprintln(w)
+	}
+
+	return statusCode, nil
+}
+
+// resolveBody resolves a --body value to an io.Reader.
+//   - Empty string → nil (no body).
+//   - "@-" → stdin.
+//   - "@path" → file contents.
+//   - Otherwise → treated as inline JSON string.
+func resolveBody(body string) (io.Reader, error) {
+	if body == "" {
+		return nil, nil
+	}
+	if body == "@-" {
+		return os.Stdin, nil
+	}
+	if strings.HasPrefix(body, "@") {
+		filePath := body[1:]
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("reading body file %q: %w", filePath, err)
+		}
+		return bytes.NewReader(data), nil
+	}
+	return strings.NewReader(body), nil
+}

--- a/internal/cmd/api/request.go
+++ b/internal/cmd/api/request.go
@@ -19,8 +19,17 @@ func runRequest(apiURL, apiKey, method, path, body string, headers []string, inc
 	c := client.New(apiKey, apiURL)
 
 	fullURL := resolveEndpoint(apiURL, path)
-	// Compute relative path for RawDo (which prepends apiURL)
-	relPath := strings.TrimPrefix(fullURL, apiURL)
+	// RawDo prepends apiURL, so compute the relative path.
+	// For full URLs with a different host, pass the full URL as the path
+	// to a client constructed with an empty base URL.
+	relPath := fullURL
+	if strings.HasPrefix(fullURL, apiURL) {
+		relPath = strings.TrimPrefix(fullURL, apiURL)
+	} else if strings.HasPrefix(fullURL, "http://") || strings.HasPrefix(fullURL, "https://") {
+		// Full URL to a different host — use empty-base client so RawDo
+		// doesn't prepend apiURL.
+		c = client.New(apiKey, "")
+	}
 
 	// Resolve body
 	bodyReader, err := resolveBody(body)

--- a/internal/cmd/api/request_test.go
+++ b/internal/cmd/api/request_test.go
@@ -1,0 +1,178 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRunRequest_GET(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/sessions" {
+			t.Errorf("expected /api/v1/sessions, got %s", r.URL.Path)
+		}
+		if r.Header.Get("x-api-key") != "test-key" {
+			t.Errorf("expected x-api-key=test-key, got %q", r.Header.Get("x-api-key"))
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`[{"id":"s1"}]`))
+	}))
+	defer ts.Close()
+
+	var out bytes.Buffer
+	code, err := runRequest(ts.URL, "test-key", "GET", "sessions", "", nil, false, &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Errorf("expected status 200, got %d", code)
+	}
+	if !strings.Contains(out.String(), `"id"`) {
+		t.Errorf("expected JSON output, got %q", out.String())
+	}
+}
+
+func TestRunRequest_POSTWithBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var data map[string]any
+		json.Unmarshal(body, &data)
+		if data["name"] != "test" {
+			t.Errorf("expected name=test, got %v", data["name"])
+		}
+		w.WriteHeader(201)
+		_, _ = w.Write([]byte(`{"id":"new"}`))
+	}))
+	defer ts.Close()
+
+	var out bytes.Buffer
+	code, err := runRequest(ts.URL, "key", "POST", "sessions", `{"name":"test"}`, nil, false, &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 201 {
+		t.Errorf("expected 201, got %d", code)
+	}
+}
+
+func TestRunRequest_ExtraHeaders(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Custom") != "val" {
+			t.Errorf("expected X-Custom=val, got %q", r.Header.Get("X-Custom"))
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	var out bytes.Buffer
+	_, err := runRequest(ts.URL, "key", "GET", "sessions", "", []string{"X-Custom:val"}, false, &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunRequest_Include(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Request-Id", "abc")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	var out bytes.Buffer
+	_, err := runRequest(ts.URL, "key", "GET", "sessions", "", nil, true, &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "200") {
+		t.Errorf("expected status line, got %q", out.String())
+	}
+	if !strings.Contains(out.String(), "X-Request-Id") {
+		t.Errorf("expected header in output, got %q", out.String())
+	}
+}
+
+func TestRunRequest_4xxPrintsBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		_, _ = w.Write([]byte(`{"detail":"not found"}`))
+	}))
+	defer ts.Close()
+
+	var out bytes.Buffer
+	code, err := runRequest(ts.URL, "key", "GET", "sessions", "", nil, false, &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 404 {
+		t.Errorf("expected 404, got %d", code)
+	}
+	if !strings.Contains(out.String(), "not found") {
+		t.Errorf("expected error body in output, got %q", out.String())
+	}
+}
+
+func TestRunRequest_BodyFromFile(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.WriteHeader(200)
+		w.Write(body)
+	}))
+	defer ts.Close()
+
+	f, _ := os.CreateTemp(t.TempDir(), "body-*.json")
+	f.WriteString(`{"from":"file"}`)
+	f.Close()
+
+	var out bytes.Buffer
+	code, err := runRequest(ts.URL, "key", "POST", "sessions", "@"+f.Name(), nil, false, &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Errorf("expected 200, got %d", code)
+	}
+	if !strings.Contains(out.String(), "from") {
+		t.Errorf("expected file body echoed, got %q", out.String())
+	}
+}
+
+func TestResolveBody_InlineJSON(t *testing.T) {
+	r, err := resolveBody(`{"key":"val"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, _ := io.ReadAll(r)
+	if string(data) != `{"key":"val"}` {
+		t.Errorf("unexpected body: %s", data)
+	}
+}
+
+func TestResolveBody_Empty(t *testing.T) {
+	r, err := resolveBody("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r != nil {
+		t.Error("expected nil reader for empty body")
+	}
+}
+
+func TestResolveBody_FileNotFound(t *testing.T) {
+	_, err := resolveBody("@/nonexistent/path.json")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}

--- a/internal/cmd/api/request_test.go
+++ b/internal/cmd/api/request_test.go
@@ -149,6 +149,33 @@ func TestRunRequest_BodyFromFile(t *testing.T) {
 	}
 }
 
+func TestRunRequest_FullURLDifferentHost(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/custom/endpoint" {
+			t.Errorf("expected /custom/endpoint, got %s", r.URL.Path)
+		}
+		if r.Header.Get("x-api-key") != "key" {
+			t.Errorf("expected x-api-key=key, got %q", r.Header.Get("x-api-key"))
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"full_url":true}`))
+	}))
+	defer ts.Close()
+
+	var out bytes.Buffer
+	// Pass a full URL as the path — should NOT prepend apiURL
+	code, err := runRequest("https://different.host", "key", "GET", ts.URL+"/custom/endpoint", "", nil, false, &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Errorf("expected 200, got %d", code)
+	}
+	if !strings.Contains(out.String(), "full_url") {
+		t.Errorf("expected full_url in response, got %q", out.String())
+	}
+}
+
 func TestResolveBody_InlineJSON(t *testing.T) {
 	r, err := resolveBody(`{"key":"val"}`)
 	if err != nil {

--- a/internal/cmd/api/resolve.go
+++ b/internal/cmd/api/resolve.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -9,7 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// resolveAPIKey resolves the API key from cobra persistent flags → env → empty.
+// resolveAPIKey reads the API key from cobra's inherited persistent flags → env.
+// This is not a duplicate of cmd.GetAPIKey — that reads from package-level flag
+// vars, while this reads from cobra's flag tree (needed because the api sub-package
+// cannot import cmd due to circular dependency).
 func resolveAPIKey(cmd *cobra.Command) string {
 	if v, _ := cmd.Flags().GetString("api-key"); v != "" {
 		return v
@@ -17,7 +19,7 @@ func resolveAPIKey(cmd *cobra.Command) string {
 	return os.Getenv("LANGSMITH_API_KEY")
 }
 
-// resolveAPIURL resolves the API URL from cobra persistent flags → env → default.
+// resolveAPIURL reads the API URL from cobra's inherited persistent flags → env → default.
 func resolveAPIURL(cmd *cobra.Command) string {
 	if v, _ := cmd.Flags().GetString("api-url"); v != "" {
 		return client.NormalizeURL(v)
@@ -28,22 +30,13 @@ func resolveAPIURL(cmd *cobra.Command) string {
 	return "https://api.smith.langchain.com"
 }
 
-// resolveFormat resolves the output format from cobra persistent flags.
+// resolveFormat reads the output format from cobra's inherited persistent flags.
 func resolveFormat(cmd *cobra.Command) string {
 	v, _ := cmd.Flags().GetString("format")
 	if v == "" {
 		return "json"
 	}
 	return v
-}
-
-// mustClient creates a client or exits with an error.
-func mustClient(cmd *cobra.Command) *client.Client {
-	apiKey := resolveAPIKey(cmd)
-	if apiKey == "" {
-		exitError("LANGSMITH_API_KEY not set")
-	}
-	return client.New(apiKey, resolveAPIURL(cmd))
 }
 
 // resolveEndpoint resolves an endpoint argument to a full URL.
@@ -67,15 +60,4 @@ func isHTTPMethod(s string) bool {
 		return true
 	}
 	return false
-}
-
-// exitError prints a JSON error to stderr and exits.
-func exitError(msg string) {
-	fmt.Fprintf(os.Stderr, `{"error": %q}`+"\n", msg)
-	os.Exit(1)
-}
-
-// exitErrorf prints a formatted JSON error to stderr and exits.
-func exitErrorf(format string, args ...any) {
-	exitError(fmt.Sprintf(format, args...))
 }

--- a/internal/cmd/api/resolve.go
+++ b/internal/cmd/api/resolve.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/langchain-ai/langsmith-cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+// resolveAPIKey resolves the API key from cobra persistent flags → env → empty.
+func resolveAPIKey(cmd *cobra.Command) string {
+	if v, _ := cmd.Flags().GetString("api-key"); v != "" {
+		return v
+	}
+	return os.Getenv("LANGSMITH_API_KEY")
+}
+
+// resolveAPIURL resolves the API URL from cobra persistent flags → env → default.
+func resolveAPIURL(cmd *cobra.Command) string {
+	if v, _ := cmd.Flags().GetString("api-url"); v != "" {
+		return client.NormalizeURL(v)
+	}
+	if v := os.Getenv("LANGSMITH_ENDPOINT"); v != "" {
+		return client.NormalizeURL(v)
+	}
+	return "https://api.smith.langchain.com"
+}
+
+// resolveFormat resolves the output format from cobra persistent flags.
+func resolveFormat(cmd *cobra.Command) string {
+	v, _ := cmd.Flags().GetString("format")
+	if v == "" {
+		return "json"
+	}
+	return v
+}
+
+// mustClient creates a client or exits with an error.
+func mustClient(cmd *cobra.Command) *client.Client {
+	apiKey := resolveAPIKey(cmd)
+	if apiKey == "" {
+		exitError("LANGSMITH_API_KEY not set")
+	}
+	return client.New(apiKey, resolveAPIURL(cmd))
+}
+
+// resolveEndpoint resolves an endpoint argument to a full URL.
+//   - Full URL (http:// or https://) → returned as-is.
+//   - Absolute path (starts with /) → baseURL + path.
+//   - Shorthand (e.g. "sessions") → baseURL + /api/v1/ + path.
+func resolveEndpoint(baseURL, path string) string {
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return path
+	}
+	if strings.HasPrefix(path, "/") {
+		return baseURL + path
+	}
+	return baseURL + "/api/v1/" + path
+}
+
+// isHTTPMethod returns true if s is an uppercase HTTP method name.
+func isHTTPMethod(s string) bool {
+	switch s {
+	case "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS":
+		return true
+	}
+	return false
+}
+
+// exitError prints a JSON error to stderr and exits.
+func exitError(msg string) {
+	fmt.Fprintf(os.Stderr, `{"error": %q}`+"\n", msg)
+	os.Exit(1)
+}
+
+// exitErrorf prints a formatted JSON error to stderr and exits.
+func exitErrorf(format string, args ...any) {
+	exitError(fmt.Sprintf(format, args...))
+}

--- a/internal/cmd/api/resolve_test.go
+++ b/internal/cmd/api/resolve_test.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestResolveEndpoint(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		path    string
+		want    string
+	}{
+		{"absolute path", "https://api.smith.langchain.com", "/api/v1/sessions", "https://api.smith.langchain.com/api/v1/sessions"},
+		{"shorthand", "https://api.smith.langchain.com", "sessions", "https://api.smith.langchain.com/api/v1/sessions"},
+		{"shorthand with subpath", "https://api.smith.langchain.com", "runs/query", "https://api.smith.langchain.com/api/v1/runs/query"},
+		{"shorthand with query params", "https://api.smith.langchain.com", "sessions?limit=5", "https://api.smith.langchain.com/api/v1/sessions?limit=5"},
+		{"full URL https", "https://api.smith.langchain.com", "https://other.host/foo", "https://other.host/foo"},
+		{"full URL http", "https://api.smith.langchain.com", "http://other.host/foo", "http://other.host/foo"},
+		{"self-hosted base", "https://myhost.com", "sessions", "https://myhost.com/api/v1/sessions"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveEndpoint(tt.baseURL, tt.path)
+			if got != tt.want {
+				t.Errorf("resolveEndpoint(%q, %q) = %q, want %q", tt.baseURL, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsHTTPMethod(t *testing.T) {
+	for _, m := range []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"} {
+		if !isHTTPMethod(m) {
+			t.Errorf("expected %q to be recognized as HTTP method", m)
+		}
+	}
+	for _, m := range []string{"get", "ls", "info", "FOO", ""} {
+		if isHTTPMethod(m) {
+			t.Errorf("expected %q to NOT be recognized as HTTP method", m)
+		}
+	}
+}

--- a/internal/cmd/api/spec.go
+++ b/internal/cmd/api/spec.go
@@ -1,0 +1,343 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const specCacheTTL = 24 * time.Hour
+
+// OpenAPISpec holds the parsed parts of the OpenAPI spec we care about.
+type OpenAPISpec struct {
+	OpenAPI    string                                `json:"openapi"`
+	Info       json.RawMessage                       `json:"info"`
+	Paths      map[string]map[string]json.RawMessage `json:"paths"`
+	Components json.RawMessage                       `json:"components"`
+}
+
+// Endpoint is a single method+path from the spec.
+type Endpoint struct {
+	Method  string `json:"method"`
+	Path    string `json:"path"`
+	Summary string `json:"summary"`
+	Tag     string `json:"tag"`
+}
+
+// EndpointDetail has full info for a single endpoint.
+type EndpointDetail struct {
+	Method      string      `json:"method"`
+	Path        string      `json:"path"`
+	Summary     string      `json:"summary"`
+	Tag         string      `json:"tag"`
+	Description string      `json:"description,omitempty"`
+	Parameters  []Parameter `json:"parameters"`
+	RequestBody any         `json:"request_body"`
+	Response    any         `json:"response_schema"`
+}
+
+// Parameter describes a single API parameter.
+type Parameter struct {
+	Name        string `json:"name"`
+	In          string `json:"in"`
+	Required    bool   `json:"required"`
+	Type        string `json:"type,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// Endpoints returns a sorted list of all endpoints in the spec.
+func (s *OpenAPISpec) Endpoints() []Endpoint {
+	var endpoints []Endpoint
+	for path, methods := range s.Paths {
+		for method, raw := range methods {
+			m := strings.ToUpper(method)
+			if !isHTTPMethod(m) {
+				continue // skip "parameters", "summary", etc.
+			}
+			var detail struct {
+				Summary string   `json:"summary"`
+				Tags    []string `json:"tags"`
+			}
+			json.Unmarshal(raw, &detail)
+			tag := ""
+			if len(detail.Tags) > 0 {
+				tag = detail.Tags[0]
+			}
+			endpoints = append(endpoints, Endpoint{
+				Method:  m,
+				Path:    path,
+				Summary: detail.Summary,
+				Tag:     tag,
+			})
+		}
+	}
+	sort.Slice(endpoints, func(i, j int) bool {
+		if endpoints[i].Path != endpoints[j].Path {
+			return endpoints[i].Path < endpoints[j].Path
+		}
+		return endpoints[i].Method < endpoints[j].Method
+	})
+	return endpoints
+}
+
+// LookupEndpoint finds an endpoint by method and path, returning full detail.
+// The path argument can be shorthand ("sessions") or absolute ("/api/v1/sessions").
+func (s *OpenAPISpec) LookupEndpoint(method, path string) (*EndpointDetail, error) {
+	// Normalize: if shorthand, prefix /api/v1/
+	normalized := path
+	if !strings.HasPrefix(normalized, "/") {
+		normalized = "/api/v1/" + normalized
+	}
+	method = strings.ToUpper(method)
+
+	methods, ok := s.Paths[normalized]
+	if !ok {
+		return nil, fmt.Errorf("endpoint not found: %s %s", method, normalized)
+	}
+	raw, ok := methods[strings.ToLower(method)]
+	if !ok {
+		return nil, fmt.Errorf("endpoint not found: %s %s", method, normalized)
+	}
+
+	var parsed struct {
+		Summary     string            `json:"summary"`
+		Description string            `json:"description"`
+		Tags        []string          `json:"tags"`
+		Parameters  []json.RawMessage `json:"parameters"`
+		RequestBody json.RawMessage   `json:"requestBody"`
+		Responses   json.RawMessage   `json:"responses"`
+	}
+	json.Unmarshal(raw, &parsed)
+
+	tag := ""
+	if len(parsed.Tags) > 0 {
+		tag = parsed.Tags[0]
+	}
+
+	// Parse parameters
+	var params []Parameter
+	for _, pRaw := range parsed.Parameters {
+		var p struct {
+			Name        string `json:"name"`
+			In          string `json:"in"`
+			Required    bool   `json:"required"`
+			Description string `json:"description"`
+			Schema      struct {
+				Type string `json:"type"`
+			} `json:"schema"`
+		}
+		json.Unmarshal(pRaw, &p)
+		params = append(params, Parameter{
+			Name:        p.Name,
+			In:          p.In,
+			Required:    p.Required,
+			Type:        p.Schema.Type,
+			Description: p.Description,
+		})
+	}
+
+	// Parse request body — resolve $ref one level deep
+	var reqBody any
+	if parsed.RequestBody != nil {
+		reqBody = s.resolveRequestBody(parsed.RequestBody)
+	}
+
+	// Parse response — take first 2xx response
+	var respSchema any
+	if parsed.Responses != nil {
+		respSchema = s.resolveResponse(parsed.Responses)
+	}
+
+	return &EndpointDetail{
+		Method:      method,
+		Path:        normalized,
+		Summary:     parsed.Summary,
+		Tag:         tag,
+		Description: parsed.Description,
+		Parameters:  params,
+		RequestBody: reqBody,
+		Response:    respSchema,
+	}, nil
+}
+
+// resolveRequestBody extracts and resolves the request body schema.
+func (s *OpenAPISpec) resolveRequestBody(raw json.RawMessage) any {
+	var body struct {
+		Required bool `json:"required"`
+		Content  map[string]struct {
+			Schema json.RawMessage `json:"schema"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil
+	}
+	for contentType, ct := range body.Content {
+		schema := s.resolveRef(ct.Schema)
+		return map[string]any{
+			"content_type": contentType,
+			"required":     body.Required,
+			"schema":       schema,
+		}
+	}
+	return nil
+}
+
+// resolveResponse extracts the first 2xx response schema.
+func (s *OpenAPISpec) resolveResponse(raw json.RawMessage) any {
+	var responses map[string]struct {
+		Content map[string]struct {
+			Schema json.RawMessage `json:"schema"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &responses); err != nil {
+		return nil
+	}
+	for _, code := range []string{"200", "201", "202", "204"} {
+		resp, ok := responses[code]
+		if !ok {
+			continue
+		}
+		for _, ct := range resp.Content {
+			return s.resolveRef(ct.Schema)
+		}
+	}
+	return nil
+}
+
+// resolveRef resolves a JSON schema, inlining one level of $ref from components.
+func (s *OpenAPISpec) resolveRef(raw json.RawMessage) any {
+	if raw == nil {
+		return nil
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		var result any
+		json.Unmarshal(raw, &result)
+		return result
+	}
+
+	// Check for $ref
+	if refRaw, ok := obj["$ref"]; ok {
+		var ref string
+		json.Unmarshal(refRaw, &ref)
+		resolved := s.resolveComponentRef(ref)
+		if resolved != nil {
+			return resolved
+		}
+	}
+
+	// Otherwise return as generic map
+	var result any
+	json.Unmarshal(raw, &result)
+	return result
+}
+
+// resolveComponentRef resolves a $ref like "#/components/schemas/Foo" one level deep.
+func (s *OpenAPISpec) resolveComponentRef(ref string) any {
+	if s.Components == nil {
+		return nil
+	}
+	parts := strings.Split(strings.TrimPrefix(ref, "#/"), "/")
+	if len(parts) < 3 || parts[0] != "components" || parts[1] != "schemas" {
+		return map[string]any{"$ref": ref}
+	}
+	schemaName := parts[2]
+
+	var components struct {
+		Schemas map[string]json.RawMessage `json:"schemas"`
+	}
+	if err := json.Unmarshal(s.Components, &components); err != nil {
+		return map[string]any{"$ref": ref}
+	}
+	schemaRaw, ok := components.Schemas[schemaName]
+	if !ok {
+		return map[string]any{"$ref": ref}
+	}
+
+	// Parse one level — don't recurse into nested $refs
+	var schema any
+	json.Unmarshal(schemaRaw, &schema)
+	return schema
+}
+
+// loadSpec loads the OpenAPI spec, using cache if available and not expired.
+func loadSpec(apiURL, cacheDir string, forceRefresh bool) (*OpenAPISpec, error) {
+	cachePath := specCachePath(cacheDir, apiURL)
+
+	if !forceRefresh {
+		if spec, err := loadCachedSpec(cachePath); err == nil {
+			return spec, nil
+		}
+	}
+
+	// Fetch from server
+	specURL := apiURL + "/openapi.json"
+	resp, err := http.Get(specURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching OpenAPI spec from %s: %w", specURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("fetching OpenAPI spec: HTTP %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading OpenAPI spec: %w", err)
+	}
+
+	var spec OpenAPISpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("parsing OpenAPI spec: %w", err)
+	}
+
+	// Write cache
+	os.MkdirAll(filepath.Dir(cachePath), 0755)
+	os.WriteFile(cachePath, data, 0644)
+
+	return &spec, nil
+}
+
+// loadCachedSpec reads a cached spec if it exists and is within TTL.
+func loadCachedSpec(cachePath string) (*OpenAPISpec, error) {
+	info, err := os.Stat(cachePath)
+	if err != nil {
+		return nil, err
+	}
+	if time.Since(info.ModTime()) > specCacheTTL {
+		return nil, fmt.Errorf("cache expired")
+	}
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		return nil, err
+	}
+	var spec OpenAPISpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return nil, err
+	}
+	return &spec, nil
+}
+
+// specCachePath returns the cache file path for a given API URL.
+func specCachePath(cacheDir, apiURL string) string {
+	h := sha256.Sum256([]byte(apiURL))
+	name := fmt.Sprintf("openapi-%x.json", h[:8])
+	return filepath.Join(cacheDir, name)
+}
+
+// defaultCacheDir returns ~/.langsmith/cache.
+func defaultCacheDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), "langsmith-cache")
+	}
+	return filepath.Join(home, ".langsmith", "cache")
+}

--- a/internal/cmd/api/spec_test.go
+++ b/internal/cmd/api/spec_test.go
@@ -1,0 +1,205 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSpecCachePath(t *testing.T) {
+	p1 := specCachePath("/tmp/test-cache", "https://api.smith.langchain.com")
+	p2 := specCachePath("/tmp/test-cache", "https://myhost.com")
+	if p1 == p2 {
+		t.Error("expected different cache paths for different API URLs")
+	}
+	if filepath.Dir(p1) != "/tmp/test-cache" {
+		t.Errorf("expected cache dir /tmp/test-cache, got %s", filepath.Dir(p1))
+	}
+}
+
+func TestLoadSpec_FromServer(t *testing.T) {
+	spec := map[string]any{
+		"openapi": "3.1.0",
+		"paths": map[string]any{
+			"/api/v1/sessions": map[string]any{
+				"get": map[string]any{
+					"summary": "List sessions",
+					"tags":    []any{"tracer-sessions"},
+				},
+			},
+		},
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/openapi.json" {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(spec)
+	}))
+	defer ts.Close()
+
+	cacheDir := t.TempDir()
+	result, err := loadSpec(ts.URL, cacheDir, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.OpenAPI != "3.1.0" {
+		t.Errorf("expected openapi 3.1.0, got %q", result.OpenAPI)
+	}
+	if len(result.Paths) != 1 {
+		t.Errorf("expected 1 path, got %d", len(result.Paths))
+	}
+}
+
+func TestLoadSpec_UsesCache(t *testing.T) {
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		json.NewEncoder(w).Encode(map[string]any{
+			"openapi": "3.1.0",
+			"paths":   map[string]any{},
+		})
+	}))
+	defer ts.Close()
+
+	cacheDir := t.TempDir()
+
+	_, err := loadSpec(ts.URL, cacheDir, false)
+	if err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+	if callCount != 1 {
+		t.Fatalf("expected 1 server call, got %d", callCount)
+	}
+
+	_, err = loadSpec(ts.URL, cacheDir, false)
+	if err != nil {
+		t.Fatalf("second fetch: %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("expected cache hit (still 1 call), got %d calls", callCount)
+	}
+}
+
+func TestLoadSpec_RefreshBypassesCache(t *testing.T) {
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		json.NewEncoder(w).Encode(map[string]any{
+			"openapi": "3.1.0",
+			"paths":   map[string]any{},
+		})
+	}))
+	defer ts.Close()
+
+	cacheDir := t.TempDir()
+
+	_, _ = loadSpec(ts.URL, cacheDir, false)
+	if callCount != 1 {
+		t.Fatalf("expected 1 call, got %d", callCount)
+	}
+
+	_, _ = loadSpec(ts.URL, cacheDir, true)
+	if callCount != 2 {
+		t.Errorf("expected 2 calls after refresh, got %d", callCount)
+	}
+}
+
+func TestLoadSpec_ExpiredCache(t *testing.T) {
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		json.NewEncoder(w).Encode(map[string]any{
+			"openapi": "3.1.0",
+			"paths":   map[string]any{},
+		})
+	}))
+	defer ts.Close()
+
+	cacheDir := t.TempDir()
+
+	_, _ = loadSpec(ts.URL, cacheDir, false)
+	cachePath := specCachePath(cacheDir, ts.URL)
+	old := time.Now().Add(-25 * time.Hour)
+	os.Chtimes(cachePath, old, old)
+
+	_, _ = loadSpec(ts.URL, cacheDir, false)
+	if callCount != 2 {
+		t.Errorf("expected 2 calls after TTL expiry, got %d", callCount)
+	}
+}
+
+func TestEndpoints(t *testing.T) {
+	spec := &OpenAPISpec{
+		Paths: map[string]map[string]json.RawMessage{
+			"/api/v1/sessions": {
+				"get":  json.RawMessage(`{"summary": "List sessions", "tags": ["tracer-sessions"]}`),
+				"post": json.RawMessage(`{"summary": "Create session", "tags": ["tracer-sessions"]}`),
+			},
+			"/api/v1/datasets": {
+				"get": json.RawMessage(`{"summary": "List datasets", "tags": ["datasets"]}`),
+			},
+		},
+	}
+	endpoints := spec.Endpoints()
+	if len(endpoints) != 3 {
+		t.Fatalf("expected 3 endpoints, got %d", len(endpoints))
+	}
+	// Should be sorted by path then method
+	if endpoints[0].Path != "/api/v1/datasets" {
+		t.Errorf("expected first endpoint /api/v1/datasets, got %s", endpoints[0].Path)
+	}
+}
+
+func TestLookupEndpoint(t *testing.T) {
+	spec := &OpenAPISpec{
+		Paths: map[string]map[string]json.RawMessage{
+			"/api/v1/sessions": {
+				"get": json.RawMessage(`{
+					"summary": "List sessions",
+					"tags": ["tracer-sessions"],
+					"parameters": [
+						{"name": "limit", "in": "query", "required": false, "schema": {"type": "integer"}, "description": "Max results"}
+					],
+					"responses": {
+						"200": {"content": {"application/json": {"schema": {"type": "array"}}}}
+					}
+				}`),
+			},
+		},
+	}
+
+	// Absolute path
+	detail, err := spec.LookupEndpoint("GET", "/api/v1/sessions")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if detail.Method != "GET" {
+		t.Errorf("expected GET, got %s", detail.Method)
+	}
+	if len(detail.Parameters) != 1 {
+		t.Errorf("expected 1 param, got %d", len(detail.Parameters))
+	}
+	if detail.Parameters[0].Name != "limit" {
+		t.Errorf("expected param name 'limit', got %q", detail.Parameters[0].Name)
+	}
+
+	// Shorthand path
+	detail2, err := spec.LookupEndpoint("GET", "sessions")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if detail2.Path != "/api/v1/sessions" {
+		t.Errorf("expected /api/v1/sessions, got %s", detail2.Path)
+	}
+
+	// Not found
+	_, err = spec.LookupEndpoint("GET", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent endpoint")
+	}
+}

--- a/internal/cmd/dataset.go
+++ b/internal/cmd/dataset.go
@@ -54,7 +54,7 @@ func newDatasetListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List all datasets in the workspace (default: 100)",
 		Run: func(cmd *cobra.Command, args []string) {
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			pageSize := int64(20)
@@ -77,9 +77,9 @@ func newDatasetListCmd() *cobra.Command {
 				}
 			}
 			if err := pager.Err(); err != nil {
-				exitErrorf("listing datasets: %v", err)
+				ExitErrorf("listing datasets: %v", err)
 			}
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				columns := []string{"Name", "ID", "Description", "Examples", "Created"}
@@ -133,12 +133,12 @@ func newDatasetGetCmd() *cobra.Command {
 		Short: "Get dataset details by name or UUID",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			ds, err := resolveDataset(ctx, c, args[0])
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
 			data := map[string]any{
@@ -150,7 +150,7 @@ func newDatasetGetCmd() *cobra.Command {
 				"created_at":    formatTimeISO(ds.CreatedAt),
 			}
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 			if fmt_ == "pretty" {
 				output.PrintOutput(data, "pretty", outputFile)
 			} else {
@@ -173,7 +173,7 @@ func newDatasetCreateCmd() *cobra.Command {
 		Use:   "create",
 		Short: "Create a new empty dataset",
 		Run: func(cmd *cobra.Command, args []string) {
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			params := langsmith.DatasetNewParams{
@@ -185,7 +185,7 @@ func newDatasetCreateCmd() *cobra.Command {
 
 			ds, err := c.SDK.Datasets.New(ctx, params)
 			if err != nil {
-				exitErrorf("creating dataset: %v", err)
+				ExitErrorf("creating dataset: %v", err)
 			}
 
 			output.OutputJSON(map[string]any{
@@ -213,12 +213,12 @@ func newDatasetDeleteCmd() *cobra.Command {
 		Short: "Delete a dataset by name or UUID",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			ds, err := resolveDataset(ctx, c, args[0])
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
 			if !yes {
@@ -226,13 +226,13 @@ func newDatasetDeleteCmd() *cobra.Command {
 				var confirm string
 				_, _ = fmt.Scanln(&confirm)
 				if strings.ToLower(confirm) != "y" {
-					exitError("aborted")
+					ExitError("aborted")
 				}
 			}
 
 			_, err = c.SDK.Datasets.Delete(ctx, ds.ID)
 			if err != nil {
-				exitErrorf("deleting dataset: %v", err)
+				ExitErrorf("deleting dataset: %v", err)
 			}
 
 			output.OutputJSON(map[string]any{
@@ -258,12 +258,12 @@ func newDatasetExportCmd() *cobra.Command {
 			nameOrID := args[0]
 			outputFile := args[1]
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			ds, err := resolveDataset(ctx, c, nameOrID)
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
 			exportPageSize := int64(20)
@@ -282,7 +282,7 @@ func newDatasetExportCmd() *cobra.Command {
 				}
 			}
 			if err := pager.Err(); err != nil {
-				exitErrorf("listing examples: %v", err)
+				ExitErrorf("listing examples: %v", err)
 			}
 
 			var data []map[string]any
@@ -295,7 +295,7 @@ func newDatasetExportCmd() *cobra.Command {
 
 			jsonBytes, _ := json.MarshalIndent(data, "", "  ")
 			if err := os.WriteFile(outputFile, jsonBytes, 0644); err != nil {
-				exitErrorf("writing file: %v", err)
+				ExitErrorf("writing file: %v", err)
 			}
 
 			output.OutputJSON(map[string]any{
@@ -324,17 +324,17 @@ func newDatasetUploadCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			filePath := args[0]
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			fileData, err := os.ReadFile(filePath)
 			if err != nil {
-				exitErrorf("reading file: %v", err)
+				ExitErrorf("reading file: %v", err)
 			}
 
 			var rawData any
 			if err := json.Unmarshal(fileData, &rawData); err != nil {
-				exitErrorf("parsing JSON: %v", err)
+				ExitErrorf("parsing JSON: %v", err)
 			}
 
 			var items []map[string]any
@@ -348,7 +348,7 @@ func newDatasetUploadCmd() *cobra.Command {
 			case map[string]any:
 				items = []map[string]any{v}
 			default:
-				exitError("JSON file must be an array or object")
+				ExitError("JSON file must be an array or object")
 			}
 
 			// Create dataset
@@ -361,7 +361,7 @@ func newDatasetUploadCmd() *cobra.Command {
 
 			ds, err := c.SDK.Datasets.New(ctx, dsParams)
 			if err != nil {
-				exitErrorf("creating dataset: %v", err)
+				ExitErrorf("creating dataset: %v", err)
 			}
 
 			// Create examples
@@ -386,7 +386,7 @@ func newDatasetUploadCmd() *cobra.Command {
 
 				_, err := c.SDK.Examples.New(ctx, exParams)
 				if err != nil {
-					exitErrorf("creating example: %v", err)
+					ExitErrorf("creating example: %v", err)
 				}
 			}
 

--- a/internal/cmd/evaluator.go
+++ b/internal/cmd/evaluator.go
@@ -55,15 +55,15 @@ func newEvaluatorListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List all evaluator rules in the workspace",
 		Run: func(cmd *cobra.Command, args []string) {
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			var rules []evaluatorRule
 			if err := c.RawGet(ctx, "/runs/rules", &rules); err != nil {
-				exitErrorf("listing evaluators: %v", err)
+				ExitErrorf("listing evaluators: %v", err)
 			}
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				columns := []string{"Name", "Sampling Rate", "Target", "Enabled"}
@@ -129,7 +129,7 @@ func newEvaluatorUploadCmd() *cobra.Command {
 				return
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			// Resolve targets
@@ -138,7 +138,7 @@ func newEvaluatorUploadCmd() *cobra.Command {
 			if targetDataset != "" {
 				ds, err := resolveDataset(ctx, c, targetDataset)
 				if err != nil {
-					exitErrorf("%v", err)
+					ExitErrorf("%v", err)
 				}
 				datasetID = ds.ID
 			}
@@ -146,7 +146,7 @@ func newEvaluatorUploadCmd() *cobra.Command {
 			if targetProject != "" {
 				sid, err := c.ResolveSessionID(ctx, targetProject)
 				if err != nil {
-					exitErrorf("%v", err)
+					ExitErrorf("%v", err)
 				}
 				projectID = sid
 			}
@@ -154,7 +154,7 @@ func newEvaluatorUploadCmd() *cobra.Command {
 			// Check for existing evaluator
 			var rules []evaluatorRule
 			if err := c.RawGet(ctx, "/runs/rules", &rules); err != nil {
-				exitErrorf("checking existing evaluators: %v", err)
+				ExitErrorf("checking existing evaluators: %v", err)
 			}
 
 			existing := findEvaluator(rules, name, datasetID, projectID)
@@ -171,23 +171,23 @@ func newEvaluatorUploadCmd() *cobra.Command {
 					var confirm string
 					_, _ = fmt.Scanln(&confirm)
 					if strings.ToLower(confirm) != "y" {
-						exitError("aborted")
+						ExitError("aborted")
 					}
 				}
 				if err := c.RawDelete(ctx, fmt.Sprintf("/runs/rules/%s", existing.ID), nil); err != nil {
-					exitErrorf("deleting existing evaluator: %v", err)
+					ExitErrorf("deleting existing evaluator: %v", err)
 				}
 			}
 
 			// Read and prepare function source
 			source, err := os.ReadFile(evaluatorFile)
 			if err != nil {
-				exitErrorf("reading evaluator file: %v", err)
+				ExitErrorf("reading evaluator file: %v", err)
 			}
 
 			language, evalFuncName := detectLanguage(evaluatorFile)
 			if language == "" {
-				exitErrorf("unsupported file extension: %s (use .py, .js, .ts, .tsx, or .mjs)", evaluatorFile)
+				ExitErrorf("unsupported file extension: %s (use .py, .js, .ts, .tsx, or .mjs)", evaluatorFile)
 			}
 
 			var sourceStr string
@@ -195,14 +195,14 @@ func newEvaluatorUploadCmd() *cobra.Command {
 			case "python":
 				sourceStr = extractPythonFunction(string(source), funcName)
 				if sourceStr == "" {
-					exitErrorf("function %q not found in %s", funcName, evaluatorFile)
+					ExitErrorf("function %q not found in %s", funcName, evaluatorFile)
 				}
 				re := regexp.MustCompile(`\bdef\s+` + regexp.QuoteMeta(funcName) + `\s*\(`)
 				sourceStr = re.ReplaceAllString(sourceStr, "def "+evalFuncName+"(")
 			case "javascript":
 				sourceStr = extractJSFunction(string(source), funcName)
 				if sourceStr == "" {
-					exitErrorf("function %q not found in %s", funcName, evaluatorFile)
+					ExitErrorf("function %q not found in %s", funcName, evaluatorFile)
 				}
 				sourceStr = renameJSFunction(sourceStr, funcName)
 			}
@@ -227,7 +227,7 @@ func newEvaluatorUploadCmd() *cobra.Command {
 
 			var result map[string]any
 			if err := c.RawPost(ctx, "/runs/rules", payload, &result); err != nil {
-				exitErrorf("uploading evaluator: %v", err)
+				ExitErrorf("uploading evaluator: %v", err)
 			}
 
 			target := "project"
@@ -267,12 +267,12 @@ func newEvaluatorDeleteCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			name := args[0]
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			var rules []evaluatorRule
 			if err := c.RawGet(ctx, "/runs/rules", &rules); err != nil {
-				exitErrorf("listing evaluators: %v", err)
+				ExitErrorf("listing evaluators: %v", err)
 			}
 
 			var matching []evaluatorRule
@@ -292,14 +292,14 @@ func newEvaluatorDeleteCmd() *cobra.Command {
 				var confirm string
 				_, _ = fmt.Scanln(&confirm)
 				if strings.ToLower(confirm) != "y" {
-					exitError("aborted")
+					ExitError("aborted")
 				}
 			}
 
 			deleted := 0
 			for _, rule := range matching {
 				if err := c.RawDelete(ctx, fmt.Sprintf("/runs/rules/%s", rule.ID), nil); err != nil {
-					exitErrorf("deleting evaluator %s: %v", rule.ID, err)
+					ExitErrorf("deleting evaluator %s: %v", rule.ID, err)
 				}
 				deleted++
 			}

--- a/internal/cmd/example.go
+++ b/internal/cmd/example.go
@@ -49,12 +49,12 @@ func newExampleListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List examples in a dataset (default: 20)",
 		Run: func(cmd *cobra.Command, args []string) {
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			ds, err := resolveDataset(ctx, c, datasetName)
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
 			pageSize := int64(20)
@@ -77,9 +77,9 @@ func newExampleListCmd() *cobra.Command {
 				}
 			}
 			if err := pager.Err(); err != nil {
-				exitErrorf("listing examples: %v", err)
+				ExitErrorf("listing examples: %v", err)
 			}
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			// Filter by split if specified
 			if split != "" {
@@ -161,7 +161,7 @@ func newExampleCreateCmd() *cobra.Command {
 		Use:   "create",
 		Short: "Create a new example in a dataset",
 		Run: func(cmd *cobra.Command, args []string) {
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			// Parse JSON inputs
@@ -190,7 +190,7 @@ func newExampleCreateCmd() *cobra.Command {
 			// Resolve dataset
 			ds, err := resolveDataset(ctx, c, datasetName)
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
 			params := langsmith.ExampleNewParams{
@@ -211,7 +211,7 @@ func newExampleCreateCmd() *cobra.Command {
 
 			ex, err := c.SDK.Examples.New(ctx, params)
 			if err != nil {
-				exitErrorf("creating example: %v", err)
+				ExitErrorf("creating example: %v", err)
 			}
 
 			output.OutputJSON(map[string]any{
@@ -250,16 +250,16 @@ func newExampleDeleteCmd() *cobra.Command {
 				var confirm string
 				_, _ = fmt.Scanln(&confirm)
 				if strings.ToLower(confirm) != "y" {
-					exitError("aborted")
+					ExitError("aborted")
 				}
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			_, err := c.SDK.Examples.Delete(ctx, exampleID)
 			if err != nil {
-				exitErrorf("deleting example: %v", err)
+				ExitErrorf("deleting example: %v", err)
 			}
 
 			output.OutputJSON(map[string]any{

--- a/internal/cmd/experiment.go
+++ b/internal/cmd/experiment.go
@@ -44,7 +44,7 @@ func newExperimentListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List experiments, optionally filtered by dataset (default: 20)",
 		Run: func(cmd *cobra.Command, args []string) {
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			pageSize := int64(20)
@@ -60,7 +60,7 @@ func newExperimentListCmd() *cobra.Command {
 			if datasetName != "" {
 				ds, err := resolveDataset(ctx, c, datasetName)
 				if err != nil {
-					exitErrorf("%v", err)
+					ExitErrorf("%v", err)
 				}
 				params.ReferenceDataset = langsmith.F([]string{ds.ID})
 			}
@@ -74,9 +74,9 @@ func newExperimentListCmd() *cobra.Command {
 				}
 			}
 			if err := pager.Err(); err != nil {
-				exitErrorf("listing experiments: %v", err)
+				ExitErrorf("listing experiments: %v", err)
 			}
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				columns := []string{"Name", "ID", "Dataset ID", "Runs"}
@@ -132,7 +132,7 @@ func newExperimentGetCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			nameOrID := args[0]
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			var p langsmith.TracerSession
@@ -143,7 +143,7 @@ func newExperimentGetCmd() *cobra.Command {
 					IncludeStats: langsmith.F(true),
 				})
 				if err != nil {
-					exitErrorf("fetching experiment by ID: %v", err)
+					ExitErrorf("fetching experiment by ID: %v", err)
 				}
 				p = *session
 			} else {
@@ -155,10 +155,10 @@ func newExperimentGetCmd() *cobra.Command {
 				}
 				resp, err := c.SDK.Sessions.List(ctx, params)
 				if err != nil {
-					exitErrorf("fetching experiment: %v", err)
+					ExitErrorf("fetching experiment: %v", err)
 				}
 				if len(resp.Items) == 0 {
-					exitErrorf("experiment not found: %s", nameOrID)
+					ExitErrorf("experiment not found: %s", nameOrID)
 				}
 				p = resp.Items[0]
 			}
@@ -183,7 +183,7 @@ func newExperimentGetCmd() *cobra.Command {
 				}
 			}
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 			if fmt_ == "pretty" {
 				output.PrintOutput(data, "pretty", outputFile)
 			} else {

--- a/internal/cmd/filters.go
+++ b/internal/cmd/filters.go
@@ -62,7 +62,7 @@ func resolveStartTime(since string, lastNMinutes int) time.Time {
 		if err != nil {
 			t, err = time.Parse("2006-01-02T15:04:05", since)
 			if err != nil {
-				exitErrorf("invalid --since timestamp: %s", since)
+				ExitErrorf("invalid --since timestamp: %s", since)
 			}
 		}
 		return t

--- a/internal/cmd/insights.go
+++ b/internal/cmd/insights.go
@@ -55,17 +55,17 @@ for full details including the executive summary and category breakdown.`,
   langsmith insights list --project my-app --limit 5
   langsmith insights list --project my-app --format pretty`,
 		Run: func(cmd *cobra.Command, args []string) {
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			projectName := ResolveProject(project)
 			if projectName == "" {
-				exitError("--project is required (or set LANGSMITH_PROJECT)")
+				ExitError("--project is required (or set LANGSMITH_PROJECT)")
 			}
 
 			sessionID, err := c.ResolveSessionID(ctx, projectName)
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
 			var jobs []langsmith.SessionInsightListResponse
@@ -77,10 +77,10 @@ for full details including the executive summary and category breakdown.`,
 				}
 			}
 			if err := pager.Err(); err != nil {
-				exitErrorf("listing insights: %v", err)
+				ExitErrorf("listing insights: %v", err)
 			}
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				columns := []string{"Name", "ID", "Status", "Created", "Clusters"}
@@ -131,25 +131,25 @@ statistics (error rates, latency, costs, token usage, feedback scores).`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			insightID := args[0]
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			projectName := ResolveProject(project)
 			if projectName == "" {
-				exitError("--project is required (or set LANGSMITH_PROJECT)")
+				ExitError("--project is required (or set LANGSMITH_PROJECT)")
 			}
 
 			sessionID, err := c.ResolveSessionID(ctx, projectName)
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
 			detail, err := c.SDK.Sessions.Insights.GetJob(ctx, sessionID, insightID)
 			if err != nil {
-				exitErrorf("fetching insight: %v", err)
+				ExitErrorf("fetching insight: %v", err)
 			}
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				printInsightPretty(detail)

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -1,0 +1,319 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/langchain-ai/langsmith-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// getConfigPath returns the config file path from env or the default.
+func getConfigPath() string {
+	if v := os.Getenv("LANGSMITH_CONFIG_FILE"); v != "" {
+		return v
+	}
+	return config.DefaultConfigPath()
+}
+
+// promptInput reads a line from stdin, printing the prompt to stderr.
+func promptInput(prompt string) string {
+	fmt.Fprint(os.Stderr, prompt)
+	scanner := bufio.NewScanner(os.Stdin)
+	if scanner.Scan() {
+		return strings.TrimSpace(scanner.Text())
+	}
+	return ""
+}
+
+// promptInputDefault reads a line from stdin, showing a default value in the prompt.
+// Returns the default value if the input is empty.
+func promptInputDefault(label, defaultVal string) string {
+	var prompt string
+	if defaultVal != "" {
+		prompt = fmt.Sprintf("%s [%s]: ", label, defaultVal)
+	} else {
+		prompt = fmt.Sprintf("%s: ", label)
+	}
+	fmt.Fprint(os.Stderr, prompt)
+	scanner := bufio.NewScanner(os.Stdin)
+	if scanner.Scan() {
+		val := strings.TrimSpace(scanner.Text())
+		if val == "" {
+			return defaultVal
+		}
+		return val
+	}
+	return defaultVal
+}
+
+func newProfileCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "profile",
+		Short: "Manage named configuration profiles",
+		Long: `Manage named configuration profiles for LangSmith.
+
+Profiles store API keys, API URLs, and workspace IDs so you can
+switch between multiple LangSmith environments (e.g., production vs. staging).
+
+Examples:
+  langsmith profile create prod --api-key ls-xxx --api-url https://api.smith.langchain.com
+  langsmith profile list
+  langsmith profile use prod
+  langsmith profile show prod
+  langsmith profile delete prod`,
+	}
+
+	cmd.AddCommand(newProfileListCmd())
+	cmd.AddCommand(newProfileShowCmd())
+	cmd.AddCommand(newProfileCreateCmd())
+	cmd.AddCommand(newProfileDeleteCmd())
+	cmd.AddCommand(newProfileUseCmd())
+
+	return cmd
+}
+
+func newProfileListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all named profiles",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfgPath := getConfigPath()
+			cfg, err := config.LoadFrom(cfgPath)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			activeName := cfg.ResolveProfileName(flagProfile, os.Getenv("LANGSMITH_PROFILE"))
+
+			// Collect and sort profile names
+			names := make([]string, 0, len(cfg.Profiles))
+			for name := range cfg.Profiles {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+
+			type profileEntry struct {
+				Name   string `json:"name"`
+				APIURL string `json:"api_url"`
+				Active bool   `json:"active"`
+			}
+
+			entries := make([]profileEntry, 0, len(names))
+			for _, name := range names {
+				p := cfg.Profiles[name]
+				entries = append(entries, profileEntry{
+					Name:   name,
+					APIURL: p.APIURL,
+					Active: name == activeName,
+				})
+			}
+
+			out, err := json.Marshal(entries)
+			if err != nil {
+				return fmt.Errorf("marshaling output: %w", err)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), string(out))
+			return nil
+		},
+	}
+}
+
+func newProfileShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show NAME",
+		Short: "Show a profile's configuration (API key is masked)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			cfgPath := getConfigPath()
+			cfg, err := config.LoadFrom(cfgPath)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			p, ok := cfg.Profiles[name]
+			if !ok {
+				return fmt.Errorf("profile %q not found", name)
+			}
+
+			type showEntry struct {
+				Name        string `json:"name"`
+				APIKey      string `json:"api_key"`
+				APIURL      string `json:"api_url"`
+				WorkspaceID string `json:"workspace_id,omitempty"`
+			}
+			entry := showEntry{
+				Name:        name,
+				APIKey:      config.MaskAPIKey(p.APIKey),
+				APIURL:      p.APIURL,
+				WorkspaceID: p.WorkspaceID,
+			}
+
+			out, err := json.Marshal(entry)
+			if err != nil {
+				return fmt.Errorf("marshaling output: %w", err)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), string(out))
+			return nil
+		},
+	}
+}
+
+func newProfileCreateCmd() *cobra.Command {
+	var (
+		apiKey      string
+		apiURL      string
+		workspaceID string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create NAME",
+		Short: "Create a new named profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+
+			if err := config.ValidateProfileName(name); err != nil {
+				return err
+			}
+
+			cfgPath := getConfigPath()
+			cfg, err := config.LoadFrom(cfgPath)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			if _, exists := cfg.Profiles[name]; exists {
+				return fmt.Errorf("profile %q already exists", name)
+			}
+
+			// Prompt interactively for missing values only when flags weren't passed.
+			interactive := !cmd.Flags().Changed("api-key")
+			if apiKey == "" && interactive {
+				apiKey = promptInput("API Key: ")
+			}
+			if apiURL == "" && interactive {
+				apiURL = promptInputDefault("API URL", "https://api.smith.langchain.com")
+			}
+			if apiURL == "" {
+				apiURL = "https://api.smith.langchain.com"
+			}
+			if workspaceID == "" && interactive {
+				workspaceID = promptInputDefault("Workspace ID (optional)", "")
+			}
+
+			cfg.Profiles[name] = config.Profile{
+				APIKey:      apiKey,
+				APIURL:      apiURL,
+				WorkspaceID: workspaceID,
+			}
+
+			// First profile becomes current
+			if len(cfg.Profiles) == 1 {
+				cfg.CurrentProfile = name
+			}
+
+			if err := cfg.SaveTo(cfgPath); err != nil {
+				return fmt.Errorf("saving config: %w", err)
+			}
+
+			out, err := json.Marshal(map[string]string{
+				"status":  "created",
+				"profile": name,
+			})
+			if err != nil {
+				return fmt.Errorf("marshaling output: %w", err)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), string(out))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&apiKey, "api-key", "", "API key for this profile")
+	cmd.Flags().StringVar(&apiURL, "api-url", "", "API URL for this profile")
+	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "Workspace ID for this profile (optional)")
+
+	return cmd
+}
+
+func newProfileDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete NAME",
+		Short: "Delete a named profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			cfgPath := getConfigPath()
+			cfg, err := config.LoadFrom(cfgPath)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			if _, ok := cfg.Profiles[name]; !ok {
+				return fmt.Errorf("profile %q not found", name)
+			}
+
+			delete(cfg.Profiles, name)
+
+			// Clear current_profile if we deleted it
+			if cfg.CurrentProfile == name {
+				cfg.CurrentProfile = ""
+			}
+
+			if err := cfg.SaveTo(cfgPath); err != nil {
+				return fmt.Errorf("saving config: %w", err)
+			}
+
+			out, err := json.Marshal(map[string]string{
+				"status":  "deleted",
+				"profile": name,
+			})
+			if err != nil {
+				return fmt.Errorf("marshaling output: %w", err)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), string(out))
+			return nil
+		},
+	}
+}
+
+func newProfileUseCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "use NAME",
+		Short: "Switch to a named profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			cfgPath := getConfigPath()
+			cfg, err := config.LoadFrom(cfgPath)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			if _, ok := cfg.Profiles[name]; !ok {
+				return fmt.Errorf("profile %q not found", name)
+			}
+
+			cfg.CurrentProfile = name
+
+			if err := cfg.SaveTo(cfgPath); err != nil {
+				return fmt.Errorf("saving config: %w", err)
+			}
+
+			out, err := json.Marshal(map[string]string{
+				"status":  "switched",
+				"profile": name,
+			})
+			if err != nil {
+				return fmt.Errorf("marshaling output: %w", err)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), string(out))
+			return nil
+		},
+	}
+}

--- a/internal/cmd/profile_test.go
+++ b/internal/cmd/profile_test.go
@@ -1,0 +1,331 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTempConfig writes a TOML config file in a temp dir and returns its path.
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("writing temp config: %v", err)
+	}
+	return path
+}
+
+// ==================== profile create ====================
+
+func TestProfileCreate_NewFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	t.Setenv("LANGSMITH_CONFIG_FILE", cfgPath)
+
+	out, err := executeCommand(t, "profile", "create", "myprofile",
+		"--api-key", "ls-testkey12345",
+		"--api-url", "https://api.smith.langchain.com",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v (output: %s)", err, out)
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+		t.Fatalf("parsing output JSON: %v (output: %s)", err, out)
+	}
+	if result["status"] != "created" {
+		t.Errorf("expected status=created, got %q", result["status"])
+	}
+	if result["profile"] != "myprofile" {
+		t.Errorf("expected profile=myprofile, got %q", result["profile"])
+	}
+
+	// Verify file was created
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Errorf("config file not created: %v", err)
+	}
+}
+
+func TestProfileCreate_AlreadyExists(t *testing.T) {
+	cfgPath := writeTempConfig(t, `
+[myprofile]
+api_key = "ls-existing"
+api_url = "https://api.smith.langchain.com"
+`)
+	t.Setenv("LANGSMITH_CONFIG_FILE", cfgPath)
+
+	_, err := executeCommand(t, "profile", "create", "myprofile",
+		"--api-key", "ls-newkey",
+		"--api-url", "https://api.smith.langchain.com",
+	)
+	if err == nil {
+		t.Error("expected error when profile already exists")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("expected 'already exists' error, got %v", err)
+	}
+}
+
+func TestProfileCreate_InvalidName(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	t.Setenv("LANGSMITH_CONFIG_FILE", cfgPath)
+
+	_, err := executeCommand(t, "profile", "create", "my profile!",
+		"--api-key", "ls-key",
+		"--api-url", "https://api.smith.langchain.com",
+	)
+	if err == nil {
+		t.Error("expected error for invalid profile name")
+	}
+}
+
+func TestProfileCreate_FirstBecomesCurrentProfile(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	t.Setenv("LANGSMITH_CONFIG_FILE", cfgPath)
+
+	_, err := executeCommand(t, "profile", "create", "first",
+		"--api-key", "ls-key12345",
+		"--api-url", "https://api.smith.langchain.com",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Read the config file to check current_profile was set
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("reading config file: %v", err)
+	}
+	if !strings.Contains(string(data), `current_profile = "first"`) {
+		t.Errorf("first profile should become current_profile, config:\n%s", data)
+	}
+}
+
+// ==================== profile list ====================
+
+func TestProfileList_Empty(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	t.Setenv("LANGSMITH_CONFIG_FILE", cfgPath)
+
+	out, err := executeCommand(t, "profile", "list")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result []any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+		t.Fatalf("parsing output JSON: %v (output: %s)", err, out)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty list, got %d items", len(result))
+	}
+}
+
+func TestProfileList_WithProfiles(t *testing.T) {
+	cfgPath := writeTempConfig(t, `current_profile = "beta"
+
+[alpha]
+api_key = "ls-alpha"
+api_url = "https://api.smith.langchain.com"
+
+[beta]
+api_key = "ls-beta"
+api_url = "https://api.smith.langchain.com"
+`)
+	t.Setenv("LANGSMITH_CONFIG_FILE", cfgPath)
+
+	out, err := executeCommand(t, "profile", "list")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result []map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+		t.Fatalf("parsing output JSON: %v (output: %s)", err, out)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 profiles, got %d", len(result))
+	}
+
+	// Should be sorted by name: alpha first, beta second
+	if result[0]["name"] != "alpha" {
+		t.Errorf("expected first profile alpha, got %v", result[0]["name"])
+	}
+	if result[1]["name"] != "beta" {
+		t.Errorf("expected second profile beta, got %v", result[1]["name"])
+	}
+
+	// beta should be marked active
+	if result[0]["active"] != false {
+		t.Errorf("expected alpha inactive, got %v", result[0]["active"])
+	}
+	if result[1]["active"] != true {
+		t.Errorf("expected beta active, got %v", result[1]["active"])
+	}
+}
+
+// ==================== profile show ====================
+
+func TestProfileShow_Exists(t *testing.T) {
+	cfgPath := writeTempConfig(t, `
+[myprofile]
+api_key = "ls-secretkey12345"
+api_url = "https://api.smith.langchain.com"
+workspace_id = "ws-abc"
+`)
+	t.Setenv("LANGSMITH_CONFIG_FILE", cfgPath)
+
+	out, err := executeCommand(t, "profile", "show", "myprofile")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+		t.Fatalf("parsing output JSON: %v (output: %s)", err, out)
+	}
+	if result["name"] != "myprofile" {
+		t.Errorf("expected name=myprofile, got %v", result["name"])
+	}
+	// Key should be masked
+	apiKey, _ := result["api_key"].(string)
+	if strings.Contains(apiKey, "secretkey") {
+		t.Errorf("API key should be masked, got %q", apiKey)
+	}
+	if !strings.Contains(apiKey, "...") {
+		t.Errorf("masked key should contain '...', got %q", apiKey)
+	}
+	if result["api_url"] != "https://api.smith.langchain.com" {
+		t.Errorf("unexpected api_url: %v", result["api_url"])
+	}
+	if result["workspace_id"] != "ws-abc" {
+		t.Errorf("expected workspace_id=ws-abc, got %v", result["workspace_id"])
+	}
+}
+
+func TestProfileShow_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	t.Setenv("LANGSMITH_CONFIG_FILE", cfgPath)
+
+	_, err := executeCommand(t, "profile", "show", "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent profile")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got %v", err)
+	}
+}
+
+// ==================== profile delete ====================
+
+func TestProfileDelete_Exists(t *testing.T) {
+	cfgPath := writeTempConfig(t, `
+[myprofile]
+api_key = "ls-key"
+api_url = "https://api.smith.langchain.com"
+`)
+	t.Setenv("LANGSMITH_CONFIG_FILE", cfgPath)
+
+	out, err := executeCommand(t, "profile", "delete", "myprofile")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+		t.Fatalf("parsing output JSON: %v (output: %s)", err, out)
+	}
+	if result["status"] != "deleted" {
+		t.Errorf("expected status=deleted, got %q", result["status"])
+	}
+	if result["profile"] != "myprofile" {
+		t.Errorf("expected profile=myprofile, got %q", result["profile"])
+	}
+}
+
+func TestProfileDelete_ClearsCurrentProfile(t *testing.T) {
+	cfgPath := writeTempConfig(t, `current_profile = "active"
+
+[active]
+api_key = "ls-key"
+api_url = "https://api.smith.langchain.com"
+`)
+	t.Setenv("LANGSMITH_CONFIG_FILE", cfgPath)
+
+	_, err := executeCommand(t, "profile", "delete", "active")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("reading config file: %v", err)
+	}
+	if strings.Contains(string(data), "current_profile") {
+		t.Errorf("current_profile should be cleared after deleting active profile, config:\n%s", data)
+	}
+}
+
+func TestProfileDelete_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	t.Setenv("LANGSMITH_CONFIG_FILE", cfgPath)
+
+	_, err := executeCommand(t, "profile", "delete", "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent profile")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got %v", err)
+	}
+}
+
+// ==================== profile use ====================
+
+func TestProfileUse_Exists(t *testing.T) {
+	cfgPath := writeTempConfig(t, `
+[myprofile]
+api_key = "ls-key"
+api_url = "https://api.smith.langchain.com"
+`)
+	t.Setenv("LANGSMITH_CONFIG_FILE", cfgPath)
+
+	out, err := executeCommand(t, "profile", "use", "myprofile")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+		t.Fatalf("parsing output JSON: %v (output: %s)", err, out)
+	}
+	if result["status"] != "switched" {
+		t.Errorf("expected status=switched, got %q", result["status"])
+	}
+	if result["profile"] != "myprofile" {
+		t.Errorf("expected profile=myprofile, got %q", result["profile"])
+	}
+}
+
+func TestProfileUse_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	t.Setenv("LANGSMITH_CONFIG_FILE", cfgPath)
+
+	_, err := executeCommand(t, "profile", "use", "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent profile")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got %v", err)
+	}
+}

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -47,7 +47,7 @@ func newProjectListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List tracing projects in the workspace (default: 20, sorted by most recent activity)",
 		Run: func(cmd *cobra.Command, args []string) {
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			pageSize := int64(20)
@@ -72,9 +72,9 @@ func newProjectListCmd() *cobra.Command {
 				}
 			}
 			if err := pager.Err(); err != nil {
-				exitErrorf("listing projects: %v", err)
+				ExitErrorf("listing projects: %v", err)
 			}
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				columns := []string{"Name", "ID", "Runs", "Latency p50", "Error Rate", "Last Active"}

--- a/internal/cmd/prompt.go
+++ b/internal/cmd/prompt.go
@@ -74,7 +74,7 @@ func newPromptListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List Prompt Hub repos",
 		Run: func(cmd *cobra.Command, args []string) {
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			pageSize := int64(20)
@@ -108,7 +108,7 @@ func newPromptListCmd() *cobra.Command {
 				case "updated":
 					params.SortField = langsmith.F(langsmith.RepoListParamsSortFieldUpdatedAt)
 				default:
-					exitErrorf("unknown --sort-by %q (valid: likes, downloads, views, updated)", sortBy)
+					ExitErrorf("unknown --sort-by %q (valid: likes, downloads, views, updated)", sortBy)
 				}
 			}
 
@@ -121,10 +121,10 @@ func newPromptListCmd() *cobra.Command {
 				}
 			}
 			if err := pager.Err(); err != nil {
-				exitErrorf("listing prompts: %v", err)
+				ExitErrorf("listing prompts: %v", err)
 			}
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				columns := []string{"Full Name", "Public", "Commits", "Likes", "Updated"}
@@ -173,15 +173,15 @@ func newPromptGetCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			owner, repo, _, err := parseOwnerRepo(args[0])
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			resp, err := c.SDK.Repos.Get(ctx, owner, repo)
 			if err != nil {
-				exitErrorf("getting prompt %s/%s: %v", owner, repo, err)
+				ExitErrorf("getting prompt %s/%s: %v", owner, repo, err)
 			}
 
 			r := resp.Repo
@@ -191,7 +191,7 @@ func newPromptGetCmd() *cobra.Command {
 				data["manifest"] = r.LatestCommitManifest.Manifest
 			}
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 			if fmt_ == "pretty" {
 				output.PrintOutput(data, "pretty", outputFile)
 			} else {
@@ -216,7 +216,7 @@ func newPromptCreateCmd() *cobra.Command {
 		Use:   "create",
 		Short: "Create a new Prompt Hub repo",
 		Run: func(cmd *cobra.Command, args []string) {
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			params := langsmith.RepoNewParams{
@@ -232,7 +232,7 @@ func newPromptCreateCmd() *cobra.Command {
 
 			resp, err := c.SDK.Repos.New(ctx, params)
 			if err != nil {
-				exitErrorf("creating prompt: %v", err)
+				ExitErrorf("creating prompt: %v", err)
 			}
 
 			output.OutputJSON(repoToMap(resp.Repo), "")
@@ -258,7 +258,7 @@ func newPromptDeleteCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			owner, repo, _, err := parseOwnerRepo(args[0])
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
 			if !yes {
@@ -266,16 +266,16 @@ func newPromptDeleteCmd() *cobra.Command {
 				var confirm string
 				_, _ = fmt.Scanln(&confirm)
 				if strings.ToLower(confirm) != "y" {
-					exitError("aborted")
+					ExitError("aborted")
 				}
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			_, err = c.SDK.Repos.Delete(ctx, owner, repo)
 			if err != nil {
-				exitErrorf("deleting prompt %s/%s: %v", owner, repo, err)
+				ExitErrorf("deleting prompt %s/%s: %v", owner, repo, err)
 			}
 
 			output.OutputJSON(map[string]any{
@@ -303,7 +303,7 @@ func newPromptPullCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			owner, repo, inlineRef, err := parseOwnerRepo(args[0])
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
 			ref := "latest"
@@ -314,12 +314,12 @@ func newPromptPullCmd() *cobra.Command {
 				ref = commitRef
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			resp, err := c.SDK.Commits.Get(ctx, owner, repo, ref, langsmith.CommitGetParams{})
 			if err != nil {
-				exitErrorf("pulling %s/%s@%s: %v", owner, repo, ref, err)
+				ExitErrorf("pulling %s/%s@%s: %v", owner, repo, ref, err)
 			}
 
 			data := map[string]any{
@@ -329,7 +329,7 @@ func newPromptPullCmd() *cobra.Command {
 				"manifest":    resp.Manifest,
 			}
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 			if fmt_ == "pretty" {
 				output.PrintOutput(data, "pretty", outputFile)
 			} else {
@@ -356,28 +356,28 @@ func newPromptPushCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			owner, repo, _, err := parseOwnerRepo(args[0])
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
 			var manifestBytes []byte
 			if manifestFile != "" {
 				manifestBytes, err = os.ReadFile(manifestFile)
 				if err != nil {
-					exitErrorf("reading manifest file: %v", err)
+					ExitErrorf("reading manifest file: %v", err)
 				}
 			} else {
 				manifestBytes, err = io.ReadAll(os.Stdin)
 				if err != nil {
-					exitErrorf("reading stdin: %v", err)
+					ExitErrorf("reading stdin: %v", err)
 				}
 			}
 
 			var manifest any
 			if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
-				exitErrorf("parsing manifest JSON: %v", err)
+				ExitErrorf("parsing manifest JSON: %v", err)
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			params := langsmith.CommitNewParams{
@@ -389,7 +389,7 @@ func newPromptPushCmd() *cobra.Command {
 
 			resp, err := c.SDK.Commits.New(ctx, owner, repo, params)
 			if err != nil {
-				exitErrorf("pushing commit to %s/%s: %v", owner, repo, err)
+				ExitErrorf("pushing commit to %s/%s: %v", owner, repo, err)
 			}
 
 			output.OutputJSON(map[string]any{
@@ -421,10 +421,10 @@ func newPromptCommitsCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			owner, repo, _, err := parseOwnerRepo(args[0])
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			pageSize := int64(20)
@@ -443,10 +443,10 @@ func newPromptCommitsCmd() *cobra.Command {
 				}
 			}
 			if err := pager.Err(); err != nil {
-				exitErrorf("listing commits: %v", err)
+				ExitErrorf("listing commits: %v", err)
 			}
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				columns := []string{"Hash", "Author", "Downloads", "Created"}
@@ -529,19 +529,19 @@ func newPromptTagListCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			owner, repo, _, err := parseOwnerRepo(args[0])
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			var tags []repoTag
 			path := fmt.Sprintf("/repos/%s/%s/tags", owner, repo)
 			if err := c.RawGet(ctx, path, &tags); err != nil {
-				exitErrorf("listing tags for %s/%s: %v", owner, repo, err)
+				ExitErrorf("listing tags for %s/%s: %v", owner, repo, err)
 			}
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				columns := []string{"Tag", "Commit ID", "Created"}
@@ -584,10 +584,10 @@ func newPromptTagCreateCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			owner, repo, _, err := parseOwnerRepo(args[0])
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			body := map[string]any{
@@ -597,7 +597,7 @@ func newPromptTagCreateCmd() *cobra.Command {
 			var tag repoTag
 			path := fmt.Sprintf("/repos/%s/%s/tags", owner, repo)
 			if err := c.RawPost(ctx, path, body, &tag); err != nil {
-				exitErrorf("creating tag %q: %v", tagName, err)
+				ExitErrorf("creating tag %q: %v", tagName, err)
 			}
 
 			output.OutputJSON(map[string]any{
@@ -626,11 +626,11 @@ func newPromptTagUpdateCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			owner, repo, _, err := parseOwnerRepo(args[0])
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 			tagName := args[1]
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			body := map[string]any{
@@ -640,7 +640,7 @@ func newPromptTagUpdateCmd() *cobra.Command {
 			var tag repoTag
 			path := fmt.Sprintf("/repos/%s/%s/tags", owner, repo)
 			if err := c.RawPost(ctx, path, body, &tag); err != nil {
-				exitErrorf("updating tag %q: %v", tagName, err)
+				ExitErrorf("updating tag %q: %v", tagName, err)
 			}
 
 			output.OutputJSON(map[string]any{

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -14,6 +14,7 @@ var (
 	flagAPIKey       string
 	flagAPIURL       string
 	flagOutputFormat string
+	flagProfile      string
 )
 
 // NewRootCmd creates the top-level `langsmith` command.
@@ -51,6 +52,7 @@ Output:
 	rootCmd.PersistentFlags().StringVar(&flagAPIKey, "api-key", "", "LangSmith API key [env: LANGSMITH_API_KEY]")
 	rootCmd.PersistentFlags().StringVar(&flagAPIURL, "api-url", "", "LangSmith API URL [env: LANGSMITH_ENDPOINT]")
 	rootCmd.PersistentFlags().StringVar(&flagOutputFormat, "format", "json", "Output format: json or pretty")
+	rootCmd.PersistentFlags().StringVar(&flagProfile, "profile", "", "Named profile to use [env: LANGSMITH_PROFILE]")
 
 	// Register all subcommand groups
 	rootCmd.AddCommand(newProjectCmd())
@@ -67,11 +69,12 @@ Output:
 	rootCmd.AddCommand(newPromptCmd())
 	rootCmd.AddCommand(newUpdateCmd(rawVersion))
 	rootCmd.AddCommand(api.NewCmd())
+	rootCmd.AddCommand(newProfileCmd())
 
 	return rootCmd
 }
 
-// GetAPIKey resolves the API key from flag → env → error.
+// GetAPIKey resolves the API key from flag → env → empty.
 func GetAPIKey() string {
 	if flagAPIKey != "" {
 		return flagAPIKey

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
+	"github.com/langchain-ai/langsmith-cli/internal/cmd/api"
 	"github.com/spf13/cobra"
 )
 
@@ -65,6 +66,7 @@ Output:
 	rootCmd.AddCommand(newFleetCmd())
 	rootCmd.AddCommand(newPromptCmd())
 	rootCmd.AddCommand(newUpdateCmd(rawVersion))
+	rootCmd.AddCommand(api.NewCmd())
 
 	return rootCmd
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -71,8 +71,8 @@ Output:
 	return rootCmd
 }
 
-// getAPIKey resolves the API key from flag → env → error.
-func getAPIKey() string {
+// GetAPIKey resolves the API key from flag → env → error.
+func GetAPIKey() string {
 	if flagAPIKey != "" {
 		return flagAPIKey
 	}
@@ -82,8 +82,8 @@ func getAPIKey() string {
 	return ""
 }
 
-// getAPIURL resolves the API URL from flag → env → default.
-func getAPIURL() string {
+// GetAPIURL resolves the API URL from flag → env → default.
+func GetAPIURL() string {
 	if flagAPIURL != "" {
 		return flagAPIURL
 	}
@@ -93,27 +93,27 @@ func getAPIURL() string {
 	return "https://api.smith.langchain.com"
 }
 
-// getFormat returns the output format.
-func getFormat() string {
+// GetFormat returns the output format.
+func GetFormat() string {
 	return flagOutputFormat
 }
 
-// mustGetClient creates a LangSmith client or exits with an error.
-func mustGetClient() *client.Client {
-	apiKey := getAPIKey()
+// MustGetClient creates a LangSmith client or exits with an error.
+func MustGetClient() *client.Client {
+	apiKey := GetAPIKey()
 	if apiKey == "" {
-		exitError("LANGSMITH_API_KEY not set")
+		ExitError("LANGSMITH_API_KEY not set")
 	}
-	return client.New(apiKey, getAPIURL())
+	return client.New(apiKey, GetAPIURL())
 }
 
-// exitError prints a JSON error to stderr and exits.
-func exitError(msg string) {
+// ExitError prints a JSON error to stderr and exits.
+func ExitError(msg string) {
 	fmt.Fprintf(os.Stderr, `{"error": %q}`+"\n", msg)
 	os.Exit(1)
 }
 
-// exitErrorf prints a formatted JSON error to stderr and exits.
-func exitErrorf(format string, args ...any) {
-	exitError(fmt.Sprintf(format, args...))
+// ExitErrorf prints a formatted JSON error to stderr and exits.
+func ExitErrorf(format string, args ...any) {
+	ExitError(fmt.Sprintf(format, args...))
 }

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestRootCmd_HasAllSubcommands(t *testing.T) {
 	root := NewRootCmd("1.0.0", "1.0.0")
-	expected := []string{"project", "trace", "run", "thread", "dataset", "example", "evaluator", "experiment", "self-update"}
+	expected := []string{"project", "trace", "run", "thread", "dataset", "example", "evaluator", "experiment", "self-update", "api"}
 	cmds := root.Commands()
 
 	names := make(map[string]bool, len(cmds))

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestRootCmd_HasAllSubcommands(t *testing.T) {
 	root := NewRootCmd("1.0.0", "1.0.0")
-	expected := []string{"project", "trace", "run", "thread", "dataset", "example", "evaluator", "experiment", "self-update", "api"}
+	expected := []string{"project", "trace", "run", "thread", "dataset", "example", "evaluator", "experiment", "self-update", "api", "profile"}
 	cmds := root.Commands()
 
 	names := make(map[string]bool, len(cmds))
@@ -183,3 +183,17 @@ func TestRootCmd_UnknownSubcommand(t *testing.T) {
 		t.Error("expected error for unknown subcommand")
 	}
 }
+
+// ---------- --profile flag ----------
+
+func TestRootCmd_PersistentFlags_Profile(t *testing.T) {
+	root := NewRootCmd("dev", "dev")
+	f := root.PersistentFlags().Lookup("profile")
+	if f == nil {
+		t.Fatal("--profile flag not found")
+	}
+	if f.DefValue != "" {
+		t.Errorf("expected default empty, got %q", f.DefValue)
+	}
+}
+

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -91,7 +91,7 @@ func TestGetAPIKey_FlagPrecedence(t *testing.T) {
 	flagAPIKey = "from-flag"
 	t.Setenv("LANGSMITH_API_KEY", "from-env")
 
-	if got := getAPIKey(); got != "from-flag" {
+	if got := GetAPIKey(); got != "from-flag" {
 		t.Errorf("expected from-flag, got %q", got)
 	}
 }
@@ -103,7 +103,7 @@ func TestGetAPIKey_EnvFallback(t *testing.T) {
 	flagAPIKey = ""
 	t.Setenv("LANGSMITH_API_KEY", "from-env")
 
-	if got := getAPIKey(); got != "from-env" {
+	if got := GetAPIKey(); got != "from-env" {
 		t.Errorf("expected from-env, got %q", got)
 	}
 }
@@ -115,7 +115,7 @@ func TestGetAPIKey_Empty(t *testing.T) {
 	flagAPIKey = ""
 	os.Unsetenv("LANGSMITH_API_KEY")
 
-	if got := getAPIKey(); got != "" {
+	if got := GetAPIKey(); got != "" {
 		t.Errorf("expected empty, got %q", got)
 	}
 }
@@ -129,7 +129,7 @@ func TestGetAPIURL_FlagPrecedence(t *testing.T) {
 	flagAPIURL = "http://custom.example.com"
 	t.Setenv("LANGSMITH_ENDPOINT", "http://env.example.com")
 
-	if got := getAPIURL(); got != "http://custom.example.com" {
+	if got := GetAPIURL(); got != "http://custom.example.com" {
 		t.Errorf("expected http://custom.example.com, got %q", got)
 	}
 }
@@ -141,7 +141,7 @@ func TestGetAPIURL_EnvFallback(t *testing.T) {
 	flagAPIURL = ""
 	t.Setenv("LANGSMITH_ENDPOINT", "http://env.example.com")
 
-	if got := getAPIURL(); got != "http://env.example.com" {
+	if got := GetAPIURL(); got != "http://env.example.com" {
 		t.Errorf("expected http://env.example.com, got %q", got)
 	}
 }
@@ -153,7 +153,7 @@ func TestGetAPIURL_DefaultValue(t *testing.T) {
 	flagAPIURL = ""
 	os.Unsetenv("LANGSMITH_ENDPOINT")
 
-	if got := getAPIURL(); got != "https://api.smith.langchain.com" {
+	if got := GetAPIURL(); got != "https://api.smith.langchain.com" {
 		t.Errorf("expected default URL, got %q", got)
 	}
 }
@@ -165,12 +165,12 @@ func TestGetFormat_ReturnsValue(t *testing.T) {
 	defer func() { flagOutputFormat = old }()
 
 	flagOutputFormat = "pretty"
-	if got := getFormat(); got != "pretty" {
+	if got := GetFormat(); got != "pretty" {
 		t.Errorf("expected pretty, got %q", got)
 	}
 
 	flagOutputFormat = "json"
-	if got := getFormat(); got != "json" {
+	if got := GetFormat(); got != "json" {
 		t.Errorf("expected json, got %q", got)
 	}
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -58,11 +58,11 @@ func newRunListCmd() *cobra.Command {
 				ff.Limit = 50
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 			projectName := ResolveProject(ff.Project)
 			if projectName == "" {
-				exitError("--project is required for run list (or set LANGSMITH_PROJECT)")
+				ExitError("--project is required for run list (or set LANGSMITH_PROJECT)")
 			}
 
 			params := BuildRunQueryParams(&ff, false, ff.Limit)
@@ -71,10 +71,10 @@ func newRunListCmd() *cobra.Command {
 			}
 			runs, err := queryRuns(ctx, c, params, projectName, ff.Limit, ff.MinTokens)
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				data := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)
@@ -121,11 +121,11 @@ func newRunGetCmd() *cobra.Command {
 				includeFeedback = true
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 			projectName := ResolveProject(project)
 			if projectName == "" {
-				exitError("--project is required for run get (or set LANGSMITH_PROJECT)")
+				ExitError("--project is required for run get (or set LANGSMITH_PROJECT)")
 			}
 
 			params := langsmith.RunQueryParams{
@@ -139,14 +139,14 @@ func newRunGetCmd() *cobra.Command {
 
 			runs, err := queryRuns(ctx, c, params, projectName, 1, 0)
 			if err != nil {
-				exitErrorf("fetching run: %v", err)
+				ExitErrorf("fetching run: %v", err)
 			}
 			if len(runs) == 0 {
-				exitErrorf("run not found: %s", runID)
+				ExitErrorf("run not found: %s", runID)
 			}
 
 			data := extract.ExtractRun(runs[0], includeMetadata, includeIO, includeFeedback)
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				output.PrintOutput(data, "pretty", outputFile)
@@ -194,11 +194,11 @@ func newRunExportCmd() *cobra.Command {
 				ff.Limit = 100
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 			projectName := ResolveProject(ff.Project)
 			if projectName == "" {
-				exitError("--project is required for run export (or set LANGSMITH_PROJECT)")
+				ExitError("--project is required for run export (or set LANGSMITH_PROJECT)")
 			}
 
 			params := BuildRunQueryParams(&ff, false, ff.Limit)
@@ -207,7 +207,7 @@ func newRunExportCmd() *cobra.Command {
 			}
 			runs, err := queryRuns(ctx, c, params, projectName, ff.Limit, ff.MinTokens)
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
 			data := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)

--- a/internal/cmd/sandbox_tunnel.go
+++ b/internal/cmd/sandbox_tunnel.go
@@ -55,7 +55,7 @@ Examples:
 				return fmt.Errorf("--local-port must be between 1 and 65535 (got %d)", localPort)
 			}
 
-			apiKey := getAPIKey()
+			apiKey := GetAPIKey()
 			if apiKey == "" {
 				return fmt.Errorf("LANGSMITH_API_KEY not set (use --api-key or $LANGSMITH_API_KEY)")
 			}

--- a/internal/cmd/skill.go
+++ b/internal/cmd/skill.go
@@ -75,7 +75,7 @@ Use --copy to copy instead of symlink.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			skillName := args[0]
-			c := mustGetClient()
+			c := MustGetClient()
 
 			var canonicalDir string
 			if global {
@@ -176,7 +176,7 @@ Use --copy to copy instead of symlink.`,
 				Files:     written,
 			}
 
-			if getFormat() == "pretty" {
+			if GetFormat() == "pretty" {
 				fmt.Printf("Installed skill %q to %s\n", skillName, canonicalAbs)
 				for _, l := range linked {
 					fmt.Printf("  Linked: %s\n", l)

--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -51,16 +51,16 @@ func newThreadListCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			project = ResolveProject(project)
 			if project == "" {
-				exitError("--project is required for thread list (or set LANGSMITH_PROJECT)")
+				ExitError("--project is required for thread list (or set LANGSMITH_PROJECT)")
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			// Resolve project to session ID
 			sessionID, err := c.ResolveSessionID(ctx, project)
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
 			// Query root runs (like the Python SDK does)
@@ -90,7 +90,7 @@ func newThreadListCmd() *cobra.Command {
 				}
 				resp, err := c.SDK.Runs.Query(ctx, params)
 				if err != nil {
-					exitErrorf("querying runs: %v", err)
+					ExitErrorf("querying runs: %v", err)
 				}
 				for _, run := range resp.Runs {
 					tid := run.ThreadID
@@ -146,7 +146,7 @@ func newThreadListCmd() *cobra.Command {
 				threads = threads[:limit]
 			}
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				columns := []string{"Thread ID", "Run Count", "Min Start", "Max Start"}
@@ -210,16 +210,16 @@ func newThreadGetCmd() *cobra.Command {
 
 			project = ResolveProject(project)
 			if project == "" {
-				exitError("--project is required for thread get (or set LANGSMITH_PROJECT)")
+				ExitError("--project is required for thread get (or set LANGSMITH_PROJECT)")
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			// Resolve project to session ID
 			sessionID, err := c.ResolveSessionID(ctx, project)
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
 			// Query root runs filtered by thread_id
@@ -240,12 +240,12 @@ func newThreadGetCmd() *cobra.Command {
 
 			runs, err := queryRuns(ctx, c, params, "", queryLimit, 0)
 			if err != nil {
-				exitErrorf("querying thread runs: %v", err)
+				ExitErrorf("querying thread runs: %v", err)
 			}
 
 			extracted := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				output.PrintRunsTable(os.Stdout, extracted, includeMetadata, fmt.Sprintf("Thread %s", threadID))

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -62,11 +62,11 @@ func newTraceListCmd() *cobra.Command {
 				ff.Limit = defaultLimit
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 			projectName := ResolveProject(ff.Project)
 			if projectName == "" {
-				exitError("--project is required for trace list (or set LANGSMITH_PROJECT)")
+				ExitError("--project is required for trace list (or set LANGSMITH_PROJECT)")
 			}
 
 			params := BuildRunQueryParams(&ff, true, ff.Limit)
@@ -75,10 +75,10 @@ func newTraceListCmd() *cobra.Command {
 			}
 			runs, err := queryRuns(ctx, c, params, projectName, ff.Limit, ff.MinTokens)
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				if showHierarchy {
@@ -88,7 +88,7 @@ func newTraceListCmd() *cobra.Command {
 							Order: langsmith.F(langsmith.RunQueryParamsOrderAsc),
 						}, projectName, 1000, 0)
 						if err != nil {
-							exitErrorf("%v", err)
+							ExitErrorf("%v", err)
 						}
 						output.OutputTree(runsToTreeData(allRuns), "")
 					}
@@ -109,7 +109,7 @@ func newTraceListCmd() *cobra.Command {
 						childParams.Trace = langsmith.F(run.TraceID)
 						allRuns, err := queryRuns(ctx, c, childParams, projectName, 1000, 0)
 						if err != nil {
-							exitErrorf("%v", err)
+							ExitErrorf("%v", err)
 						}
 						result = append(result, map[string]any{
 							"trace_id":  run.TraceID,
@@ -162,11 +162,11 @@ func newTraceGetCmd() *cobra.Command {
 				includeFeedback = true
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 			projectName := ResolveProject(project)
 			if projectName == "" {
-				exitError("--project is required for trace get (or set LANGSMITH_PROJECT)")
+				ExitError("--project is required for trace get (or set LANGSMITH_PROJECT)")
 			}
 
 			params := langsmith.RunQueryParams{
@@ -180,10 +180,10 @@ func newTraceGetCmd() *cobra.Command {
 
 			runs, err := queryRuns(ctx, c, params, projectName, 1000, 0)
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				output.OutputTree(runsToTreeData(runs), "")
@@ -238,14 +238,14 @@ func newTraceExportCmd() *cobra.Command {
 			}
 
 			if err := os.MkdirAll(outputDir, 0755); err != nil {
-				exitErrorf("creating output directory: %v", err)
+				ExitErrorf("creating output directory: %v", err)
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 			projectName := ResolveProject(ff.Project)
 			if projectName == "" {
-				exitError("--project is required for trace export (or set LANGSMITH_PROJECT)")
+				ExitError("--project is required for trace export (or set LANGSMITH_PROJECT)")
 			}
 
 			params := BuildRunQueryParams(&ff, true, ff.Limit)
@@ -255,7 +255,7 @@ func newTraceExportCmd() *cobra.Command {
 			}
 			rootRuns, err := queryRuns(ctx, c, params, projectName, ff.Limit, ff.MinTokens)
 			if err != nil {
-				exitErrorf("%v", err)
+				ExitErrorf("%v", err)
 			}
 
 			exported := 0
@@ -271,7 +271,7 @@ func newTraceExportCmd() *cobra.Command {
 				}
 				allRuns, err := queryRuns(ctx, c, childParams, projectName, 1000, 0)
 				if err != nil {
-					exitErrorf("%v", err)
+					ExitErrorf("%v", err)
 				}
 
 				name := root.Name
@@ -287,7 +287,7 @@ func newTraceExportCmd() *cobra.Command {
 
 				f, err := os.Create(fpath)
 				if err != nil {
-					exitErrorf("creating file %s: %v", fpath, err)
+					ExitErrorf("creating file %s: %v", fpath, err)
 				}
 
 				for _, run := range allRuns {

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -54,7 +54,7 @@ func runUpdate(ctx context.Context, currentVersion string, dryRun bool) error {
 	}
 
 	cmp := compareVersions(currentVersion, latest)
-	format := getFormat()
+	format := GetFormat()
 
 	if cmp >= 0 {
 		if format == "pretty" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,8 +15,11 @@ import (
 )
 
 // Profile holds per-profile configuration.
+// A profile uses either APIKey (X-API-Key header) or BearerToken
+// (Authorization: Bearer header) for authentication, not both.
 type Profile struct {
 	APIKey      string
+	BearerToken string
 	APIURL      string
 	WorkspaceID string
 }
@@ -82,6 +85,9 @@ func LoadFrom(path string) (*Config, error) {
 		p := Profile{}
 		if v, ok := section["api_key"].(string); ok {
 			p.APIKey = v
+		}
+		if v, ok := section["bearer_token"].(string); ok {
+			p.BearerToken = v
 		}
 		if v, ok := section["api_url"].(string); ok {
 			p.APIURL = v
@@ -154,6 +160,9 @@ func (c *Config) SaveTo(path string) error {
 		w("\n[%s]\n", name)
 		if p.APIKey != "" {
 			w("api_key = %q\n", p.APIKey)
+		}
+		if p.BearerToken != "" {
+			w("bearer_token = %q\n", p.BearerToken)
 		}
 		if p.APIURL != "" {
 			w("api_url = %q\n", p.APIURL)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,214 @@
+// Package config handles reading, writing, and querying a TOML config file
+// for named profiles. The config file lives at ~/.langsmith/config.toml.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Profile holds per-profile configuration.
+type Profile struct {
+	APIKey      string
+	APIURL      string
+	WorkspaceID string
+}
+
+// Config holds the full config file contents.
+type Config struct {
+	CurrentProfile string
+	Profiles       map[string]Profile
+}
+
+// DefaultConfigPath returns the default config file path: ~/.langsmith/config.toml.
+func DefaultConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".langsmith", "config.toml")
+	}
+	return filepath.Join(home, ".langsmith", "config.toml")
+}
+
+// Load loads the config from the default path.
+func Load() (*Config, error) {
+	return LoadFrom(DefaultConfigPath())
+}
+
+// LoadFrom loads the config from the given path. Returns an empty Config if the
+// file does not exist.
+func LoadFrom(path string) (*Config, error) {
+	cfg := &Config{
+		Profiles: make(map[string]Profile),
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return cfg, nil
+		}
+		return nil, fmt.Errorf("reading config file: %w", err)
+	}
+
+	// Decode into a raw map so we can handle the mixed structure (scalar
+	// current_profile + profile sections).
+	var raw map[string]any
+	if err := toml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing config file: %w", err)
+	}
+
+	// Extract current_profile scalar.
+	if v, ok := raw["current_profile"]; ok {
+		if s, ok := v.(string); ok {
+			cfg.CurrentProfile = s
+		}
+	}
+
+	// Every other top-level key is a profile section.
+	for key, val := range raw {
+		if key == "current_profile" {
+			continue
+		}
+		section, ok := val.(map[string]any)
+		if !ok {
+			continue
+		}
+		p := Profile{}
+		if v, ok := section["api_key"].(string); ok {
+			p.APIKey = v
+		}
+		if v, ok := section["api_url"].(string); ok {
+			p.APIURL = v
+		}
+		if v, ok := section["workspace_id"].(string); ok {
+			p.WorkspaceID = v
+		}
+		cfg.Profiles[key] = p
+	}
+
+	return cfg, nil
+}
+
+// Save saves the config to the default path.
+func (c *Config) Save() error {
+	return c.SaveTo(DefaultConfigPath())
+}
+
+// validProfileName matches alphanumeric, hyphens, and underscores only.
+var validProfileName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// ValidateProfileName checks that a profile name is safe for use as a TOML section header.
+func ValidateProfileName(name string) error {
+	if !validProfileName.MatchString(name) {
+		return fmt.Errorf("invalid profile name %q: must contain only alphanumeric characters, hyphens, and underscores", name)
+	}
+	return nil
+}
+
+// SaveTo saves the config to the given path, creating parent directories as
+// needed. The file is written with 0600 permissions since it contains secrets.
+func (c *Config) SaveTo(path string) error {
+	for name := range c.Profiles {
+		if err := ValidateProfileName(name); err != nil {
+			return err
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("opening config file for write: %w", err)
+	}
+	defer f.Close()
+
+	var writeErr error
+	w := func(format string, args ...any) {
+		if writeErr != nil {
+			return
+		}
+		_, writeErr = fmt.Fprintf(f, format, args...)
+	}
+
+	if c.CurrentProfile != "" {
+		w("current_profile = %q\n", c.CurrentProfile)
+	}
+
+	// Sort profile names for deterministic output.
+	names := make([]string, 0, len(c.Profiles))
+	for name := range c.Profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		p := c.Profiles[name]
+		w("\n[%s]\n", name)
+		if p.APIKey != "" {
+			w("api_key = %q\n", p.APIKey)
+		}
+		if p.APIURL != "" {
+			w("api_url = %q\n", p.APIURL)
+		}
+		if p.WorkspaceID != "" {
+			w("workspace_id = %q\n", p.WorkspaceID)
+		}
+	}
+
+	if writeErr != nil {
+		return fmt.Errorf("writing config file: %w", writeErr)
+	}
+	return nil
+}
+
+// ResolveProfile resolves the active profile using the following precedence:
+// flagProfile → envProfile → CurrentProfile → "default" → nil.
+func (c *Config) ResolveProfile(flagProfile, envProfile string) *Profile {
+	name := c.ResolveProfileName(flagProfile, envProfile)
+	if name == "" {
+		return nil
+	}
+	p, ok := c.Profiles[name]
+	if !ok {
+		return nil
+	}
+	return &p
+}
+
+// ResolveProfileName returns the name of the active profile using the same
+// precedence as ResolveProfile. Returns "" when no profile can be found.
+func (c *Config) ResolveProfileName(flagProfile, envProfile string) string {
+	for _, candidate := range []string{flagProfile, envProfile, c.CurrentProfile, "default"} {
+		if candidate == "" {
+			continue
+		}
+		if _, ok := c.Profiles[candidate]; ok {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// MaskAPIKey masks an API key for display.
+//   - len > 12:  first 8 chars + "..." + last 4 chars
+//   - len 5–12: first 4 chars + "..." + last 3 chars
+//   - len <= 4:  "****"
+func MaskAPIKey(key string) string {
+	n := len(key)
+	switch {
+	case n > 12:
+		return key[:8] + "..." + key[n-4:]
+	case n >= 5:
+		return key[:4] + "..." + key[n-3:]
+	default:
+		return "****"
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,357 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad_NoFile(t *testing.T) {
+	// Point default path to a non-existent file via a temp dir
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "does_not_exist.toml")
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil Config")
+	}
+	if cfg.CurrentProfile != "" {
+		t.Errorf("expected empty CurrentProfile, got %q", cfg.CurrentProfile)
+	}
+	if len(cfg.Profiles) != 0 {
+		t.Errorf("expected empty Profiles, got %v", cfg.Profiles)
+	}
+}
+
+func TestLoad_ValidFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.toml")
+
+	content := `current_profile = "staging"
+
+[default]
+api_key = "lsv2_pt_abc123"
+api_url = "https://api.smith.langchain.com"
+
+[staging]
+api_key = "lsv2_pt_def456"
+api_url = "https://staging.example.com"
+workspace_id = "ws-123"
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if cfg.CurrentProfile != "staging" {
+		t.Errorf("expected CurrentProfile=staging, got %q", cfg.CurrentProfile)
+	}
+
+	def, ok := cfg.Profiles["default"]
+	if !ok {
+		t.Fatal("expected 'default' profile to be present")
+	}
+	if def.APIKey != "lsv2_pt_abc123" {
+		t.Errorf("expected default.APIKey=lsv2_pt_abc123, got %q", def.APIKey)
+	}
+	if def.APIURL != "https://api.smith.langchain.com" {
+		t.Errorf("expected default.APIURL=https://api.smith.langchain.com, got %q", def.APIURL)
+	}
+	if def.WorkspaceID != "" {
+		t.Errorf("expected default.WorkspaceID empty, got %q", def.WorkspaceID)
+	}
+
+	staging, ok := cfg.Profiles["staging"]
+	if !ok {
+		t.Fatal("expected 'staging' profile to be present")
+	}
+	if staging.APIKey != "lsv2_pt_def456" {
+		t.Errorf("expected staging.APIKey=lsv2_pt_def456, got %q", staging.APIKey)
+	}
+	if staging.APIURL != "https://staging.example.com" {
+		t.Errorf("expected staging.APIURL=https://staging.example.com, got %q", staging.APIURL)
+	}
+	if staging.WorkspaceID != "ws-123" {
+		t.Errorf("expected staging.WorkspaceID=ws-123, got %q", staging.WorkspaceID)
+	}
+}
+
+func TestSaveTo_CreatesFile(t *testing.T) {
+	tmp := t.TempDir()
+	// Use a nested path to verify parent dir creation
+	path := filepath.Join(tmp, "subdir", "config.toml")
+
+	cfg := &Config{
+		CurrentProfile: "staging",
+		Profiles: map[string]Profile{
+			"default": {
+				APIKey: "lsv2_pt_abc123",
+				APIURL: "https://api.smith.langchain.com",
+			},
+			"staging": {
+				APIKey:      "lsv2_pt_def456",
+				APIURL:      "https://staging.example.com",
+				WorkspaceID: "ws-123",
+			},
+		},
+	}
+
+	if err := cfg.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo failed: %v", err)
+	}
+
+	// Round-trip: load back and verify
+	loaded, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom after save failed: %v", err)
+	}
+
+	if loaded.CurrentProfile != "staging" {
+		t.Errorf("expected CurrentProfile=staging, got %q", loaded.CurrentProfile)
+	}
+
+	def, ok := loaded.Profiles["default"]
+	if !ok {
+		t.Fatal("expected 'default' profile after round-trip")
+	}
+	if def.APIKey != "lsv2_pt_abc123" {
+		t.Errorf("expected default.APIKey=lsv2_pt_abc123, got %q", def.APIKey)
+	}
+
+	staging, ok := loaded.Profiles["staging"]
+	if !ok {
+		t.Fatal("expected 'staging' profile after round-trip")
+	}
+	if staging.WorkspaceID != "ws-123" {
+		t.Errorf("expected staging.WorkspaceID=ws-123, got %q", staging.WorkspaceID)
+	}
+}
+
+func TestSaveTo_FilePermissions(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.toml")
+
+	cfg := &Config{
+		Profiles: map[string]Profile{
+			"default": {APIKey: "secret"},
+		},
+	}
+
+	if err := cfg.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo failed: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat failed: %v", err)
+	}
+
+	perm := info.Mode().Perm()
+	if perm != 0600 {
+		t.Errorf("expected permissions 0600, got %04o", perm)
+	}
+}
+
+func TestResolveProfile_FlagOverride(t *testing.T) {
+	cfg := &Config{
+		CurrentProfile: "current",
+		Profiles: map[string]Profile{
+			"flag-profile": {APIKey: "flag-key"},
+			"env-profile":  {APIKey: "env-key"},
+			"current":      {APIKey: "current-key"},
+			"default":      {APIKey: "default-key"},
+		},
+	}
+
+	p := cfg.ResolveProfile("flag-profile", "env-profile")
+	if p == nil {
+		t.Fatal("expected non-nil profile")
+	}
+	if p.APIKey != "flag-key" {
+		t.Errorf("expected flag-key, got %q", p.APIKey)
+	}
+}
+
+func TestResolveProfile_EnvOverride(t *testing.T) {
+	cfg := &Config{
+		CurrentProfile: "current",
+		Profiles: map[string]Profile{
+			"env-profile": {APIKey: "env-key"},
+			"current":     {APIKey: "current-key"},
+			"default":     {APIKey: "default-key"},
+		},
+	}
+
+	p := cfg.ResolveProfile("", "env-profile")
+	if p == nil {
+		t.Fatal("expected non-nil profile")
+	}
+	if p.APIKey != "env-key" {
+		t.Errorf("expected env-key, got %q", p.APIKey)
+	}
+}
+
+func TestResolveProfile_CurrentProfile(t *testing.T) {
+	cfg := &Config{
+		CurrentProfile: "current",
+		Profiles: map[string]Profile{
+			"current": {APIKey: "current-key"},
+			"default": {APIKey: "default-key"},
+		},
+	}
+
+	p := cfg.ResolveProfile("", "")
+	if p == nil {
+		t.Fatal("expected non-nil profile")
+	}
+	if p.APIKey != "current-key" {
+		t.Errorf("expected current-key, got %q", p.APIKey)
+	}
+}
+
+func TestResolveProfile_FallbackDefault(t *testing.T) {
+	cfg := &Config{
+		Profiles: map[string]Profile{
+			"default": {APIKey: "default-key"},
+		},
+	}
+
+	p := cfg.ResolveProfile("", "")
+	if p == nil {
+		t.Fatal("expected non-nil profile")
+	}
+	if p.APIKey != "default-key" {
+		t.Errorf("expected default-key, got %q", p.APIKey)
+	}
+}
+
+func TestResolveProfile_NoMatch(t *testing.T) {
+	cfg := &Config{
+		Profiles: map[string]Profile{},
+	}
+
+	p := cfg.ResolveProfile("", "")
+	if p != nil {
+		t.Errorf("expected nil, got %+v", p)
+	}
+}
+
+func TestResolveProfileName(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *Config
+		flagProfile string
+		envProfile  string
+		want        string
+	}{
+		{
+			name: "flag takes precedence",
+			cfg: &Config{
+				CurrentProfile: "current",
+				Profiles: map[string]Profile{
+					"flag-profile": {},
+					"env-profile":  {},
+					"current":      {},
+					"default":      {},
+				},
+			},
+			flagProfile: "flag-profile",
+			envProfile:  "env-profile",
+			want:        "flag-profile",
+		},
+		{
+			name: "env overrides current_profile",
+			cfg: &Config{
+				CurrentProfile: "current",
+				Profiles: map[string]Profile{
+					"env-profile": {},
+					"current":     {},
+				},
+			},
+			flagProfile: "",
+			envProfile:  "env-profile",
+			want:        "env-profile",
+		},
+		{
+			name: "current_profile when no flag/env",
+			cfg: &Config{
+				CurrentProfile: "current",
+				Profiles: map[string]Profile{
+					"current": {},
+					"default": {},
+				},
+			},
+			flagProfile: "",
+			envProfile:  "",
+			want:        "current",
+		},
+		{
+			name: "falls back to default",
+			cfg: &Config{
+				Profiles: map[string]Profile{
+					"default": {},
+				},
+			},
+			flagProfile: "",
+			envProfile:  "",
+			want:        "default",
+		},
+		{
+			name: "no match returns empty string",
+			cfg: &Config{
+				Profiles: map[string]Profile{},
+			},
+			flagProfile: "",
+			envProfile:  "",
+			want:        "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.ResolveProfileName(tt.flagProfile, tt.envProfile)
+			if got != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestMaskAPIKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want string
+	}{
+		// len > 12: show first 8 + "..." + last 4
+		{"lsv2_pt_abc123def456", "lsv2_pt_...f456"},
+		{"abcdefghijklmnop", "abcdefgh...mnop"},
+		// len == 13: still > 12
+		{"abcdefghijklm", "abcdefgh...jklm"},
+		// len == 12: show first 4 + "..." + last 3
+		{"abcdefghijkl", "abcd...jkl"},
+		// len == 8: show first 4 + "..." + last 3
+		{"abcdefgh", "abcd...fgh"},
+		// len == 5: show first 4 + "..." + last 3 (overlap is ok)
+		{"abcde", "abcd...cde"},
+		// len == 4: return "****"
+		{"abcd", "****"},
+		// len == 1: return "****"
+		{"a", "****"},
+		// len == 0: return "****"
+		{"", "****"},
+	}
+
+	for _, tt := range tests {
+		got := MaskAPIKey(tt.key)
+		if got != tt.want {
+			t.Errorf("MaskAPIKey(%q) = %q, want %q", tt.key, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `langsmith profile` subcommand group (`create`, `list`, `show`, `delete`, `use`) for managing named CLI profiles
- Profiles store API key, endpoint URL, and workspace ID in `~/.langsmith/config.toml` (TOML format)
- New `--profile` flag and `LANGSMITH_PROFILE` env var for selecting active profile
- Resolution priority: CLI flags > env vars > named profile > default profile > hardcoded defaults
- `client.New` now accepts workspace ID as a parameter instead of reading env directly

## Usage

```bash
# Create a profile
langsmith profile create prod --api-key lsv2_pt_... --api-url https://api.smith.langchain.com

# Create a second profile
langsmith profile create staging --api-key lsv2_pt_... --api-url https://staging.example.com

# List profiles (* marks active)
langsmith profile list
# [{"name":"prod","api_url":"https://api.smith.langchain.com","active":true},
#  {"name":"staging","api_url":"https://staging.example.com","active":false}]

# Switch active profile
langsmith profile use staging

# Show profile config (API key is masked)
langsmith profile show staging
# {"name":"staging","api_key":"lsv2_pt_...g456","api_url":"https://staging.example.com"}

# Use a profile for a single command
langsmith project list --profile prod

# Or via environment variable
LANGSMITH_PROFILE=staging langsmith project list

# Delete a profile
langsmith profile delete staging
```

### Config file format (`~/.langsmith/config.toml`)

```toml
current_profile = "prod"

[prod]
api_key = "lsv2_pt_abc123..."
api_url = "https://api.smith.langchain.com"
workspace_id = "ws-optional"

[staging]
api_key = "lsv2_pt_def456..."
api_url = "https://staging.example.com"
```

## Test plan
- [x] Unit tests for config package (load, save, round-trip, permissions, resolution precedence, masking)
- [x] Unit tests for all 5 profile subcommands (happy path + error cases)
- [x] Unit tests for profile fallback in `GetAPIKey`/`GetAPIURL`/`GetWorkspaceID`
- [x] E2E smoke test: create → list → show → use → delete flow
- [x] All existing tests pass (`go test ./...`)
- [x] Lint clean (`golangci-lint run`)