### PR TITLE
fix(trace messages): preserve feedback_stats from API response

### DIFF
--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -225,9 +225,8 @@ Examples:
 }
 
 type rootPreview struct {
-	inputs        string
-	outputs       string
-	feedbackStats map[string]map[string]interface{}
+	inputs  string
+	outputs string
 }
 
 // attachRootIO looks up inputs_preview/outputs_preview for the root runs of
@@ -256,15 +255,9 @@ func attachRootIO(ctx context.Context, c *client.Client, sessionID string, start
 		if p, ok := previews[tid]; ok {
 			trace["root_inputs_preview"] = p.inputs
 			trace["root_outputs_preview"] = p.outputs
-			if len(p.feedbackStats) > 0 {
-				trace["feedback_stats"] = p.feedbackStats
-			} else {
-				trace["feedback_stats"] = map[string]map[string]interface{}{}
-			}
 		} else {
 			trace["root_inputs_preview"] = nil
 			trace["root_outputs_preview"] = nil
-			trace["feedback_stats"] = map[string]map[string]interface{}{}
 		}
 	}
 }
@@ -289,7 +282,6 @@ func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, 
 			langsmith.RunQueryParamsSelectTraceID,
 			langsmith.RunQueryParamsSelectInputsPreview,
 			langsmith.RunQueryParamsSelectOutputsPreview,
-			langsmith.RunQueryParamsSelectFeedbackStats,
 		}),
 	}
 	resp, err := c.SDK.Runs.Query(ctx, params)
@@ -306,9 +298,8 @@ func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, 
 			continue
 		}
 		out[tid] = rootPreview{
-			inputs:        truncateHard(run.InputsPreview, 2000),
-			outputs:       truncateHard(run.OutputsPreview, 2000),
-			feedbackStats: run.FeedbackStats,
+			inputs:  truncateHard(run.InputsPreview, 2000),
+			outputs: truncateHard(run.OutputsPreview, 2000),
 		}
 	}
 	return out

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -225,8 +225,9 @@ Examples:
 }
 
 type rootPreview struct {
-	inputs  string
-	outputs string
+	inputs        string
+	outputs       string
+	feedbackStats map[string]map[string]interface{}
 }
 
 // attachRootIO looks up inputs_preview/outputs_preview for the root runs of
@@ -255,9 +256,15 @@ func attachRootIO(ctx context.Context, c *client.Client, sessionID string, start
 		if p, ok := previews[tid]; ok {
 			trace["root_inputs_preview"] = p.inputs
 			trace["root_outputs_preview"] = p.outputs
+			if len(p.feedbackStats) > 0 {
+				trace["feedback_stats"] = p.feedbackStats
+			} else {
+				trace["feedback_stats"] = map[string]map[string]interface{}{}
+			}
 		} else {
 			trace["root_inputs_preview"] = nil
 			trace["root_outputs_preview"] = nil
+			trace["feedback_stats"] = map[string]map[string]interface{}{}
 		}
 	}
 }
@@ -282,6 +289,7 @@ func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, 
 			langsmith.RunQueryParamsSelectTraceID,
 			langsmith.RunQueryParamsSelectInputsPreview,
 			langsmith.RunQueryParamsSelectOutputsPreview,
+			langsmith.RunQueryParamsSelectFeedbackStats,
 		}),
 	}
 	resp, err := c.SDK.Runs.Query(ctx, params)
@@ -298,8 +306,9 @@ func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, 
 			continue
 		}
 		out[tid] = rootPreview{
-			inputs:  truncateHard(run.InputsPreview, 2000),
-			outputs: truncateHard(run.OutputsPreview, 2000),
+			inputs:        truncateHard(run.InputsPreview, 2000),
+			outputs:       truncateHard(run.OutputsPreview, 2000),
+			feedbackStats: run.FeedbackStats,
 		}
 	}
 	return out

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -564,6 +564,9 @@ func TestTraceMessages_BeforeFlag(t *testing.T) {
 	}
 }
 
+// TestTraceMessages_FeedbackStats verifies that feedback_stats returned by the
+// /v2/traces/messages API is preserved in the CLI output without being
+// overwritten or dropped by attachRootIO.
 func TestTraceMessages_FeedbackStats(t *testing.T) {
 	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -573,32 +576,28 @@ func TestTraceMessages_FeedbackStats(t *testing.T) {
 				{"id": "sess-fb", "name": "fb-proj"},
 			})
 		case r.URL.Path == "/v2/traces/messages":
