### PR TITLE
feat(trace): bulk ID + conversation dump for agent callers

### DIFF
--- a/internal/cmd/flagged.go
+++ b/internal/cmd/flagged.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/langchain-ai/langsmith-cli/internal/client"
+)
+
+// UserFlaggedIssueKey is the feedback key used to mark a trace as flagged for
+// issues-agent review.
+const UserFlaggedIssueKey = "langsmith_user_flagged_issue"
+
+// FlaggedTrace is a single user-flagged trace with its optional review
+// comment.
+type FlaggedTrace struct {
+	TraceID string
+	Comment string
+}
+
+// FetchFlaggedTraces paginates /api/v1/feedback for the user-flagged issue
+// feedback key on the given session and returns the set of flagged traces.
+// Failures are logged to stderr and surfaced as partial results — callers
+// get whatever was successfully fetched before the error.
+//
+// If lastNMinutes > 0, only flagged traces created within the window are
+// returned. Otherwise all flagged traces for the session are returned.
+func FetchFlaggedTraces(ctx context.Context, c *client.Client, sessionID string, lastNMinutes int) []FlaggedTrace {
+	var out []FlaggedTrace
+	seen := map[string]bool{}
+	offset := 0
+	const limit = 100
+
+	minCreatedQS := ""
+	if lastNMinutes > 0 {
+		minCreated := time.Now().UTC().Add(-time.Duration(lastNMinutes) * time.Minute)
+		minCreatedQS = "&min_created_at=" + url.QueryEscape(minCreated.Format(time.RFC3339))
+	}
+
+	for {
+		path := fmt.Sprintf(
+			"/api/v1/feedback?key=%s&session=%s%s&limit=%d&offset=%d",
+			url.QueryEscape(UserFlaggedIssueKey),
+			url.QueryEscape(sessionID),
+			minCreatedQS,
+			limit,
+			offset,
+		)
+		var page []map[string]any
+		if err := c.RawGet(ctx, path, &page); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: fetching flagged traces failed: %v\n", err)
+			return out
+		}
+		if len(page) == 0 {
+			break
+		}
+		for _, fb := range page {
+			tid, _ := fb["trace_id"].(string)
+			if tid == "" {
+				tid, _ = fb["run_id"].(string)
+			}
+			if tid == "" || seen[tid] {
+				continue
+			}
+			seen[tid] = true
+			comment, _ := fb["comment"].(string)
+			out = append(out, FlaggedTrace{TraceID: tid, Comment: comment})
+		}
+		if len(page) < limit {
+			break
+		}
+		offset += limit
+	}
+	return out
+}

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -1,48 +1,60 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
 
