### PR TITLE
feat(trace messages): add --cursor flag for external pagination

### DIFF
--- a/internal/cmd/filters.go
+++ b/internal/cmd/filters.go
@@ -18,6 +18,7 @@ type FilterFlags struct {
 	LastNMinutes int
 	Since        string
 	Before       string
+	Cursor       string
 	ErrorFlag    bool
 	NoErrorFlag  bool
 	Name         string
@@ -38,6 +39,7 @@ func addCommonFilterFlags(cmd *cobra.Command, f *FilterFlags, includeRunType boo
 	cmd.Flags().IntVar(&f.LastNMinutes, "last-n-minutes", 0, "Only include runs from the last N minutes, e.g. 60 (overrides 7-day default)")
 	cmd.Flags().StringVar(&f.Since, "since", "", "Only include runs after this timestamp, e.g. 2024-01-15T00:00:00Z (overrides 7-day default)")
 	cmd.Flags().StringVar(&f.Before, "before", "", "Only include runs before this timestamp, e.g. 2024-01-15T00:00:00Z (for pagination)")
+	cmd.Flags().StringVar(&f.Cursor, "cursor", "", "Resume from a pagination cursor returned by a previous call; enables single-page mode with cursors.next in output")
 	cmd.Flags().BoolVar(&f.ErrorFlag, "error", false, "Filter for failed runs only")
 	cmd.Flags().BoolVar(&f.NoErrorFlag, "no-error", false, "Filter for successful runs only")
 	cmd.Flags().StringVar(&f.Name, "name", "", "Filter by run name (exact match)")

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -86,6 +86,10 @@ Examples:
 			startTime := resolveStartTime(ff.Since, ff.LastNMinutes)
 			body["min_start_time"] = startTime.Format("2006-01-02T15:04:05Z07:00")
 
+			if ff.Before != "" {
+				body["max_start_time"] = ff.Before
+			}
+
 			if ff.TraceIDs != "" {
 				ids := splitTrim(ff.TraceIDs)
 				if len(ids) == 1 {
@@ -108,6 +112,53 @@ Examples:
 			filterStr := buildFilterDSL(&ff)
 			if filterStr != "" {
 				body["filter"] = filterStr
+			}
+
+			// Single-page mode: when --cursor is explicitly set, make one API call
+			// and expose the real cursors.next so callers can paginate externally.
+			if cmd.Flags().Changed("cursor") {
+				pageSize := ff.Limit
+				if pageSize == 0 {
+					pageSize = defaultLimit
+				}
+				if ff.Cursor != "" {
+					body["cursor"] = ff.Cursor
+				}
+				body["limit"] = pageSize
+
+				var result map[string]any
+				if err := c.RawPost(ctx, "/v2/traces/messages", body, &result); err != nil {
+					ExitErrorf("%v", err)
+				}
+
+				traces, _ := result["traces"].([]any)
+				if traces == nil {
+					traces = []any{}
+				}
+
+				attachRootIO(ctx, c, sessionID, startTime, traces)
+				for _, t := range traces {
+					trace, _ := t.(map[string]any)
+					traj := buildTraceTrajectory(trace)
+					trace["trajectory"] = traj.Steps
+				}
+
+				cursors, _ := result["cursors"].(map[string]any)
+				if cursors == nil {
+					cursors = map[string]any{}
+				}
+
+				combined := map[string]any{
+					"traces":  traces,
+					"cursors": cursors,
+				}
+				fmt_ := GetFormat()
+				if fmt_ == "pretty" {
+					printTraceMessages(combined)
+				} else {
+					output.OutputJSON(combined, outputFile)
+				}
+				return
 			}
 
 			// Paginate: fetch up to ff.Limit traces using pages of <= maxPageSize

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -423,6 +423,147 @@ func TestTraceMessages_PaginationStopsAtLimit(t *testing.T) {
 	}
 }
 
+func TestTraceMessages_CursorFlag_SinglePage(t *testing.T) {
+	callCount := 0
+	var receivedBody map[string]any
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/sessions":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"id": "sess-cur", "name": "cur-proj"},
+			})
+		case r.URL.Path == "/v2/traces/messages":
+			callCount++
+			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"traces": []map[string]any{
+					{"trace_id": "trace-A", "groups": []any{}},
+					{"trace_id": "trace-B", "groups": []any{}},
+				},
+				"cursors": map[string]any{"next": "cursor-next-page"},
+			})
+		}
+	})
+	cleanup := setupTestEnv(t, ts.URL)
+	defer cleanup()
+
+	out := captureStdout(t, func() {
+		cmd := newTraceMessagesCmd()
+		cmd.SetArgs([]string{"--project", "cur-proj", "--limit", "20", "--cursor", "cursor-abc"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Only one API call despite there being more pages (single-page mode)
+	if callCount != 1 {
+		t.Errorf("expected exactly 1 API call in cursor mode, got %d", callCount)
+	}
+	// Cursor was forwarded to the API
+	if receivedBody["cursor"] != "cursor-abc" {
+		t.Errorf("expected cursor=cursor-abc in request, got %v", receivedBody["cursor"])
+	}
+	// cursors.next is present in output so caller can continue paginating
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, out)
+	}
+	cursors, _ := result["cursors"].(map[string]any)
+	if cursors["next"] != "cursor-next-page" {
+		t.Errorf("expected cursors.next=cursor-next-page in output, got %v", cursors["next"])
+	}
+	traces, _ := result["traces"].([]any)
+	if len(traces) != 2 {
+		t.Errorf("expected 2 traces, got %d", len(traces))
+	}
+}
+
+func TestTraceMessages_CursorFlag_EmptyCursorIsFirstPage(t *testing.T) {
+	callCount := 0
+	var receivedBody map[string]any
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/sessions":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"id": "sess-first", "name": "first-proj"},
+			})
+		case r.URL.Path == "/v2/traces/messages":
+			callCount++
+			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"traces":  []map[string]any{{"trace_id": "trace-1", "groups": []any{}}},
+				"cursors": map[string]any{"next": "cursor-page2"},
+			})
+		}
+	})
+	cleanup := setupTestEnv(t, ts.URL)
+	defer cleanup()
+
+	out := captureStdout(t, func() {
+		cmd := newTraceMessagesCmd()
+		// --cursor "" means first page in single-page mode
+		cmd.SetArgs([]string{"--project", "first-proj", "--limit", "20", "--cursor", ""})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if callCount != 1 {
+		t.Errorf("expected 1 API call, got %d", callCount)
+	}
+	// Empty cursor should NOT be forwarded to the API
+	if _, ok := receivedBody["cursor"]; ok {
+		t.Errorf("empty --cursor should not send cursor field to API, got %v", receivedBody["cursor"])
+	}
+	// cursors.next is still exposed
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	cursors, _ := result["cursors"].(map[string]any)
+	if cursors["next"] != "cursor-page2" {
+		t.Errorf("expected cursors.next=cursor-page2, got %v", cursors["next"])
+	}
+}
+
+func TestTraceMessages_BeforeFlag(t *testing.T) {
+	var receivedBody map[string]any
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/sessions":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"id": "sess-bef", "name": "bef-proj"},
+			})
+		case r.URL.Path == "/v2/traces/messages":
+			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"traces":  []any{},
+				"cursors": map[string]any{},
+			})
+		}
+	})
+	cleanup := setupTestEnv(t, ts.URL)
+	defer cleanup()
+
+	captureStdout(t, func() {
+		cmd := newTraceMessagesCmd()
+		cmd.SetArgs([]string{"--project", "bef-proj", "--before", "2024-01-15T00:00:00Z"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if receivedBody["max_start_time"] != "2024-01-15T00:00:00Z" {
+		t.Errorf("expected max_start_time=2024-01-15T00:00:00Z, got %v", receivedBody["max_start_time"])
+	}
+}
+
 func TestTraceMessages_EmptyResult(t *testing.T) {
 	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {


### PR DESCRIPTION
## Summary

The `trace messages` command internally paginates up to `--limit` (max 100) but always discards the backend cursor, making it impossible to fetch beyond the first 100 traces.

- Add `--cursor` flag: when explicitly passed (including `--cursor ""`), the command switches to **single-page mode** — exactly one API call, `cursors.next` exposed in JSON output so callers can paginate externally
- Wire `--before` → `body["max_start_time"]` (the flag was registered via `addCommonFilterFlags` but never read in the messages handler)
- Add 3 new tests covering single-page cursor mode, empty cursor as first page, and `--before` wiring

The cursor design uses `cmd.Flags().Changed("cursor")` to distinguish `--cursor ""` (explicit first page) from not passing the flag at all (internal pagination mode).

## Test Plan

- [x] `go test ./internal/cmd/ -run "TestTraceMessages" -v` — all 13 tests pass (3 new)
- [x] Manual: `langsmith trace messages --project <name> --cursor ""` returns `cursors.next`, subsequent `--cursor <next>` fetches the next page

## Release Note
Add `--cursor` flag to `langsmith trace messages` for external pagination beyond 100 traces.