### PR TITLE
docs(sandbox): improve top-level help with common workflow examples

### DIFF
--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -8,12 +8,25 @@ func newSandboxCmd() *cobra.Command {
 		Short: "Manage and interact with sandboxes (experimental)",
 		Long: `Manage and interact with sandboxes (currently in experimental preview).
 
-Examples:
-  langsmith sandbox create my-vm --snapshot-id <id>
-  langsmith sandbox list
-  langsmith sandbox console my-vm
+Common workflows:
+
+  # Build a snapshot from a Docker image and wait for it to be ready
+  langsmith sandbox snapshot build my-snap --docker-image ubuntu:24.04 --wait
+
+  # Create a sandbox from the snapshot and wait for it to boot
+  langsmith sandbox create my-vm --snapshot-id <id> --wait
+
+  # Run a command inside the sandbox
   langsmith sandbox exec my-vm -- uname -a
+
+  # Open an interactive shell
+  langsmith sandbox console my-vm
+
+  # Tunnel a remote port (e.g. Postgres) to localhost
   langsmith sandbox tunnel my-vm --remote-port 5432
+
+  # Set up SSH access (writes ~/.ssh/config so "ssh sandbox-my-vm" works)
+  # Requires sshd to be installed in your Docker image.
   langsmith sandbox ssh-setup my-vm`,
 	}
 


### PR DESCRIPTION
## Summary
- Replace the bare command list in `langsmith sandbox --help` with commented, sequential examples showing the typical snapshot → create → use workflow
- Note that SSH access requires sshd in the Docker image

## Test Plan
- [x] `langsmith sandbox --help` renders correctly