### PR TITLE
feat(trace): enrichment flags for agent callers

### DIFF
--- a/internal/cmd/flagged.go
+++ b/internal/cmd/flagged.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/langchain-ai/langsmith-cli/internal/client"
+)
+
+// UserFlaggedIssueKey is the feedback key used to mark a trace as flagged for
+// issues-agent review.
+const UserFlaggedIssueKey = "langsmith_user_flagged_issue"
+
+// FlaggedTrace is a single user-flagged trace with its optional review
+// comment.
+type FlaggedTrace struct {
+	TraceID string
+	Comment string
+}
+
+// FetchFlaggedTraces paginates /api/v1/feedback for the user-flagged issue
+// feedback key on the given session and returns the set of flagged traces.
+// Failures are logged to stderr and surfaced as partial results — callers
+// get whatever was successfully fetched before the error.
+//
+// If lastNMinutes > 0, only flagged traces created within the window are
+// returned. Otherwise all flagged traces for the session are returned.
+func FetchFlaggedTraces(ctx context.Context, c *client.Client, sessionID string, lastNMinutes int) []FlaggedTrace {
+	var out []FlaggedTrace
+	seen := map[string]bool{}
+	offset := 0
+	const limit = 100
+
+	minCreatedQS := ""
+	if lastNMinutes > 0 {
+		minCreated := time.Now().UTC().Add(-time.Duration(lastNMinutes) * time.Minute)
+		minCreatedQS = "&min_created_at=" + url.QueryEscape(minCreated.Format(time.RFC3339))
+	}
+
+	for {
+		path := fmt.Sprintf(
+			"/api/v1/feedback?key=%s&session=%s%s&limit=%d&offset=%d",
+			url.QueryEscape(UserFlaggedIssueKey),
+			url.QueryEscape(sessionID),
+			minCreatedQS,
+			limit,
+			offset,
+		)
+		var page []map[string]any
+		if err := c.RawGet(ctx, path, &page); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: fetching flagged traces failed: %v\n", err)
+			return out
+		}
+		if len(page) == 0 {
+			break
+		}
+		for _, fb := range page {
+			tid, _ := fb["trace_id"].(string)
+			if tid == "" {
+				tid, _ = fb["run_id"].(string)
+			}
+			if tid == "" || seen[tid] {
+				continue
+			}
+			seen[tid] = true
+			comment, _ := fb["comment"].(string)
+			out = append(out, FlaggedTrace{TraceID: tid, Comment: comment})
+		}
+		if len(page) < limit {
+			break
+		}
+		offset += limit
+	}
+	return out
+}

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -3,19 +3,25 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+	"time"
 