+	langsmith "github.com/langchain-ai/langsmith-go"
+
+	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
 func newTraceMessagesCmd() *cobra.Command {
 	var (
-		ff         FilterFlags
-		outputFile string
+		ff            FilterFlags
+		outputFile    string
+		outDir        string
+		fromList      string
+		flaggedList   string
+		includeRootIO bool
 	)
 
 	cmd := &cobra.Command{
-		Use:   "messages",
+		Use:    "messages",
 		Short:  "[Private Beta] Get conversation messages for multiple traces (batch)",
 		Hidden: true,
 		Long: `[Private Beta] Get conversation messages for multiple traces in a single request.
 This feature is currently in private beta and may not be available to all users.
 
-Queries root runs matching the given filters, then returns normalized
-conversation messages extracted from each trace's LLM and tool runs.
+Queries root runs matching the given filters (or reads IDs from --from-list),
+then returns normalized conversation messages extracted from each trace's
+LLM and tool runs.
 
 Each trace in the response contains a list of conversation groups:
   - "message" groups contain a single normalized message (human, ai, system, tool)
   - "tool_interaction" groups contain an AI message with tool calls and their results
 
-Requires --project. Results are paginated internally (default limit: 10, max: 100).
+Modes:
+  1. stdout (default): paginate up to --limit (max 100), emit a single JSON blob.
+  2. --out-dir <dir>: write one plain-text conversation file per trace to the
+     directory. Use with --from-list to consume a file of IDs produced by
+     `+"`langsmith trace list --out-dir`"+`. When --from-list is omitted, the
+     command scans the lookback window exhaustively (no --limit cap).
 
 Examples:
   langsmith trace messages --project my-chatbot --limit 5
-  langsmith trace messages --project my-chatbot --filter "eq(status, \"error\")"
-  langsmith trace messages --project my-chatbot --since 2024-01-15T00:00:00Z`,
+  langsmith trace messages --project my-chatbot --out-dir /tmp/convos --last-n-minutes 360
+  langsmith trace list --project my-chatbot --last-n-minutes 360 --out-dir /tmp/ids --include-flagged
+  langsmith trace messages --project my-chatbot --from-list /tmp/ids/trace_ids.txt --flagged-list /tmp/ids/flagged.tsv --out-dir /tmp/convos --include-root-io`,
 		Run: func(cmd *cobra.Command, args []string) {
-			defaultLimit := 10
-			if ff.Limit == 0 {
-				ff.Limit = defaultLimit
-			}
-			if ff.Limit > 100 {
-				ExitError("--limit cannot exceed 100 for trace messages")
-			}
-
 			c := MustGetClient()
 			ctx := context.Background()
 			projectName := ResolveProject(ff.Project)
@@ -55,92 +67,517 @@ Examples:
 				ExitErrorf("%v", err)
 			}
 
-			// Build base request body for POST /v2/traces/messages
-			body := map[string]any{
-				"session": []string{sessionID},
-			}
-
 			startTime := resolveStartTime(ff.Since, ff.LastNMinutes)
-			body["min_start_time"] = startTime.Format("2006-01-02T15:04:05Z07:00")
 
-			if ff.TraceIDs != "" {
-				ids := splitTrim(ff.TraceIDs)
-				if len(ids) == 1 {
-					body["trace"] = ids[0]
+			if outDir != "" {
+				if fromList != "" {
+					runMessagesFromList(ctx, c, sessionID, startTime, &ff, outDir, fromList, flaggedList, includeRootIO)
 				} else {
-					body["id"] = ids
+					runMessagesScanWindow(ctx, c, sessionID, startTime, &ff, outDir, includeRootIO)
 				}
+				return
 			}
 
-			if ff.RunType != "" {
-				body["run_type"] = ff.RunType
+			if fromList != "" {
+				ExitError("--from-list requires --out-dir")
+			}
+			if flaggedList != "" {
+				ExitError("--flagged-list requires --out-dir")
 			}
 
-			if ff.ErrorFlag {
-				body["error"] = true
-			} else if ff.NoErrorFlag {
-				body["error"] = false
-			}
-
-			filterStr := buildFilterDSL(&ff)
-			if filterStr != "" {
-				body["filter"] = filterStr
-			}
-
-			// Paginate: fetch up to ff.Limit traces using pages of <= maxPageSize
-			const maxPageSize = 10
-			remaining := ff.Limit
-			var allTraces []any
-
-			for {
-				pageSize := maxPageSize
-				if remaining < pageSize {
-					pageSize = remaining
-				}
-				body["limit"] = pageSize
-
-				var result map[string]any
-				if err := c.RawPost(ctx, "/v2/traces/messages", body, &result); err != nil {
-					ExitErrorf("%v", err)
-				}
-
-				traces, _ := result["traces"].([]any)
-				allTraces = append(allTraces, traces...)
-				remaining -= len(traces)
-
-				// Stop if we have enough or no more pages
-				cursors, _ := result["cursors"].(map[string]any)
-				next, _ := cursors["next"].(string)
-				if next == "" || remaining <= 0 {
-					break
-				}
-				body["cursor"] = next
-			}
-
-			// Trim to exact limit if we overshot
-			if len(allTraces) > ff.Limit {
-				allTraces = allTraces[:ff.Limit]
-			}
-
-			combined := map[string]any{
-				"traces":  allTraces,
-				"cursors": map[string]any{},
-			}
-
-			fmt_ := GetFormat()
-
-			if fmt_ == "pretty" {
-				printTraceMessages(combined)
-			} else {
-				output.OutputJSON(combined, outputFile)
-			}
+			runMessagesStdout(ctx, c, sessionID, startTime, &ff, outputFile)
 		},
 	}
 
 	addCommonFilterFlags(cmd, &ff, true)
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
+	cmd.Flags().StringVar(&outDir, "out-dir", "", "Write one plain-text conversation file per trace into this directory. Required for --from-list / --flagged-list / --include-root-io.")
+	cmd.Flags().StringVar(&fromList, "from-list", "", "Path to a plain-text file of trace IDs (one per line, as produced by `langsmith trace list --out-dir`). When set, the command fetches conversations for exactly these IDs and skips the lookback scan.")
+	cmd.Flags().StringVar(&flaggedList, "flagged-list", "", "Path to a TSV file of flagged trace IDs (`<trace_id>\\t<comment>` per line, as produced by `langsmith trace list --out-dir --include-flagged`). Traces listed here get a [USER_FLAGGED] header in their conversation file.")
+	cmd.Flags().BoolVar(&includeRootIO, "include-root-io", false, "Enrich each conversation file with [ROOT INPUT] and [ROOT OUTPUT] blocks from the root run's inputs_preview/outputs_preview. Requires --out-dir.")
 
 	return cmd
+}
+
+// runMessagesStdout is the original stdout-mode path: paginate up to --limit
+// (capped at 100) and emit the combined JSON / pretty output.
+func runMessagesStdout(
+	ctx context.Context,
+	c *client.Client,
+	sessionID string,
+	startTime time.Time,
+	ff *FilterFlags,
+	outputFile string,
+) {
+	defaultLimit := 10
+	if ff.Limit == 0 {
+		ff.Limit = defaultLimit
+	}
+	if ff.Limit > 100 {
+		ExitError("--limit cannot exceed 100 for trace messages (unless using --out-dir)")
+	}
+
+	body := buildMessagesBody(sessionID, startTime, ff)
+
+	const maxPageSize = 10
+	remaining := ff.Limit
+	var allTraces []any
+
+	for {
+		pageSize := maxPageSize
+		if remaining < pageSize {
+			pageSize = remaining
+		}
+		body["limit"] = pageSize
+
+		var result map[string]any
+		if err := c.RawPost(ctx, "/v2/traces/messages", body, &result); err != nil {
+			ExitErrorf("%v", err)
+		}
+
+		traces, _ := result["traces"].([]any)
+		allTraces = append(allTraces, traces...)
+		remaining -= len(traces)
+
+		cursors, _ := result["cursors"].(map[string]any)
+		next, _ := cursors["next"].(string)
+		if next == "" || remaining <= 0 {
+			break
+		}
+		body["cursor"] = next
+	}
+
+	if len(allTraces) > ff.Limit {
+		allTraces = allTraces[:ff.Limit]
+	}
+
+	combined := map[string]any{
+		"traces":  allTraces,
+		"cursors": map[string]any{},
+	}
+
+	if GetFormat() == "pretty" {
+		printTraceMessages(combined)
+	} else {
+		output.OutputJSON(combined, outputFile)
+	}
+}
+
+// runMessagesScanWindow paginates the full lookback window (no ID filter) and
+// writes one conversation file per trace. Used when the caller wants
+// `trace messages --out-dir` as a standalone one-shot. Prefer
+// `trace list --out-dir` → `trace messages --from-list` for the agent flow.
+func runMessagesScanWindow(
+	ctx context.Context,
+	c *client.Client,
+	sessionID string,
+	startTime time.Time,
+	ff *FilterFlags,
+	outDir string,
+	includeRootIO bool,
+) {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		ExitErrorf("creating --out-dir: %v", err)
+	}
+
+	body := buildMessagesBody(sessionID, startTime, ff)
+	allTraces := paginateAllMessages(ctx, c, body, 10)
+
+	rootIO := map[string]rootPreview{}
+	if includeRootIO {
+		rootIO = fetchRootPreviews(ctx, c, sessionID, startTime)
+	}
+
+	written := writeTraceFiles(allTraces, outDir, nil, rootIO)
+	output.OutputJSON(map[string]any{
+		"status":          "written",
+		"traces_written":  written,
+		"out_dir":         outDir,
+		"include_root_io": includeRootIO,
+	}, "")
+}
+
+// runMessagesFromList reads trace IDs from a file, fetches conversations in
+// batches, and writes one file per trace. This is the primary path in the
+// agent flow — trace list writes the ID file, trace messages consumes it.
+func runMessagesFromList(
+	ctx context.Context,
+	c *client.Client,
+	sessionID string,
+	startTime time.Time,
+	ff *FilterFlags,
+	outDir string,
+	fromList string,
+	flaggedList string,
+	includeRootIO bool,
+) {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		ExitErrorf("creating --out-dir: %v", err)
+	}
+
+	ids, err := readIDsFile(fromList)
+	if err != nil {
+		ExitErrorf("reading --from-list: %v", err)
+	}
+	if len(ids) == 0 {
+		output.OutputJSON(map[string]any{
+			"status":         "empty",
+			"traces_written": 0,
+			"out_dir":        outDir,
+			"note":           "--from-list file had no trace IDs",
+		}, "")
+		return
+	}
+
+	flagged := map[string]string{}
+	if flaggedList != "" {
+		flagged, err = readFlaggedFile(flaggedList)
+		if err != nil {
+			ExitErrorf("reading --flagged-list: %v", err)
+		}
+	}
+
+	rootIO := map[string]rootPreview{}
+	if includeRootIO {
+		rootIO = fetchRootPreviews(ctx, c, sessionID, startTime)
+	}
+
+	// Batch IDs so the request body stays small and the server's per-call
+	// filter stays well under any list-length cap. Within each batch we
+	// paginate the response cursor until exhausted.
+	const batchSize = 50
+	totalWritten := 0
+	for start := 0; start < len(ids); start += batchSize {
+		end := start + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+
+		body := buildMessagesBody(sessionID, startTime, ff)
+		body["id"] = batch
+		delete(body, "trace")
+		traces := paginateAllMessages(ctx, c, body, 10)
+
+		totalWritten += writeTraceFiles(traces, outDir, flagged, rootIO)
+	}
+
+	output.OutputJSON(map[string]any{
+		"status":          "written",
+		"traces_written":  totalWritten,
+		"ids_requested":   len(ids),
+		"flagged_count":   len(flagged),
+		"out_dir":         outDir,
+		"include_root_io": includeRootIO,
+	}, "")
+}
+
+// writeTraceFiles formats each trace as plain text and writes one file per
+// trace into outDir. Returns the number of files written. Flagged IDs get a
+// [USER_FLAGGED] header; rootIO entries add [ROOT INPUT]/[ROOT OUTPUT] blocks.
+func writeTraceFiles(traces []any, outDir string, flagged map[string]string, rootIO map[string]rootPreview) int {
+	written := 0
+	for _, t := range traces {
+		trace, _ := t.(map[string]any)
+		traceID, _ := trace["trace_id"].(string)
+		if traceID == "" {
+			continue
+		}
+
+		var b strings.Builder
+		if note, ok := flagged[traceID]; ok {
+			if note == "" {
+				note = "User flagged for review"
+			}
+			fmt.Fprintf(&b, "[USER_FLAGGED]: %s\n\n", note)
+		}
+		if preview, ok := rootIO[traceID]; ok && preview.inputs != "" {
+			fmt.Fprintf(&b, "[ROOT INPUT]: %s\n", preview.inputs)
+		}
+		writeConversationLines(&b, trace)
+		if preview, ok := rootIO[traceID]; ok && preview.outputs != "" {
+			fmt.Fprintf(&b, "\n[ROOT OUTPUT / FINAL AGENT RESPONSE]: %s", preview.outputs)
+		}
+
+		fpath := filepath.Join(outDir, traceID+".txt")
+		if err := os.WriteFile(fpath, []byte(b.String()), 0o644); err != nil {
+			ExitErrorf("writing %s: %v", fpath, err)
+		}
+		written++
+	}
+	return written
+}
+
+// readIDsFile reads a plain-text file of trace IDs (one per line). Blank lines
+// and leading/trailing whitespace are ignored.
+func readIDsFile(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var ids []string
+	seen := map[string]bool{}
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || seen[line] {
+			continue
+		}
+		seen[line] = true
+		ids = append(ids, line)
+	}
+	return ids, scanner.Err()
+}
+
+// readFlaggedFile reads a TSV file of `<trace_id>\t<comment>` per line and
+// returns a map of trace_id → comment.
+func readFlaggedFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	out := map[string]string{}
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		tid, comment, _ := strings.Cut(line, "\t")
+		tid = strings.TrimSpace(tid)
+		if tid == "" {
+			continue
+		}
+		out[tid] = comment
+	}
+	return out, scanner.Err()
+}
+
+// buildMessagesBody builds the base request body shared by all calls to
+// /v2/traces/messages in this command.
+func buildMessagesBody(sessionID string, startTime time.Time, ff *FilterFlags) map[string]any {
+	body := map[string]any{
+		"session":        []string{sessionID},
+		"min_start_time": startTime.Format("2006-01-02T15:04:05Z07:00"),
+	}
+
+	if ff.TraceIDs != "" {
+		ids := splitTrim(ff.TraceIDs)
+		if len(ids) == 1 {
+			body["trace"] = ids[0]
+		} else {
+			body["id"] = ids
+		}
+	}
+
+	if ff.RunType != "" {
+		body["run_type"] = ff.RunType
+	}
+
+	if ff.ErrorFlag {
+		body["error"] = true
+	} else if ff.NoErrorFlag {
+		body["error"] = false
+	}
+
+	if filterStr := buildFilterDSL(ff); filterStr != "" {
+		body["filter"] = filterStr
+	}
+
+	return body
+}
+
+// paginateAllMessages exhaustively paginates /v2/traces/messages using the
+// given body. `pageSize` is the per-page `limit` (max 10 server-side). Does
+// not mutate `body` for the caller beyond adding the `cursor` key while paging.
+func paginateAllMessages(ctx context.Context, c *client.Client, body map[string]any, pageSize int) []any {
+	body["limit"] = pageSize
+	delete(body, "cursor")
+
+	var all []any
+	for {
+		var result map[string]any
+		if err := c.RawPost(ctx, "/v2/traces/messages", body, &result); err != nil {
+			ExitErrorf("%v", err)
+		}
+		traces, _ := result["traces"].([]any)
+		all = append(all, traces...)
+
+		cursors, _ := result["cursors"].(map[string]any)
+		next, _ := cursors["next"].(string)
+		if next == "" {
+			break
+		}
+		body["cursor"] = next
+	}
+	return all
+}
+
+type rootPreview struct {
+	inputs  string
+	outputs string
+}
+
+// fetchRootPreviews queries root runs for the session within the time window
+// and returns a map of trace_id → (inputs_preview, outputs_preview). Each
+// preview is truncated to 2000 characters to match the legacy fetch script.
+func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, startTime time.Time) map[string]rootPreview {
+	out := map[string]rootPreview{}
+
+	params := langsmith.RunQueryParams{
+		Session:   langsmith.F([]string{sessionID}),
+		IsRoot:    langsmith.F(true),
+		StartTime: langsmith.F(startTime),
+		Order:     langsmith.F(langsmith.RunQueryParamsOrderDesc),
+		Limit:     langsmith.F(int64(100)),
+		Select: langsmith.F([]langsmith.RunQueryParamsSelect{
+			langsmith.RunQueryParamsSelectTraceID,
+			langsmith.RunQueryParamsSelectInputsPreview,
+			langsmith.RunQueryParamsSelectOutputsPreview,
+		}),
+	}
+
+	for {
+		resp, err := c.SDK.Runs.Query(ctx, params)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: fetching root previews failed: %v\n", err)
+			return out
+		}
+		for _, run := range resp.Runs {
+			tid := run.TraceID
+			if tid == "" {
+				tid = run.ID
+			}
+			if tid == "" {
+				continue
+			}
+			out[tid] = rootPreview{
+				inputs:  truncateHard(run.InputsPreview, 2000),
+				outputs: truncateHard(run.OutputsPreview, 2000),
+			}
+		}
+		if resp.Cursors == nil || resp.Cursors["next"] == "" {
+			break
+		}
+		params.Cursor = langsmith.F(resp.Cursors["next"])
+	}
+
+	return out
+}
+
+// writeConversationLines emits one line per message / tool call / tool result
+// in the trace. Handles both the flat group shape (group.message,
+// group.tool_call, group.tool_result) and the nested shape
+// (group.type == "tool_interaction" with aiMessage + toolCalls[]) so the
+// output stays stable if the server response evolves.
+func writeConversationLines(b *strings.Builder, trace map[string]any) {
+	groups, _ := trace["groups"].([]any)
+	for _, g := range groups {
+		group, _ := g.(map[string]any)
+		if group == nil {
+			continue
+		}
+
+		if msg, ok := group["message"].(map[string]any); ok {
+			writeMessageLine(b, msg)
+		}
+
+		if tc, ok := group["tool_call"].(map[string]any); ok {
+			writeToolCallLine(b, tc)
+		}
+
+		if tr, ok := group["tool_result"].(map[string]any); ok {
+			writeToolResultLine(b, tr)
+		}
+
+		if gt, _ := group["type"].(string); gt == "tool_interaction" {
+			if ai, ok := group["aiMessage"].(map[string]any); ok {
+				writeMessageLine(b, ai)
+			}
+			toolCalls, _ := group["toolCalls"].([]any)
+			for _, tc := range toolCalls {
+				call, _ := tc.(map[string]any)
+				if call == nil {
+					continue
+				}
+				writeToolCallLine(b, call)
+				if resultMsg, ok := call["result"].(map[string]any); ok {
+					writeToolResultLine(b, resultMsg)
+				}
+			}
+		}
+	}
+}
+
+func writeMessageLine(b *strings.Builder, msg map[string]any) {
+	role, _ := msg["role"].(string)
+	if role == "" {
+		role = "unknown"
+	}
+	fmt.Fprintf(b, "[%s]: %s\n", strings.ToUpper(role), messageContentAsString(msg["content"]))
+}
+
+func writeToolCallLine(b *strings.Builder, tc map[string]any) {
+	name, _ := tc["name"].(string)
+	if name == "" {
+		name = "?"
+	}
+	args := tc["args"]
+	if args == nil {
+		args = tc["arguments"]
+	}
+	argsJSON, _ := json.Marshal(args)
+	fmt.Fprintf(b, "[TOOL_CALL] %s: %s\n", name, truncateHard(string(argsJSON), 500))
+}
+
+func writeToolResultLine(b *strings.Builder, tr map[string]any) {
+	content := tr["content"]
+	if content == nil {
+		content = tr["result"]
+	}
+	fmt.Fprintf(b, "[TOOL_RESULT]: %s\n", truncateHard(messageContentAsString(content), 1000))
+}
+
+// messageContentAsString renders a message content value (string or list of
+// content blocks) as a single-line string.
+func messageContentAsString(content any) string {
+	switch v := content.(type) {
+	case string:
+		return v
+	case []any:
+		var parts []string
+		for _, block := range v {
+			bm, ok := block.(map[string]any)
+			if !ok {
+				continue
+			}
+			if text, ok := bm["text"].(string); ok && text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, " ")
+	case nil:
+		return ""
+	default:
+		out, _ := json.Marshal(v)
+		return string(out)
+	}
+}
+
+// truncateHard chops the string to at most n bytes with no ellipsis. Matches
+// the legacy fetch_traces.py truncation exactly so file contents stay
+// byte-for-byte comparable when cutting over.
+func truncateHard(s string, n int) string {
+	if n <= 0 || len(s) <= n {
+		return s
+	}
+	return s[:n]
 }
 
 // printTraceMessages prints a human-readable summary of batch trace messages.

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -44,14 +44,13 @@ Each trace in the response contains a list of conversation groups:
 
 Modes:
   1. stdout (default): paginate up to --limit (max 100), emit a single JSON blob.
-  2. --out-dir <dir>: write one plain-text conversation file per trace to the
-     directory. Use with --from-list to consume a file of IDs produced by
-     `+"`langsmith trace list --out-dir`"+`. When --from-list is omitted, the
-     command scans the lookback window exhaustively (no --limit cap).
+  2. --from-list + --out-dir: read trace IDs from a file produced by
+     `+"`langsmith trace list --out-dir`"+`, fetch conversations for those
+     IDs in batches, and write one plain-text file per trace to the
+     directory.
 
 Examples:
   langsmith trace messages --project my-chatbot --limit 5
-  langsmith trace messages --project my-chatbot --out-dir /tmp/convos --last-n-minutes 360
   langsmith trace list --project my-chatbot --last-n-minutes 360 --out-dir /tmp/ids --include-flagged
   langsmith trace messages --project my-chatbot --from-list /tmp/ids/trace_ids.txt --flagged-list /tmp/ids/flagged.tsv --out-dir /tmp/convos --include-root-io`,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -70,11 +69,10 @@ Examples:
 			startTime := resolveStartTime(ff.Since, ff.LastNMinutes)
 
 			if outDir != "" {
-				if fromList != "" {
-					runMessagesFromList(ctx, c, sessionID, startTime, &ff, outDir, fromList, flaggedList, includeRootIO)
-				} else {
-					runMessagesScanWindow(ctx, c, sessionID, startTime, &ff, outDir, includeRootIO)
+				if fromList == "" {
+					ExitError("--out-dir requires --from-list (pass a trace ID file produced by `langsmith trace list --out-dir`)")
 				}
+				runMessagesFromList(ctx, c, sessionID, startTime, &ff, outDir, fromList, flaggedList, includeRootIO)
 				return
 			}
 
@@ -161,40 +159,6 @@ func runMessagesStdout(
 	} else {
 		output.OutputJSON(combined, outputFile)
 	}
-}
-
-// runMessagesScanWindow paginates the full lookback window (no ID filter) and
-// writes one conversation file per trace. Used when the caller wants
-// `trace messages --out-dir` as a standalone one-shot. Prefer
-// `trace list --out-dir` → `trace messages --from-list` for the agent flow.
-func runMessagesScanWindow(
-	ctx context.Context,
-	c *client.Client,
-	sessionID string,
-	startTime time.Time,
-	ff *FilterFlags,
-	outDir string,
-	includeRootIO bool,
-) {
-	if err := os.MkdirAll(outDir, 0o755); err != nil {
-		ExitErrorf("creating --out-dir: %v", err)
-	}
-
-	body := buildMessagesBody(sessionID, startTime, ff)
-	allTraces := paginateAllMessages(ctx, c, body, 10)
-
-	rootIO := map[string]rootPreview{}
-	if includeRootIO {
-		rootIO = fetchRootPreviews(ctx, c, sessionID, startTime)
-	}
-
-	written := writeTraceFiles(allTraces, outDir, nil, rootIO)
-	output.OutputJSON(map[string]any{
-		"status":          "written",
-		"traces_written":  written,
-		"out_dir":         outDir,
-		"include_root_io": includeRootIO,
-	}, "")
 }
 
 // runMessagesFromList reads trace IDs from a file, fetches conversations in

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -3,11 +3,13 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	langsmith "github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -46,6 +48,8 @@ func newTraceListCmd() *cobra.Command {
 		full            bool
 		showHierarchy   bool
 		outputFile      string
+		outDir          string
+		includeFlagged  bool
 	)
 
 	cmd := &cobra.Command{
@@ -58,16 +62,21 @@ func newTraceListCmd() *cobra.Command {
 				includeFeedback = true
 			}
 
-			defaultLimit := 20
-			if ff.Limit == 0 {
-				ff.Limit = defaultLimit
-			}
-
 			c := MustGetClient()
 			ctx := context.Background()
 			projectName := ResolveProject(ff.Project)
 			if projectName == "" {
 				ExitError("--project is required for trace list (or set LANGSMITH_PROJECT)")
+			}
+
+			if outDir != "" {
+				runTraceListOutDir(ctx, c, projectName, &ff, outDir, includeFlagged)
+				return
+			}
+
+			defaultLimit := 20
+			if ff.Limit == 0 {
+				ff.Limit = defaultLimit
 			}
 
 			params := BuildRunQueryParams(&ff, true, ff.Limit)
@@ -134,8 +143,105 @@ func newTraceListCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io --include-feedback")
 	cmd.Flags().BoolVar(&showHierarchy, "show-hierarchy", false, "Fetch the full run tree for each trace")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
+	cmd.Flags().StringVar(&outDir, "out-dir", "", "Write trace IDs to plain-text files in this directory. Paginates exhaustively over the time window (--limit is ignored). Writes trace_ids.txt (one ID per line).")
+	cmd.Flags().BoolVar(&includeFlagged, "include-flagged", false, "Also fetch user-flagged traces from /api/v1/feedback, union them into trace_ids.txt, and write flagged.tsv (<trace_id>\\t<comment> per line). Requires --out-dir.")
 
 	return cmd
+}
+
+// runTraceListOutDir exhaustively paginates root runs in the window, unions
+// in any user-flagged traces if requested, and writes plain-text ID lists
+// suitable for feeding into `trace messages --from-list`.
+func runTraceListOutDir(
+	ctx context.Context,
+	c *client.Client,
+	projectName string,
+	ff *FilterFlags,
+	outDir string,
+	includeFlagged bool,
+) {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		ExitErrorf("creating --out-dir: %v", err)
+	}
+
+	// 1. Exhaustive scan of root runs matching the filters.
+	params := BuildRunQueryParams(ff, true, 0)
+	// Only select trace_id — we don't need anything else for the ID list.
+	params.Select = langsmith.F([]langsmith.RunQueryParamsSelect{
+		langsmith.RunQueryParamsSelectID,
+		langsmith.RunQueryParamsSelectTraceID,
+	})
+
+	// queryRuns uses the `limit` arg as an upper bound on total results;
+	// pass math.MaxInt32 to paginate through everything that matches.
+	const unbounded = 1 << 30
+	runs, err := queryRuns(ctx, c, params, projectName, unbounded, ff.MinTokens)
+	if err != nil {
+		ExitErrorf("%v", err)
+	}
+
+	ids := make([]string, 0, len(runs))
+	seen := make(map[string]bool, len(runs))
+	for _, run := range runs {
+		tid := run.TraceID
+		if tid == "" {
+			tid = run.ID
+		}
+		if tid == "" || seen[tid] {
+			continue
+		}
+		seen[tid] = true
+		ids = append(ids, tid)
+	}
+
+	// 2. Pull flagged traces and union any missing IDs.
+	var flagged []FlaggedTrace
+	if includeFlagged {
+		sessionID, err := c.ResolveSessionID(ctx, projectName)
+		if err != nil {
+			ExitErrorf("resolving project: %v", err)
+		}
+		flagged = FetchFlaggedTraces(ctx, c, sessionID, ff.LastNMinutes)
+		for _, ft := range flagged {
+			if !seen[ft.TraceID] {
+				seen[ft.TraceID] = true
+				ids = append(ids, ft.TraceID)
+			}
+		}
+	}
+
+	// 3. Write trace_ids.txt (one ID per line).
+	idsPath := filepath.Join(outDir, "trace_ids.txt")
+	if err := os.WriteFile(idsPath, []byte(strings.Join(ids, "\n")+"\n"), 0o644); err != nil {
+		ExitErrorf("writing %s: %v", idsPath, err)
+	}
+
+	// 4. Write flagged.tsv if we fetched flagged traces.
+	flaggedPath := ""
+	if includeFlagged {
+		flaggedPath = filepath.Join(outDir, "flagged.tsv")
+		var b strings.Builder
+		for _, ft := range flagged {
+			// Replace tabs/newlines in comments so the TSV stays parseable.
+			comment := strings.NewReplacer("\t", " ", "\n", " ", "\r", " ").Replace(ft.Comment)
+			fmt.Fprintf(&b, "%s\t%s\n", ft.TraceID, comment)
+		}
+		if err := os.WriteFile(flaggedPath, []byte(b.String()), 0o644); err != nil {
+			ExitErrorf("writing %s: %v", flaggedPath, err)
+		}
+	}
+
+	summary := map[string]any{
+		"status":         "written",
+		"traces_written": len(ids),
+		"flagged_count":  len(flagged),
+		"out_dir":        outDir,
+		"trace_ids_path": idsPath,
+	}
+	if flaggedPath != "" {
+		summary["flagged_path"] = flaggedPath
+	}
+	output.OutputJSON(summary, "")
 }
 
 func newTraceGetCmd() *cobra.Command {


### PR DESCRIPTION
## Summary

Adds a two-command flow for callers that need every trace in a window written to disk without looping by hand. Motivated by the `issues-board-ao` agent, which was previously running a Python fetch script inside the sandbox to paginate, merge user-flagged traces, enrich with root I/O, and write per-trace files — all things that belong in the CLI.

**New flow:**
```bash
langsmith trace list --project X --last-n-minutes N --out-dir /tmp/ids --include-flagged
# → trace_ids.txt (one ID per line) + flagged.tsv (trace_id\tcomment)

langsmith trace messages --project X --last-n-minutes N \
  --from-list /tmp/ids/trace_ids.txt \
  --flagged-list /tmp/ids/flagged.tsv \
  --out-dir /tmp/convos --include-root-io
# → one plain-text conversation file per trace, with [USER_FLAGGED] and [ROOT INPUT]/[ROOT OUTPUT] markers
```

### What changed

- **`trace list`** gains `--out-dir` and `--include-flagged`. With `--out-dir`, pagination goes exhaustive (`--limit` ignored); flagged-trace discovery hits `/api/v1/feedback?key=langsmith_user_flagged_issue` and unions the IDs into `trace_ids.txt`, also writing `flagged.tsv` with comments.
- **`trace messages`** gains `--from-list`, `--flagged-list`, and `--include-root-io`. `--from-list` reads IDs from a file produced by `trace list --out-dir`, batches them 50-at-a-time, and paginates each batch internally. `--flagged-list` annotates the output files with `[USER_FLAGGED]` headers. `--include-root-io` appends root `inputs_preview`/`outputs_preview` to each conversation file. The previous scan-window mode (`--out-dir` without `--from-list`) and stdout mode are preserved.
- **`flagged.go`** (new) — shared helper for hitting the feedback endpoint, used by `trace list`.

### Previous commits on this branch

Two pre-existing commits on this branch build up the infrastructure this PR depends on: exhaustive pagination in stdout mode, and a 100-trace cap on `--limit`. Including them in this PR for a single reviewable unit.

### Design notes

- Flagged-trace discovery lives on `trace list` (a list concern), not `trace messages` (a conversation concern). A previous iteration had it on `trace messages` but that conflated "find traces" with "render conversations."
- `--from-list` consumes a plain-text file of IDs so callers can decide what gets fetched rather than re-querying the same window twice.
- Per-trace output files use the same plain-text format as the legacy `fetch_traces.py` script (`[ROLE]:`/`[TOOL_CALL]`/`[TOOL_RESULT]` lines, truncations preserved) so existing consumers keep working.

## Test plan

- [x] Unit tests pass (`go test ./internal/cmd/`)
- [x] Built linux/amd64 binary, sideloaded into a sandbox, end-to-end run against `chat-langchain-test-clean` (508 traces, 30d lookback) — `trace list --out-dir --include-flagged` produced `traces_written: 508, flagged_count: 3`; `trace messages --from-list --flagged-list --out-dir --include-root-io` produced `ids_requested: 508, traces_written: 499`
- [ ] Verify in a cloud-deployed agent run after release