### PR TITLE
fix: update issues/filters to use exported function names

### DIFF
--- a/internal/cmd/filters.go
+++ b/internal/cmd/filters.go
@@ -101,7 +101,7 @@ func BuildRunQueryParams(f *FilterFlags, isRoot bool, defaultLimit int) langsmit
 		if err != nil {
 			t, err = time.Parse("2006-01-02T15:04:05", f.Before)
 			if err != nil {
-				exitErrorf("invalid --before timestamp: %s", f.Before)
+				ExitErrorf("invalid --before timestamp: %s", f.Before)
 			}
 		}
 		params.EndTime = langsmith.F(t)

--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -182,17 +182,17 @@ Examples:
   langsmith project issues events --project my-app --look-back-minutes 1440
   langsmith project issues events --project my-app --limit 50 --format pretty`,
 		Run: func(cmd *cobra.Command, args []string) {
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			projectName := ResolveProject(project)
 			if projectName == "" {
-				exitError("--project is required (or set LANGSMITH_PROJECT)")
+				ExitError("--project is required (or set LANGSMITH_PROJECT)")
 			}
 
 			sessionID, err := c.ResolveSessionID(ctx, projectName)
 			if err != nil {
-				exitErrorf("resolving project %q: %v", projectName, err)
+				ExitErrorf("resolving project %q: %v", projectName, err)
 			}
 
 			path := fmt.Sprintf("/v1/platform/sessions/%s/issue-events?look_back_minutes=%d&limit=%d",
@@ -200,10 +200,10 @@ Examples:
 
 			var events []issueEvent
 			if err := c.RawGet(ctx, path, &events); err != nil {
-				exitErrorf("listing issue events: %v", err)
+				ExitErrorf("listing issue events: %v", err)
 			}
 
-			fmt_ := getFormat()
+			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
 				columns := []string{"EVENT TYPE", "ACTOR", "ISSUE ID", "CREATED"}
@@ -273,10 +273,10 @@ Examples:
 		Run: func(cmd *cobra.Command, args []string) {
 			issueID := args[0]
 			if title == "" && description == "" {
-				exitError("at least one of --title or --description is required")
+				ExitError("at least one of --title or --description is required")
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			body := map[string]any{}
@@ -291,7 +291,7 @@ Examples:
 
 			var issue forgeIssue
 			if err := c.RawPatch(ctx, path, body, &issue); err != nil {
-				exitErrorf("updating issue: %v", err)
+				ExitErrorf("updating issue: %v", err)
 			}
 
 			output.OutputJSON(issueToMap(issue), outputFile)
@@ -395,10 +395,10 @@ func newProjectIssuesRunsAddCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			issueID := args[0]
 			if runID == "" || startTime == "" {
-				exitError("--run-id and --start-time are required")
+				ExitError("--run-id and --start-time are required")
 			}
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			body := map[string]any{
@@ -411,7 +411,7 @@ func newProjectIssuesRunsAddCmd() *cobra.Command {
 
 			path := fmt.Sprintf("/v1/platform/issues/%s/runs", issueID)
 			if err := c.RawPost(ctx, path, body, nil); err != nil {
-				exitErrorf("linking run: %v", err)
+				ExitErrorf("linking run: %v", err)
 			}
 			fmt.Printf("Run %s linked to issue %s\n", runID, issueID)
 		},
@@ -434,13 +434,13 @@ func newProjectIssuesRunsUpdateCmd() *cobra.Command {
 			issueID := args[0]
 			runID := args[1]
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			body := map[string]any{"comment": comment}
 			path := fmt.Sprintf("/v1/platform/issues/%s/runs/%s", issueID, runID)
 			if err := c.RawPatch(ctx, path, body, nil); err != nil {
-				exitErrorf("updating linked run: %v", err)
+				ExitErrorf("updating linked run: %v", err)
 			}
 			fmt.Printf("Updated comment on run %s for issue %s\n", runID, issueID)
 		},
@@ -459,12 +459,12 @@ func newProjectIssuesRunsRemoveCmd() *cobra.Command {
 			issueID := args[0]
 			runID := args[1]
 
-			c := mustGetClient()
+			c := MustGetClient()
 			ctx := context.Background()
 
 			path := fmt.Sprintf("/v1/platform/issues/%s/runs/%s", issueID, runID)
 			if err := c.RawDelete(ctx, path, nil); err != nil {
-				exitErrorf("unlinking run: %v", err)
+				ExitErrorf("unlinking run: %v", err)
 			}
 			fmt.Printf("Run %s unlinked from issue %s\n", runID, issueID)
 		},


### PR DESCRIPTION
## Summary
- PR #51 renamed `exitErrorf`→`ExitErrorf`, `exitError`→`ExitError`, `mustGetClient`→`MustGetClient`, `getFormat`→`GetFormat`
- PRs #65 and #66 merged to main before #51 and still used the old names
- The merge of #51 broke the build on main — CI is red

## Release Note
none

## Test Plan
- [x] `go build ./...` passes