+	langsmith "github.com/langchain-ai/langsmith-go"
+
+	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
 func newTraceMessagesCmd() *cobra.Command {
 	var (
-		ff         FilterFlags
-		outputFile string
+		ff            FilterFlags
+		outputFile    string
+		includeRootIO bool
 	)
 
 	cmd := &cobra.Command{
-		Use:   "messages",
+		Use:    "messages",
 		Short:  "[Private Beta] Get conversation messages for multiple traces (batch)",
 		Hidden: true,
 		Long: `[Private Beta] Get conversation messages for multiple traces in a single request.
@@ -33,7 +39,8 @@ Requires --project. Results are paginated internally (default limit: 10, max: 10
 Examples:
   langsmith trace messages --project my-chatbot --limit 5
   langsmith trace messages --project my-chatbot --filter "eq(status, \"error\")"
-  langsmith trace messages --project my-chatbot --since 2024-01-15T00:00:00Z`,
+  langsmith trace messages --project my-chatbot --since 2024-01-15T00:00:00Z
+  langsmith trace messages --project my-chatbot --trace-ids <id1,id2> --include-root-io`,
 		Run: func(cmd *cobra.Command, args []string) {
 			defaultLimit := 10
 			if ff.Limit == 0 {
@@ -122,6 +129,10 @@ Examples:
 				allTraces = allTraces[:ff.Limit]
 			}
 
+			if includeRootIO {
+				attachRootIO(ctx, c, sessionID, startTime, allTraces)
+			}
+
 			combined := map[string]any{
 				"traces":  allTraces,
 				"cursors": map[string]any{},
@@ -139,8 +150,97 @@ Examples:
 
 	addCommonFilterFlags(cmd, &ff, true)
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
+	cmd.Flags().BoolVar(&includeRootIO, "include-root-io", false, "Add root_inputs_preview and root_outputs_preview fields per trace")
 
 	return cmd
+}
+
+type rootPreview struct {
+	inputs  string
+	outputs string
+}
+
+// attachRootIO looks up inputs_preview/outputs_preview for the root runs of
+// every trace in `traces` and attaches them as root_inputs_preview /
+// root_outputs_preview fields. Failures are logged to stderr — the traces
+// are returned without enrichment rather than erroring out, so callers never
+// lose the main payload to a preview-lookup hiccup.
+func attachRootIO(ctx context.Context, c *client.Client, sessionID string, startTime time.Time, traces []any) {
+	if len(traces) == 0 {
+		return
+	}
+	ids := make([]string, 0, len(traces))
+	for _, t := range traces {
+		trace, _ := t.(map[string]any)
+		if tid, _ := trace["trace_id"].(string); tid != "" {
+			ids = append(ids, tid)
+		}
+	}
+	previews := fetchRootPreviews(ctx, c, sessionID, startTime, ids)
+	for _, t := range traces {
+		trace, _ := t.(map[string]any)
+		if trace == nil {
+			continue
+		}
+		tid, _ := trace["trace_id"].(string)
+		if p, ok := previews[tid]; ok {
+			trace["root_inputs_preview"] = p.inputs
+			trace["root_outputs_preview"] = p.outputs
+		} else {
+			trace["root_inputs_preview"] = nil
+			trace["root_outputs_preview"] = nil
+		}
+	}
+}
+
+// fetchRootPreviews queries root runs for the given trace IDs and returns a
+// map trace_id → (inputs_preview, outputs_preview). For root runs, id ==
+// trace_id, so we filter by ID (the SDK's RunQueryParams has no list field
+// for trace IDs — Trace is singular).
+func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, startTime time.Time, ids []string) map[string]rootPreview {
+	out := map[string]rootPreview{}
+	if len(ids) == 0 {
+		return out
+	}
+	params := langsmith.RunQueryParams{
+		Session:   langsmith.F([]string{sessionID}),
+		IsRoot:    langsmith.F(true),
+		ID:        langsmith.F(ids),
+		StartTime: langsmith.F(startTime),
+		Order:     langsmith.F(langsmith.RunQueryParamsOrderDesc),
+		Limit:     langsmith.F(int64(len(ids))),
+		Select: langsmith.F([]langsmith.RunQueryParamsSelect{
+			langsmith.RunQueryParamsSelectTraceID,
+			langsmith.RunQueryParamsSelectInputsPreview,
+			langsmith.RunQueryParamsSelectOutputsPreview,
+		}),
+	}
+	resp, err := c.SDK.Runs.Query(ctx, params)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: fetching root previews failed: %v\n", err)
+		return out
+	}
+	for _, run := range resp.Runs {
+		tid := run.TraceID
+		if tid == "" {
+			tid = run.ID
+		}
+		if tid == "" {
+			continue
+		}
+		out[tid] = rootPreview{
+			inputs:  truncateHard(run.InputsPreview, 2000),
+			outputs: truncateHard(run.OutputsPreview, 2000),
+		}
+	}
+	return out
+}
+
+func truncateHard(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
 }
 
 // printTraceMessages prints a human-readable summary of batch trace messages.

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -43,6 +43,7 @@ func newTraceListCmd() *cobra.Command {
 		includeMetadata bool
 		includeIO       bool
 		includeFeedback bool
+		includeFlagged  bool
 		full            bool
 		showHierarchy   bool
 		outputFile      string
@@ -77,6 +78,19 @@ func newTraceListCmd() *cobra.Command {
 			runs, err := queryRuns(ctx, c, params, projectName, ff.Limit, ff.MinTokens)
 			if err != nil {
 				ExitErrorf("%v", err)
+			}
+
+			var flaggedByTrace map[string]string
+			if includeFlagged {
+				sessionID, err := c.ResolveSessionID(ctx, projectName)
+				if err != nil {
+					ExitErrorf("%v", err)
+				}
+				flagged := FetchFlaggedTraces(ctx, c, sessionID, ff.LastNMinutes)
+				flaggedByTrace = make(map[string]string, len(flagged))
+				for _, ft := range flagged {
+					flaggedByTrace[ft.TraceID] = ft.Comment
+				}
 			}
 
 			fmt_ := GetFormat()
@@ -121,6 +135,9 @@ func newTraceListCmd() *cobra.Command {
 					output.OutputJSON(result, outputFile)
 				} else {
 					data := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)
+					if flaggedByTrace != nil {
+						annotateFlagged(data, flaggedByTrace)
+					}
 					output.OutputJSON(data, outputFile)
 				}
 			}
@@ -131,6 +148,7 @@ func newTraceListCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, token_usage, costs, tags, custom_metadata (incl. revision_id)")
 	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, and error fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
+	cmd.Flags().BoolVar(&includeFlagged, "include-flagged", false, "Add flagged_comment field populated from user-flagged trace feedback")
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io --include-feedback")
 	cmd.Flags().BoolVar(&showHierarchy, "show-hierarchy", false, "Fetch the full run tree for each trace")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
@@ -318,4 +336,22 @@ func newTraceExportCmd() *cobra.Command {
 		"Filename pattern. Supports {trace_id} and {name} placeholders.")
 
 	return cmd
+}
+
+// annotateFlagged mutates each run map to add a "flagged_comment" field
+// (string or null) based on whether the trace_id has a user-flagged feedback
+// entry. Runs without a match get "flagged_comment": null so downstream jq
+// filters can distinguish "missing" from "not flagged".
+func annotateFlagged(data []map[string]any, flaggedByTrace map[string]string) {
+	for _, row := range data {
+		tid, _ := row["trace_id"].(string)
+		if comment, ok := flaggedByTrace[tid]; ok {
+			if comment == "" {
+				comment = "User flagged for review"
+			}
+			row["flagged_comment"] = comment
+		} else {
+			row["flagged_comment"] = nil
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Two targeted flags on existing commands — used by the `issues-board-ao` agent when it pipes CLI stdout to files and composes workflow in shell. No new commands, no new file-output modes.

### Changes

- **`trace list --include-flagged`** — adds a `flagged_comment` field per trace (null if not user-flagged), populated from `/api/v1/feedback?key=langsmith_user_flagged_issue`. Lets callers prioritize with `jq 'select(.flagged_comment)'` rather than curl'ing the feedback endpoint directly.
- **`trace messages --include-root-io`** — adds `root_inputs_preview` / `root_outputs_preview` to each returned trace (2000-char truncation). Lets downstream code render `[ROOT INPUT]` / `[ROOT OUTPUT]` blocks per conversation without a separate `run list` call.

`trace messages` remains `Hidden: true` (private beta) — this PR does not unhide it.

### Out of scope / deferred

- **Annotation-queue subcommands** — initially drafted here, removed. The `{project}-flagged-issues` upsert-and-append behavior will live in the `langchainplus` / agent side instead; the CLI is the wrong layer for it.
- **Auto-chunking of `trace messages --trace-ids`** — the agent hit HTTP 400 "Failed to parse" at ~100 IDs in live testing. Fix belongs in a separate focused CLI PR; not tied to this one.

## Release Note

none

## Test Plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/cmd/` passes
- [x] Live-tested each flag against dev:
  - `trace list --include-flagged` → `flagged_comment` field present per trace (null/string)
  - `trace messages --include-root-io` → `root_inputs_preview` / `root_outputs_preview` present and non-empty
- [x] End-to-end validation by the `issues-board-ao` agent once the companion prompt update lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)