+			// API returns feedback_stats directly on each trace
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"traces": []map[string]any{
-					{"trace_id": "trace-with-feedback", "groups": []any{}},
-					{"trace_id": "trace-no-feedback", "groups": []any{}},
-				},
-				"cursors": map[string]any{},
-			})
-		case r.URL.Path == "/api/v1/runs/query":
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"runs": []map[string]any{
 					{
-						"id":       "trace-with-feedback",
 						"trace_id": "trace-with-feedback",
+						"groups":   []any{},
 						"feedback_stats": map[string]any{
 							"thumbs_up": map[string]any{"n": 1, "avg": 0},
 						},
 					},
 					{
-						"id":             "trace-no-feedback",
 						"trace_id":       "trace-no-feedback",
-						"feedback_stats": nil,
+						"groups":         []any{},
+						"feedback_stats": map[string]any{},
 					},
 				},
+				"cursors": map[string]any{},
 			})
+		case r.URL.Path == "/api/v1/runs/query":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"runs": []any{}})
 		}
 	})
 	cleanup := setupTestEnv(t, ts.URL)
@@ -621,13 +620,7 @@ func TestTraceMessages_FeedbackStats(t *testing.T) {
 		t.Fatalf("expected 2 traces, got %d", len(traces))
 	}
 
-	for _, t_ := range traces {
-		trace, _ := t_.(map[string]any)
-		if _, ok := trace["feedback_stats"]; !ok {
-			t.Errorf("trace %v missing feedback_stats field", trace["trace_id"])
-		}
-	}
-
+	// feedback_stats from the API must be preserved as-is
 	traceWith, _ := traces[0].(map[string]any)
 	fs, _ := traceWith["feedback_stats"].(map[string]any)
 	if len(fs) == 0 {

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -564,6 +564,83 @@ func TestTraceMessages_BeforeFlag(t *testing.T) {
 	}
 }
 
+func TestTraceMessages_FeedbackStats(t *testing.T) {
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/sessions":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"id": "sess-fb", "name": "fb-proj"},
+			})
+		case r.URL.Path == "/v2/traces/messages":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"traces": []map[string]any{
+					{"trace_id": "trace-with-feedback", "groups": []any{}},
+					{"trace_id": "trace-no-feedback", "groups": []any{}},
+				},
+				"cursors": map[string]any{},
+			})
+		case r.URL.Path == "/api/v1/runs/query":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"runs": []map[string]any{
+					{
+						"id":       "trace-with-feedback",
+						"trace_id": "trace-with-feedback",
+						"feedback_stats": map[string]any{
+							"thumbs_up": map[string]any{"n": 1, "avg": 0},
+						},
+					},
+					{
+						"id":             "trace-no-feedback",
+						"trace_id":       "trace-no-feedback",
+						"feedback_stats": nil,
+					},
+				},
+			})
+		}
+	})
+	cleanup := setupTestEnv(t, ts.URL)
+	defer cleanup()
+
+	out := captureStdout(t, func() {
+		cmd := newTraceMessagesCmd()
+		cmd.SetArgs([]string{"--project", "fb-proj", "--limit", "20"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, out)
+	}
+	traces, _ := result["traces"].([]any)
+	if len(traces) != 2 {
+		t.Fatalf("expected 2 traces, got %d", len(traces))
+	}
+
+	for _, t_ := range traces {
+		trace, _ := t_.(map[string]any)
+		if _, ok := trace["feedback_stats"]; !ok {
+			t.Errorf("trace %v missing feedback_stats field", trace["trace_id"])
+		}
+	}
+
+	traceWith, _ := traces[0].(map[string]any)
+	fs, _ := traceWith["feedback_stats"].(map[string]any)
+	if len(fs) == 0 {
+		t.Errorf("expected non-empty feedback_stats for trace-with-feedback, got %v", fs)
+	}
+
+	traceWithout, _ := traces[1].(map[string]any)
+	fsEmpty, _ := traceWithout["feedback_stats"].(map[string]any)
+	if len(fsEmpty) != 0 {
+		t.Errorf("expected empty feedback_stats for trace-no-feedback, got %v", fsEmpty)
+	}
+}
+
 func TestTraceMessages_EmptyResult(t *testing.T) {
 	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {


### PR DESCRIPTION
## Summary

The `/v2/traces/messages` endpoint already returns `feedback_stats` on each trace. The original implementation of this PR re-fetched it via `/api/v1/runs/query` and overwrote the API value — adding a round-trip and risking data loss if the runs query failed.

Fix: revert the `fetchRootPreviews`/`attachRootIO` changes entirely and let the API response pass through unchanged. `feedback_stats` is already there.

Verified against the real API — `feedback_stats` is present and correct on every trace without any extra fetching.

## Test Plan

- [x] `go test ./internal/cmd/ -run TestTraceMessages -v` — all 14 tests pass
- [x] Manual: `trace messages` output contains `feedback_stats` on real traces

## Release Note
`trace messages` now correctly surfaces `feedback_stats` (already returned by the API) without an extra round-trip.