### PR TITLE
feat(trajectory): add inputs/outputs preview to trace trajectory

### DIFF
--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -24,15 +24,16 @@ type trajectoryStep struct {
 
 // traceTrajectory is the compact trajectory for a single trace.
 type traceTrajectory struct {
-	TraceID string           `json:"trace_id"`
-	Steps   []trajectoryStep `json:"steps"`
+	TraceID        string           `json:"trace_id"`
+	InputsPreview  string           `json:"inputs_preview,omitempty"`
+	OutputsPreview string           `json:"outputs_preview,omitempty"`
+	Steps          []trajectoryStep `json:"steps"`
 }
 
 func newTraceMessagesCmd() *cobra.Command {
 	var (
-		ff            FilterFlags
-		outputFile    string
-		includeRootIO bool
+		ff         FilterFlags
+		outputFile string
 	)
 
 	cmd := &cobra.Command{
@@ -55,7 +56,7 @@ Examples:
   langsmith trace messages --project my-chatbot --limit 5
   langsmith trace messages --project my-chatbot --filter "eq(status, \"error\")"
   langsmith trace messages --project my-chatbot --since 2024-01-15T00:00:00Z
-  langsmith trace messages --project my-chatbot --trace-ids <id1,id2> --include-root-io`,
+  langsmith trace messages --project my-chatbot --trace-ids <id1,id2>`,
 		Run: func(cmd *cobra.Command, args []string) {
 			defaultLimit := 10
 			if ff.Limit == 0 {
@@ -144,9 +145,7 @@ Examples:
 				allTraces = allTraces[:ff.Limit]
 			}
 
-			if includeRootIO {
-				attachRootIO(ctx, c, sessionID, startTime, allTraces)
-			}
+			attachRootIO(ctx, c, sessionID, startTime, allTraces)
 
 			for _, t := range allTraces {
 				trace, _ := t.(map[string]any)
@@ -170,7 +169,6 @@ Examples:
 
 	addCommonFilterFlags(cmd, &ff, true)
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
-	cmd.Flags().BoolVar(&includeRootIO, "include-root-io", false, "Add root_inputs_preview and root_outputs_preview fields per trace")
 
 	return cmd
 }
@@ -314,6 +312,8 @@ func printTraceMessages(result map[string]any) {
 // buildTraceTrajectory converts a raw trace map into a compact trajectory.
 func buildTraceTrajectory(trace map[string]any) traceTrajectory {
 	traceID, _ := trace["trace_id"].(string)
+	inputsPreview, _ := trace["root_inputs_preview"].(string)
+	outputsPreview, _ := trace["root_outputs_preview"].(string)
 	groups, _ := trace["groups"].([]any)
 
 	var steps []trajectoryStep
@@ -358,7 +358,12 @@ func buildTraceTrajectory(trace map[string]any) traceTrajectory {
 		}
 	}
 
-	return traceTrajectory{TraceID: traceID, Steps: steps}
+	return traceTrajectory{
+		TraceID:        traceID,
+		InputsPreview:  inputsPreview,
+		OutputsPreview: outputsPreview,
+		Steps:          steps,
+	}
 }
 
 func trajTokens(meta map[string]any) *int64 {

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -24,10 +24,10 @@ type trajectoryStep struct {
 
 // traceTrajectory is the compact trajectory for a single trace.
 type traceTrajectory struct {
-	TraceID        string           `json:"trace_id"`
-	InputsPreview  string           `json:"inputs_preview,omitempty"`
-	OutputsPreview string           `json:"outputs_preview,omitempty"`
-	Steps          []trajectoryStep `json:"steps"`
+	TraceID       string           `json:"trace_id"`
+	InputMessage  string           `json:"input_message,omitempty"`
+	OutputMessage string           `json:"output_message,omitempty"`
+	Steps         []trajectoryStep `json:"steps"`
 }
 
 func newTraceMessagesCmd() *cobra.Command {
@@ -359,10 +359,10 @@ func buildTraceTrajectory(trace map[string]any) traceTrajectory {
 	}
 
 	return traceTrajectory{
-		TraceID:        traceID,
-		InputsPreview:  inputsPreview,
-		OutputsPreview: outputsPreview,
-		Steps:          steps,
+		TraceID:       traceID,
+		InputMessage:  inputsPreview,
+		OutputMessage: outputsPreview,
+		Steps:         steps,
 	}
 }
 

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -101,6 +101,10 @@ func TestTraceMessages_Success(t *testing.T) {
 				},
 				"cursors": map[string]string{},
 			})
+		case r.URL.Path == "/api/v1/runs/query" && r.Method == "POST":
+			// attachRootIO always fetches root run previews
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"runs": []any{}})
 		default:
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 			http.Error(w, "not found", 404)


### PR DESCRIPTION
## Summary

- `input_message` and `output_message` are now always included in the `trajectory` object of every `trace messages` response — no flag needed
- Removes `--include-root-io` flag (added in the previous PR) in favour of making root IO enrichment unconditional alongside trajectory
- `buildTraceTrajectory` reads `root_inputs_preview` / `root_outputs_preview` from the trace map and surfaces them as `input_message` / `output_message` on the trajectory

The trajectory shape is now:
```json
{
  "trace_id": "...",
  "input_message": "What is the capital of France?",
  "output_message": "Paris is the capital of France.",
  "steps": [...]
}
```

## Test Plan

- [ ] Run `langsmith trace messages --project <project>` and confirm `trajectory.input_message` / `trajectory.output_message` are populated
- [ ] Confirm omitempty works: traces with no root run IO don't emit empty string fields

## Release Note

`trace messages` trajectory now always includes `input_message` and `output_message` from the root run; `--include-root-io` flag removed.