### PR TITLE
feat: add OAuth login profiles and workspace commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,19 @@ Thumbs.db
 # Environment
 .env
 /.env.*
+.env.*
+*.pem
+*.key
+*.crt
+credentials.json
+token.json
 
 .envrc
+
+# Local dependency and virtualenv directories
+node_modules/
+__pycache__/
+.venv/
 
 # Claude Code
 .claude/

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/yamux v0.1.2
-	github.com/langchain-ai/langsmith-go v0.2.2
+	github.com/langchain-ai/langsmith-go v0.6.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.8.1
 	github.com/xlab/treeprint v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
 github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
-github.com/langchain-ai/langsmith-go v0.2.2 h1:WVNUR9dhnuieIaXrKxmZWva6TX1DV/RHCVgc67wbAbs=
-github.com/langchain-ai/langsmith-go v0.2.2/go.mod h1:xdfOA0EBT7KF9ylz+gGq8EM6srRkv2PtpazQ+4oraWk=
+github.com/langchain-ai/langsmith-go v0.6.0 h1:N8kvxlI6NTpyxTH0w7R5JQXsFp56jjYF92a+zoy+AnM=
+github.com/langchain-ai/langsmith-go v0.6.0/go.mod h1:tUtPtr3nujib98CAfCgEHTL1QMoiNZ5VDx5Qb1pwYZg=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -19,11 +19,20 @@ import (
 type Client struct {
 	SDK         *langsmith.Client
 	apiKey      string
+	bearerToken string
 	apiURL      string
 	workspaceID string
 
 	// Cached session name → ID mappings (per invocation).
 	sessionCache map[string]string
+}
+
+// Options controls LangSmith client authentication and routing.
+type Options struct {
+	APIKey      string
+	BearerToken string
+	APIURL      string
+	WorkspaceID string
 }
 
 // NormalizeURL strips a trailing "/api/v1" suffix (with or without a trailing
@@ -36,27 +45,38 @@ func NormalizeURL(apiURL string) string {
 
 // New creates a new Client.
 func New(apiKey, apiURL string) *Client {
-	normalized := NormalizeURL(apiURL)
+	return NewWithOptions(Options{
+		APIKey:      apiKey,
+		APIURL:      apiURL,
+		WorkspaceID: os.Getenv("LANGSMITH_WORKSPACE_ID"),
+	})
+}
 
-	opts := []option.RequestOption{
-		option.WithAPIKey(apiKey),
+// NewWithOptions creates a new Client from resolved options.
+func NewWithOptions(options Options) *Client {
+	normalized := NormalizeURL(options.APIURL)
+
+	var opts []option.RequestOption
+	if options.APIKey != "" {
+		opts = append(opts, option.WithAPIKey(options.APIKey))
+	}
+	if options.BearerToken != "" {
+		opts = append(opts, option.WithBearerToken(options.BearerToken))
 	}
 	// Only set base URL if not the default (the SDK reads LANGSMITH_ENDPOINT too).
 	if normalized != "" {
 		opts = append(opts, option.WithBaseURL(normalized))
 	}
-	// Forward LANGSMITH_WORKSPACE_ID to the SDK as the tenant ID.
-	// The SDK already reads LANGSMITH_TENANT_ID, but LANGSMITH_WORKSPACE_ID
-	// is the documented env var for the CLI and MCP server.
-	if wsID := os.Getenv("LANGSMITH_WORKSPACE_ID"); wsID != "" {
-		opts = append(opts, option.WithTenantID(wsID))
+	if options.WorkspaceID != "" {
+		opts = append(opts, option.WithTenantID(options.WorkspaceID))
 	}
 
 	return &Client{
 		SDK:          langsmith.NewClient(opts...),
-		apiKey:       apiKey,
+		apiKey:       options.APIKey,
+		bearerToken:  options.BearerToken,
 		apiURL:       normalized,
-		workspaceID:  os.Getenv("LANGSMITH_WORKSPACE_ID"),
+		workspaceID:  options.WorkspaceID,
 		sessionCache: make(map[string]string),
 	}
 }
@@ -120,7 +140,12 @@ func (c *Client) doHTTP(ctx context.Context, method, path string, body io.Reader
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
-	req.Header.Set("x-api-key", c.apiKey)
+	if c.apiKey != "" {
+		req.Header.Set("x-api-key", c.apiKey)
+	}
+	if c.bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.bearerToken)
+	}
 	req.Header.Set("Content-Type", "application/json")
 	if c.workspaceID != "" {
 		req.Header.Set("x-tenant-id", c.workspaceID)
@@ -163,6 +188,9 @@ func (c *Client) RawDo(ctx context.Context, method, path string, body io.Reader,
 
 // APIKey returns the client's API key.
 func (c *Client) APIKey() string { return c.apiKey }
+
+// BearerToken returns the client's bearer token.
+func (c *Client) BearerToken() string { return c.bearerToken }
 
 // APIURL returns the client's normalized API URL.
 func (c *Client) APIURL() string { return c.apiURL }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -17,11 +17,11 @@ import (
 
 // Client wraps the LangSmith Go SDK and provides helpers for raw HTTP calls.
 type Client struct {
-	SDK         *langsmith.Client
-	apiKey      string
-	bearerToken string
-	apiURL      string
-	workspaceID string
+	SDK              *langsmith.Client
+	apiKey           string
+	oauthAccessToken string
+	apiURL           string
+	workspaceID      string
 
 	// Cached session name → ID mappings (per invocation).
 	sessionCache map[string]string
@@ -29,10 +29,10 @@ type Client struct {
 
 // Options controls LangSmith client authentication and routing.
 type Options struct {
-	APIKey      string
-	BearerToken string
-	APIURL      string
-	WorkspaceID string
+	APIKey           string
+	OAuthAccessToken string
+	APIURL           string
+	WorkspaceID      string
 }
 
 // NormalizeURL strips a trailing "/api/v1" suffix (with or without a trailing
@@ -60,8 +60,8 @@ func NewWithOptions(options Options) *Client {
 	if options.APIKey != "" {
 		opts = append(opts, option.WithAPIKey(options.APIKey))
 	}
-	if options.BearerToken != "" {
-		opts = append(opts, option.WithBearerToken(options.BearerToken))
+	if options.OAuthAccessToken != "" {
+		opts = append(opts, option.WithHeader("authorization", "Bearer "+options.OAuthAccessToken))
 	}
 	// Only set base URL if not the default (the SDK reads LANGSMITH_ENDPOINT too).
 	if normalized != "" {
@@ -72,12 +72,12 @@ func NewWithOptions(options Options) *Client {
 	}
 
 	return &Client{
-		SDK:          langsmith.NewClient(opts...),
-		apiKey:       options.APIKey,
-		bearerToken:  options.BearerToken,
-		apiURL:       normalized,
-		workspaceID:  options.WorkspaceID,
-		sessionCache: make(map[string]string),
+		SDK:              langsmith.NewClient(opts...),
+		apiKey:           options.APIKey,
+		oauthAccessToken: options.OAuthAccessToken,
+		apiURL:           normalized,
+		workspaceID:      options.WorkspaceID,
+		sessionCache:     make(map[string]string),
 	}
 }
 
@@ -143,8 +143,8 @@ func (c *Client) doHTTP(ctx context.Context, method, path string, body io.Reader
 	if c.apiKey != "" {
 		req.Header.Set("x-api-key", c.apiKey)
 	}
-	if c.bearerToken != "" {
-		req.Header.Set("Authorization", "Bearer "+c.bearerToken)
+	if c.oauthAccessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.oauthAccessToken)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if c.workspaceID != "" {
@@ -189,8 +189,8 @@ func (c *Client) RawDo(ctx context.Context, method, path string, body io.Reader,
 // APIKey returns the client's API key.
 func (c *Client) APIKey() string { return c.apiKey }
 
-// BearerToken returns the client's bearer token.
-func (c *Client) BearerToken() string { return c.bearerToken }
+// OAuthAccessToken returns the client's OAuth access token.
+func (c *Client) OAuthAccessToken() string { return c.oauthAccessToken }
 
 // APIURL returns the client's normalized API URL.
 func (c *Client) APIURL() string { return c.apiURL }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -69,15 +69,15 @@ func TestNew_EmptyURL(t *testing.T) {
 
 func TestNewWithOptions_CreatesOAuthClient(t *testing.T) {
 	c := NewWithOptions(Options{
-		BearerToken: "test-access-token",
-		APIURL:      "http://localhost:1234",
-		WorkspaceID: "ws-123",
+		OAuthAccessToken: "test-access-token",
+		APIURL:           "http://localhost:1234",
+		WorkspaceID:      "ws-123",
 	})
 	if c == nil || c.SDK == nil {
 		t.Fatal("expected non-nil client and SDK")
 	}
-	if c.BearerToken() != "test-access-token" {
-		t.Fatalf("unexpected bearer token: %q", c.BearerToken())
+	if c.OAuthAccessToken() != "test-access-token" {
+		t.Fatalf("unexpected OAuth access token: %q", c.OAuthAccessToken())
 	}
 	if c.APIKey() != "" {
 		t.Fatalf("expected empty API key, got %q", c.APIKey())
@@ -272,7 +272,7 @@ func TestRawRequest_NoWorkspaceHeaderWhenUnset(t *testing.T) {
 	_ = c.RawGet(context.Background(), "/test", nil)
 }
 
-func TestRawRequest_SetsBearerHeader(t *testing.T) {
+func TestRawRequest_SetsOAuthAuthorizationHeader(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token" {
 			t.Errorf("expected bearer auth header, got %q", got)
@@ -285,7 +285,7 @@ func TestRawRequest_SetsBearerHeader(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := NewWithOptions(Options{BearerToken: "test-access-token", APIURL: ts.URL})
+	c := NewWithOptions(Options{OAuthAccessToken: "test-access-token", APIURL: ts.URL})
 	_ = c.RawGet(context.Background(), "/test", nil)
 }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -67,6 +67,23 @@ func TestNew_EmptyURL(t *testing.T) {
 	}
 }
 
+func TestNewWithOptions_CreatesOAuthClient(t *testing.T) {
+	c := NewWithOptions(Options{
+		BearerToken: "test-access-token",
+		APIURL:      "http://localhost:1234",
+		WorkspaceID: "ws-123",
+	})
+	if c == nil || c.SDK == nil {
+		t.Fatal("expected non-nil client and SDK")
+	}
+	if c.BearerToken() != "test-access-token" {
+		t.Fatalf("unexpected bearer token: %q", c.BearerToken())
+	}
+	if c.APIKey() != "" {
+		t.Fatalf("expected empty API key, got %q", c.APIKey())
+	}
+}
+
 // ---------- RawGet ----------
 
 func TestRawGet_Success(t *testing.T) {
@@ -252,6 +269,23 @@ func TestRawRequest_NoWorkspaceHeaderWhenUnset(t *testing.T) {
 	defer ts.Close()
 
 	c := New("key", ts.URL)
+	_ = c.RawGet(context.Background(), "/test", nil)
+}
+
+func TestRawRequest_SetsBearerHeader(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token" {
+			t.Errorf("expected bearer auth header, got %q", got)
+		}
+		if got := r.Header.Get("x-api-key"); got != "" {
+			t.Errorf("expected empty x-api-key, got %q", got)
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	c := NewWithOptions(Options{BearerToken: "test-access-token", APIURL: ts.URL})
 	_ = c.RawGet(context.Background(), "/test", nil)
 }
 

--- a/internal/cmd/api/request.go
+++ b/internal/cmd/api/request.go
@@ -28,7 +28,7 @@ func runRequest(c *client.Client, method, path, body string, headers []string, i
 	if isSameHost(fullURL, apiURL) {
 		relPath = strings.TrimPrefix(fullURL, apiURL)
 	} else if strings.HasPrefix(fullURL, "http://") || strings.HasPrefix(fullURL, "https://") {
-		reqClient = client.New("", "")
+		reqClient = client.NewWithOptions(client.Options{})
 	}
 
 	// Resolve body
@@ -113,4 +113,3 @@ func isSameHost(fullURL, baseURL string) bool {
 	rest := fullURL[len(baseURL):]
 	return rest == "" || rest[0] == '/' || rest[0] == '?'
 }
-

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -1,0 +1,395 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/langchain-ai/langsmith-cli/internal/client"
+	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+const oauthClientID = "langsmith-cli"
+
+var openBrowser = openBrowserDefault
+var inputIsTerminal = func(r io.Reader) bool {
+	f, ok := r.(*os.File)
+	return ok && term.IsTerminal(int(f.Fd()))
+}
+
+type deviceCodeResponse struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+type oauthTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+type oauthErrorResponse struct {
+	Code             string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+func (e *oauthErrorResponse) Error() string {
+	if e.ErrorDescription == "" {
+		return e.Code
+	}
+	return e.Code + ": " + e.ErrorDescription
+}
+
+func newLoginCmd() *cobra.Command {
+	var (
+		noBrowser   bool
+		timeout     time.Duration
+		workspaceID string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Authenticate with LangSmith using OAuth",
+		Long: `Authenticate with LangSmith using OAuth.
+
+The command stores OAuth tokens in ~/.langsmith/config.toml under the selected
+profile. Select a profile with --profile or LANGSMITH_PROFILE.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLogin(cmd, noBrowser, timeout, workspaceID)
+		},
+	}
+	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Do not open a browser automatically")
+	cmd.Flags().DurationVar(&timeout, "timeout", 0, "Maximum time to wait for authorization (default: device-code expiry)")
+	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "Default workspace ID to save in the selected profile")
+	return cmd
+}
+
+func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspaceID string) error {
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return err
+	}
+	workspaceID = strings.TrimSpace(workspaceID)
+	if workspaceID != "" {
+		if err := validateWorkspaceID(workspaceID); err != nil {
+			return err
+		}
+	}
+
+	profileName := loginProfileName(cfg)
+	if err := validateProfileName(profileName); err != nil {
+		return err
+	}
+	apiURL := loginAPIURL(cfg, profileName)
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	device, err := requestDeviceCode(ctx, apiURL)
+	if err != nil {
+		return err
+	}
+
+	errOut := cmd.ErrOrStderr()
+	fmt.Fprintf(errOut, "Open this URL to authorize the LangSmith CLI:\n%s\n\nEnter code: %s\n\n", device.VerificationURI, device.UserCode)
+	if !noBrowser {
+		if err := openBrowser(device.VerificationURI); err != nil {
+			fmt.Fprintf(errOut, "Could not open a browser automatically: %v\n\n", err)
+		}
+	}
+	fmt.Fprintln(errOut, "Waiting for authorization...")
+
+	waitFor := timeout
+	if waitFor <= 0 {
+		waitFor = time.Duration(device.ExpiresIn+10) * time.Second
+	}
+	pollCtx, cancel := context.WithTimeout(ctx, waitFor)
+	defer cancel()
+
+	interval := time.Duration(device.Interval) * time.Second
+	token, err := pollDeviceToken(pollCtx, apiURL, device.DeviceCode, interval)
+	if err != nil {
+		return err
+	}
+
+	profile := cfg.Profiles[profileName]
+	if profile.APIURL == "" || flagAPIURL != "" || strings.TrimSpace(profile.APIURL) != apiURL {
+		profile.APIURL = apiURL
+	}
+	if workspaceID == "" && profile.WorkspaceID == "" {
+		workspaceID, err = promptWorkspaceID(cmd)
+		if err != nil {
+			return err
+		}
+	}
+	if workspaceID != "" {
+		profile.WorkspaceID = workspaceID
+	}
+	applyTokenResponse(&profile, token, time.Now())
+	cfg.Profiles[profileName] = profile
+	cfg.CurrentProfile = profileName
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	result := map[string]string{
+		"status":           "logged_in",
+		"profile":          profileName,
+		"api_url":          apiURL,
+		"oauth_expires_at": profile.OAuth.ExpiresAt,
+	}
+	if profile.WorkspaceID != "" {
+		result["workspace_id"] = profile.WorkspaceID
+	}
+	if GetFormat() == "pretty" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Logged in to %s as profile %q\n", apiURL, profileName)
+		return nil
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+func loginProfileName(cfg *lsconfig.Config) string {
+	if flagProfile != "" {
+		return flagProfile
+	}
+	if envProfile := strings.TrimSpace(getenv("LANGSMITH_PROFILE")); envProfile != "" {
+		return envProfile
+	}
+	if cfg.CurrentProfile != "" {
+		return cfg.CurrentProfile
+	}
+	return "default"
+}
+
+func loginAPIURL(cfg *lsconfig.Config, profileName string) string {
+	apiURL := lsconfig.DefaultAPIURL
+	if profile, ok := cfg.Profiles[profileName]; ok && profile.APIURL != "" {
+		apiURL = profile.APIURL
+	}
+	if envURL := getenv("LANGSMITH_ENDPOINT"); envURL != "" {
+		apiURL = envURL
+	}
+	if flagAPIURL != "" {
+		apiURL = flagAPIURL
+	}
+	return client.NormalizeURL(apiURL)
+}
+
+func validateProfileName(name string) error {
+	if name == "" || strings.ContainsAny(name, "[]\r\n") {
+		return fmt.Errorf("invalid profile name: %q", name)
+	}
+	return nil
+}
+
+func validateWorkspaceID(workspaceID string) error {
+	if _, err := uuid.Parse(workspaceID); err != nil {
+		return fmt.Errorf("invalid workspace ID %q: expected UUID", workspaceID)
+	}
+	return nil
+}
+
+func promptWorkspaceID(cmd *cobra.Command) (string, error) {
+	in := cmd.InOrStdin()
+	if !inputIsTerminal(in) {
+		return "", nil
+	}
+	fmt.Fprint(cmd.ErrOrStderr(), "Default workspace ID (optional, press Enter to skip): ")
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", fmt.Errorf("reading workspace ID: %w", err)
+	}
+	workspaceID := strings.TrimSpace(line)
+	if workspaceID == "" {
+		return "", nil
+	}
+	if err := validateWorkspaceID(workspaceID); err != nil {
+		return "", err
+	}
+	return workspaceID, nil
+}
+
+func requestDeviceCode(ctx context.Context, apiURL string) (*deviceCodeResponse, error) {
+	values := url.Values{"client_id": {oauthClientID}}
+	var resp deviceCodeResponse
+	if err := postOAuthForm(ctx, apiURL, "/oauth/device/code", values, &resp); err != nil {
+		return nil, fmt.Errorf("requesting device code: %w", err)
+	}
+	if resp.DeviceCode == "" || resp.UserCode == "" || resp.VerificationURI == "" {
+		return nil, fmt.Errorf("requesting device code: incomplete response")
+	}
+	return &resp, nil
+}
+
+func refreshProfileToken(ctx context.Context, apiURL, refreshToken string) (*oauthTokenResponse, error) {
+	values := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {oauthClientID},
+		"refresh_token": {refreshToken},
+	}
+	var resp oauthTokenResponse
+	if err := postOAuthForm(ctx, apiURL, "/oauth/token", values, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func pollDeviceToken(ctx context.Context, apiURL, deviceCode string, interval time.Duration) (*oauthTokenResponse, error) {
+	if interval < 0 {
+		interval = 0
+	}
+
+	for {
+		token, oauthErr, err := requestDeviceToken(ctx, apiURL, deviceCode)
+		if err != nil {
+			return nil, err
+		}
+		if token != nil {
+			return token, nil
+		}
+
+		switch oauthErr.Code {
+		case "authorization_pending":
+		case "slow_down":
+			interval += 5 * time.Second
+		case "access_denied", "expired_token", "invalid_grant":
+			return nil, oauthErr
+		default:
+			return nil, oauthErr
+		}
+
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, fmt.Errorf("timed out waiting for authorization")
+		case <-timer.C:
+		}
+	}
+}
+
+func requestDeviceToken(ctx context.Context, apiURL, deviceCode string) (*oauthTokenResponse, *oauthErrorResponse, error) {
+	values := url.Values{
+		"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+		"client_id":   {oauthClientID},
+		"device_code": {deviceCode},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, oauthURL(apiURL, "/oauth/token"), strings.NewReader(values.Encode()))
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("exchanging device code: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading token response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		var token oauthTokenResponse
+		if err := json.Unmarshal(body, &token); err != nil {
+			return nil, nil, fmt.Errorf("decoding token response: %w", err)
+		}
+		if token.AccessToken == "" {
+			return nil, nil, fmt.Errorf("token response did not include an access token")
+		}
+		return &token, nil, nil
+	}
+
+	oauthErr := decodeOAuthError(body, resp.StatusCode)
+	return nil, oauthErr, nil
+}
+
+func postOAuthForm(ctx context.Context, apiURL, path string, values url.Values, result any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, oauthURL(apiURL, path), strings.NewReader(values.Encode()))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return decodeOAuthError(body, resp.StatusCode)
+	}
+	if err := json.Unmarshal(body, result); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	return nil
+}
+
+func decodeOAuthError(body []byte, statusCode int) *oauthErrorResponse {
+	var oauthErr oauthErrorResponse
+	if err := json.Unmarshal(body, &oauthErr); err != nil || oauthErr.Code == "" {
+		oauthErr = oauthErrorResponse{
+			Code:             fmt.Sprintf("http_%d", statusCode),
+			ErrorDescription: strings.TrimSpace(string(body)),
+		}
+	}
+	return &oauthErr
+}
+
+func applyTokenResponse(profile *lsconfig.Profile, token *oauthTokenResponse, now time.Time) {
+	profile.OAuth.AccessToken = token.AccessToken
+	if token.RefreshToken != "" {
+		profile.OAuth.RefreshToken = token.RefreshToken
+	}
+	if token.ExpiresIn > 0 {
+		profile.OAuth.ExpiresAt = now.Add(time.Duration(token.ExpiresIn) * time.Second).UTC().Format(time.RFC3339)
+	}
+}
+
+func oauthURL(apiURL, path string) string {
+	return strings.TrimRight(client.NormalizeURL(apiURL), "/") + path
+}
+
+func openBrowserDefault(rawURL string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", rawURL)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", rawURL)
+	default:
+		cmd = exec.Command("xdg-open", rawURL)
+	}
+	return cmd.Start()
+}
+
+func getenv(name string) string {
+	return strings.TrimSpace(os.Getenv(name))
+}

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -67,7 +67,7 @@ func newLoginCmd() *cobra.Command {
 		Short: "Authenticate with LangSmith using OAuth",
 		Long: `Authenticate with LangSmith using OAuth.
 
-The command stores OAuth tokens in ~/.langsmith/config.toml under the selected
+The command stores OAuth tokens in ~/.langsmith/config.json under the selected
 profile. Select a profile with --profile or LANGSMITH_PROFILE.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLogin(cmd, noBrowser, timeout, workspaceID)

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -22,6 +22,7 @@ import (
 )
 
 const oauthClientID = "langsmith-cli"
+const defaultDeviceCodePollInterval = 5 * time.Second
 
 var openBrowser = openBrowserDefault
 var inputIsTerminal = func(r io.Reader) bool {
@@ -123,7 +124,7 @@ func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspa
 	pollCtx, cancel := context.WithTimeout(ctx, waitFor)
 	defer cancel()
 
-	interval := time.Duration(device.Interval) * time.Second
+	interval := normalizeDeviceCodePollInterval(time.Duration(device.Interval) * time.Second)
 	token, err := pollDeviceToken(pollCtx, apiURL, device.DeviceCode, interval)
 	if err != nil {
 		return err
@@ -250,13 +251,14 @@ func refreshProfileToken(ctx context.Context, apiURL, refreshToken string) (*oau
 	if err := postOAuthForm(ctx, apiURL, "/oauth/token", values, &resp); err != nil {
 		return nil, err
 	}
+	if resp.AccessToken == "" {
+		return nil, fmt.Errorf("token response did not include an access token")
+	}
 	return &resp, nil
 }
 
 func pollDeviceToken(ctx context.Context, apiURL, deviceCode string, interval time.Duration) (*oauthTokenResponse, error) {
-	if interval < 0 {
-		interval = 0
-	}
+	interval = normalizeDeviceCodePollInterval(interval)
 
 	for {
 		token, oauthErr, err := requestDeviceToken(ctx, apiURL, deviceCode)
@@ -285,6 +287,13 @@ func pollDeviceToken(ctx context.Context, apiURL, deviceCode string, interval ti
 		case <-timer.C:
 		}
 	}
+}
+
+func normalizeDeviceCodePollInterval(interval time.Duration) time.Duration {
+	if interval < defaultDeviceCodePollInterval {
+		return defaultDeviceCodePollInterval
+	}
+	return interval
 }
 
 func requestDeviceToken(ctx context.Context, apiURL, deviceCode string) (*oauthTokenResponse, *oauthErrorResponse, error) {

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
+)
+
+func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	oldOpenBrowser := openBrowser
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+		openBrowser = oldOpenBrowser
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+	flagOutputFormat = "json"
+	openBrowser = func(string) error { return nil }
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_BEARER_TOKEN", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+
+	accessToken := "test-access-token"
+	workspaceID := "00000000-0000-0000-0000-000000000123"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			if r.Method != http.MethodPost {
+				t.Fatalf("expected POST, got %s", r.Method)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			if got := r.FormValue("client_id"); got != oauthClientID {
+				t.Fatalf("expected client_id %q, got %q", oauthClientID, got)
+			}
+			_ = json.NewEncoder(w).Encode(deviceCodeResponse{
+				DeviceCode:      "device-code",
+				UserCode:        "ABCD-EFGH",
+				VerificationURI: tsActivateURL(r),
+				ExpiresIn:       60,
+				Interval:        0,
+			})
+		case "/oauth/token":
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			if got := r.FormValue("grant_type"); got != "urn:ietf:params:oauth:grant-type:device_code" {
+				t.Fatalf("unexpected grant_type %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(oauthTokenResponse{
+				AccessToken:  accessToken,
+				ExpiresIn:    300,
+				RefreshToken: "test-refresh-token",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	root := NewRootCmd("test", "test")
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"login", "--api-url", ts.URL, "--no-browser", "--workspace-id", workspaceID})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())
+	}
+
+	if strings.Contains(stdout.String(), accessToken) || strings.Contains(stderr.String(), accessToken) {
+		t.Fatalf("login output exposed access token")
+	}
+	if !strings.Contains(stderr.String(), "ABCD-EFGH") {
+		t.Fatalf("expected login instructions to include user code, got %q", stderr.String())
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout.String())
+	}
+	if result["status"] != "logged_in" || result["profile"] != "default" {
+		t.Fatalf("unexpected login result: %+v", result)
+	}
+	if result["workspace_id"] != workspaceID {
+		t.Fatalf("expected workspace_id %q in result, got %q", workspaceID, result["workspace_id"])
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := cfg.Profiles["default"]
+	if profile.OAuth.AccessToken != accessToken {
+		t.Fatalf("access token was not saved")
+	}
+	if profile.OAuth.RefreshToken != "test-refresh-token" {
+		t.Fatalf("refresh token was not saved")
+	}
+	if profile.WorkspaceID != workspaceID {
+		t.Fatalf("workspace ID was not saved")
+	}
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("expected config permissions 0600, got %o", info.Mode().Perm())
+	}
+}
+
+func TestRefreshProfileToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		if got := r.FormValue("grant_type"); got != "refresh_token" {
+			t.Fatalf("unexpected grant_type %q", got)
+		}
+		if got := r.FormValue("refresh_token"); got != "old-refresh-token" {
+			t.Fatalf("unexpected refresh token %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(oauthTokenResponse{
+			AccessToken:  "new-access-token",
+			ExpiresIn:    300,
+			RefreshToken: "new-refresh-token",
+		})
+	}))
+	defer ts.Close()
+
+	token, err := refreshProfileToken(t.Context(), ts.URL, "old-refresh-token")
+	if err != nil {
+		t.Fatalf("refreshProfileToken returned error: %v", err)
+	}
+	if token.AccessToken != "new-access-token" || token.RefreshToken != "new-refresh-token" {
+		t.Fatalf("unexpected token response: %+v", token)
+	}
+}
+
+func tsActivateURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + r.Host + "/activate"
+}

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -35,7 +35,6 @@ func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.toml")
 	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
 	t.Setenv("LANGSMITH_API_KEY", "")
-	t.Setenv("LANGSMITH_BEARER_TOKEN", "")
 	t.Setenv("LANGSMITH_PROFILE", "")
 	t.Setenv("LANGSMITH_ENDPOINT", "")
 

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
 )
@@ -158,6 +159,37 @@ func TestRefreshProfileToken(t *testing.T) {
 	}
 	if token.AccessToken != "new-access-token" || token.RefreshToken != "new-refresh-token" {
 		t.Fatalf("unexpected token response: %+v", token)
+	}
+}
+
+func TestRefreshProfileTokenRequiresAccessToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(oauthTokenResponse{
+			ExpiresIn:    300,
+			RefreshToken: "new-refresh-token",
+		})
+	}))
+	defer ts.Close()
+
+	_, err := refreshProfileToken(t.Context(), ts.URL, "old-refresh-token")
+	if err == nil || !strings.Contains(err.Error(), "access token") {
+		t.Fatalf("expected missing access token error, got %v", err)
+	}
+}
+
+func TestNormalizeDeviceCodePollInterval(t *testing.T) {
+	if got := normalizeDeviceCodePollInterval(0); got != defaultDeviceCodePollInterval {
+		t.Fatalf("expected default interval, got %s", got)
+	}
+	if got := normalizeDeviceCodePollInterval(2 * time.Second); got != defaultDeviceCodePollInterval {
+		t.Fatalf("expected default interval for low value, got %s", got)
+	}
+	if got := normalizeDeviceCodePollInterval(7 * time.Second); got != 7*time.Second {
+		t.Fatalf("expected explicit interval, got %s", got)
 	}
 }
 

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -123,7 +124,7 @@ func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
 		t.Fatalf("expected config permissions 0600, got %o", info.Mode().Perm())
 	}
 }

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -33,7 +33,7 @@ func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
 	flagOutputFormat = "json"
 	openBrowser = func(string) error { return nil }
 
-	configPath := filepath.Join(t.TempDir(), "config.toml")
+	configPath := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
 	t.Setenv("LANGSMITH_API_KEY", "")
 	t.Setenv("LANGSMITH_PROFILE", "")

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -3,18 +3,42 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"sort"
 
 	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
+	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
+
+type profileListItem struct {
+	Name           string `json:"name"`
+	Active         bool   `json:"active"`
+	APIURL         string `json:"api_url,omitempty"`
+	WorkspaceID    string `json:"workspace_id,omitempty"`
+	Auth           string `json:"auth"`
+	OAuthExpiresAt string `json:"oauth_expires_at,omitempty"`
+}
 
 func newProfileCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "profile",
 		Short: "Manage saved LangSmith profiles",
 	}
+	cmd.AddCommand(newProfileListCmd())
 	cmd.AddCommand(newProfileSetWorkspaceCmd())
 	return cmd
+}
+
+func newProfileListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List saved profiles",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProfileList(cmd)
+		},
+	}
 }
 
 func newProfileSetWorkspaceCmd() *cobra.Command {
@@ -26,6 +50,75 @@ func newProfileSetWorkspaceCmd() *cobra.Command {
 			return runProfileSetWorkspace(cmd, args[0])
 		},
 	}
+}
+
+func runProfileList(cmd *cobra.Command) error {
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return err
+	}
+
+	activeName := cfg.ResolveProfileName(flagProfile, os.Getenv("LANGSMITH_PROFILE"))
+	items := make([]profileListItem, 0, len(cfg.Profiles))
+	for name, profile := range cfg.Profiles {
+		items = append(items, profileListItem{
+			Name:           name,
+			Active:         name == activeName,
+			APIURL:         profile.APIURL,
+			WorkspaceID:    profile.WorkspaceID,
+			Auth:           profileAuthType(profile),
+			OAuthExpiresAt: profile.OAuth.ExpiresAt,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Active != items[j].Active {
+			return items[i].Active
+		}
+		return items[i].Name < items[j].Name
+	})
+
+	if GetFormat() == "pretty" {
+		renderProfileTable(cmd, items)
+		return nil
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(items)
+}
+
+func profileAuthType(profile lsconfig.Profile) string {
+	switch {
+	case profile.AccessToken() != "":
+		return "oauth"
+	case profile.APIKey != "":
+		return "api_key"
+	default:
+		return "none"
+	}
+}
+
+func renderProfileTable(cmd *cobra.Command, profiles []profileListItem) {
+	table := tablewriter.NewWriter(cmd.OutOrStdout())
+	table.SetHeader([]string{"Active", "Name", "API URL", "Workspace ID", "Auth", "Expires At"})
+	table.SetBorder(false)
+	table.SetColumnSeparator("  ")
+	table.SetHeaderLine(true)
+	table.SetAutoWrapText(false)
+	for _, profile := range profiles {
+		active := ""
+		if profile.Active {
+			active = "*"
+		}
+		table.Append([]string{
+			active,
+			profile.Name,
+			profile.APIURL,
+			profile.WorkspaceID,
+			profile.Auth,
+			profile.OAuthExpiresAt,
+		})
+	}
+	table.Render()
 }
 
 func runProfileSetWorkspace(cmd *cobra.Command, workspaceID string) error {

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -21,6 +21,16 @@ type profileListItem struct {
 	OAuthExpiresAt string `json:"oauth_expires_at,omitempty"`
 }
 
+type profileShowItem struct {
+	Name           string `json:"name"`
+	Active         bool   `json:"active"`
+	APIURL         string `json:"api_url,omitempty"`
+	WorkspaceID    string `json:"workspace_id,omitempty"`
+	Auth           string `json:"auth"`
+	APIKey         string `json:"api_key,omitempty"`
+	OAuthExpiresAt string `json:"oauth_expires_at,omitempty"`
+}
+
 func newProfileCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "profile",
@@ -28,6 +38,9 @@ func newProfileCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newProfileCreateCmd())
 	cmd.AddCommand(newProfileListCmd())
+	cmd.AddCommand(newProfileShowCmd())
+	cmd.AddCommand(newProfileDeleteCmd())
+	cmd.AddCommand(newProfileUseCmd())
 	cmd.AddCommand(newProfileSetWorkspaceCmd())
 	return cmd
 }
@@ -57,6 +70,39 @@ func newProfileListCmd() *cobra.Command {
 		Short:   "List saved profiles",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runProfileList(cmd)
+		},
+	}
+}
+
+func newProfileShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show NAME",
+		Short: "Show a saved profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProfileShow(cmd, args[0])
+		},
+	}
+}
+
+func newProfileDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete NAME",
+		Short: "Delete a saved profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProfileDelete(cmd, args[0])
+		},
+	}
+}
+
+func newProfileUseCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "use NAME",
+		Short: "Set the current profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProfileUse(cmd, args[0])
 		},
 	}
 }
@@ -153,6 +199,91 @@ func profileCreateAPIURL() string {
 	return client.NormalizeURL(apiURL)
 }
 
+func runProfileShow(cmd *cobra.Command, profileName string) error {
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return err
+	}
+	profile, ok := cfg.Profiles[profileName]
+	if !ok {
+		return fmt.Errorf("profile %q not found", profileName)
+	}
+
+	activeName := cfg.ResolveProfileName(flagProfile, os.Getenv("LANGSMITH_PROFILE"))
+	item := profileShowItem{
+		Name:           profileName,
+		Active:         profileName == activeName,
+		APIURL:         profile.APIURL,
+		WorkspaceID:    profile.WorkspaceID,
+		Auth:           profileAuthType(profile),
+		OAuthExpiresAt: profile.OAuth.ExpiresAt,
+	}
+	if profile.APIKey != "" {
+		item.APIKey = lsconfig.MaskSecret(profile.APIKey)
+	}
+
+	if GetFormat() == "pretty" {
+		renderProfileShowTable(cmd, item)
+		return nil
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(item)
+}
+
+func runProfileDelete(cmd *cobra.Command, profileName string) error {
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return err
+	}
+	if _, ok := cfg.Profiles[profileName]; !ok {
+		return fmt.Errorf("profile %q not found", profileName)
+	}
+	delete(cfg.Profiles, profileName)
+	if cfg.CurrentProfile == profileName {
+		cfg.CurrentProfile = ""
+	}
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	if GetFormat() == "pretty" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Deleted profile %q\n", profileName)
+		return nil
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(map[string]string{
+		"status":  "deleted",
+		"profile": profileName,
+	})
+}
+
+func runProfileUse(cmd *cobra.Command, profileName string) error {
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return err
+	}
+	if _, ok := cfg.Profiles[profileName]; !ok {
+		return fmt.Errorf("profile %q not found", profileName)
+	}
+	cfg.CurrentProfile = profileName
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	if GetFormat() == "pretty" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Using profile %q\n", profileName)
+		return nil
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(map[string]string{
+		"status":  "switched",
+		"profile": profileName,
+	})
+}
+
 func runProfileList(cmd *cobra.Command) error {
 	cfg, err := lsconfig.Load()
 	if err != nil {
@@ -189,7 +320,7 @@ func runProfileList(cmd *cobra.Command) error {
 
 func profileAuthType(profile lsconfig.Profile) string {
 	switch {
-	case profile.AccessToken() != "":
+	case profile.AccessToken() != "" || profile.OAuth.RefreshToken != "":
 		return "oauth"
 	case profile.APIKey != "":
 		return "api_key"
@@ -219,6 +350,29 @@ func renderProfileTable(cmd *cobra.Command, profiles []profileListItem) {
 			profile.OAuthExpiresAt,
 		})
 	}
+	table.Render()
+}
+
+func renderProfileShowTable(cmd *cobra.Command, profile profileShowItem) {
+	table := tablewriter.NewWriter(cmd.OutOrStdout())
+	table.SetHeader([]string{"Active", "Name", "API URL", "Workspace ID", "Auth", "API Key", "Expires At"})
+	table.SetBorder(false)
+	table.SetColumnSeparator("  ")
+	table.SetHeaderLine(true)
+	table.SetAutoWrapText(false)
+	active := ""
+	if profile.Active {
+		active = "*"
+	}
+	table.Append([]string{
+		active,
+		profile.Name,
+		profile.APIURL,
+		profile.WorkspaceID,
+		profile.Auth,
+		profile.APIKey,
+		profile.OAuthExpiresAt,
+	})
 	table.Render()
 }
 

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/langchain-ai/langsmith-cli/internal/client"
 	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -25,8 +26,27 @@ func newProfileCmd() *cobra.Command {
 		Use:   "profile",
 		Short: "Manage saved LangSmith profiles",
 	}
+	cmd.AddCommand(newProfileCreateCmd())
 	cmd.AddCommand(newProfileListCmd())
 	cmd.AddCommand(newProfileSetWorkspaceCmd())
+	return cmd
+}
+
+func newProfileCreateCmd() *cobra.Command {
+	var (
+		workspaceID string
+		setCurrent  bool
+	)
+	cmd := &cobra.Command{
+		Use:   "create NAME",
+		Short: "Create an API-key profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProfileCreate(cmd, args[0], workspaceID, setCurrent)
+		},
+	}
+	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "Default workspace ID to save in the profile")
+	cmd.Flags().BoolVar(&setCurrent, "set-current", false, "Set the new profile as the current profile")
 	return cmd
 }
 
@@ -50,6 +70,87 @@ func newProfileSetWorkspaceCmd() *cobra.Command {
 			return runProfileSetWorkspace(cmd, args[0])
 		},
 	}
+}
+
+func runProfileCreate(cmd *cobra.Command, profileName, workspaceID string, setCurrent bool) error {
+	if err := validateProfileName(profileName); err != nil {
+		return err
+	}
+	if workspaceID != "" {
+		if err := validateWorkspaceID(workspaceID); err != nil {
+			return err
+		}
+	}
+
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return err
+	}
+	if cfg.Profiles == nil {
+		cfg.Profiles = make(map[string]lsconfig.Profile)
+	}
+	if _, exists := cfg.Profiles[profileName]; exists {
+		return fmt.Errorf("profile %q already exists", profileName)
+	}
+
+	apiKey := profileCreateAPIKey()
+	if apiKey == "" {
+		return fmt.Errorf("api key required; pass --api-key or set LANGSMITH_API_KEY")
+	}
+	apiURL := profileCreateAPIURL()
+
+	cfg.Profiles[profileName] = lsconfig.Profile{
+		APIKey:      apiKey,
+		APIURL:      apiURL,
+		WorkspaceID: workspaceID,
+	}
+	if cfg.CurrentProfile == "" || setCurrent {
+		cfg.CurrentProfile = profileName
+	}
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	if GetFormat() == "pretty" {
+		if cfg.CurrentProfile == profileName {
+			fmt.Fprintf(cmd.OutOrStdout(), "Created and selected profile %q\n", profileName)
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "Created profile %q\n", profileName)
+		}
+		return nil
+	}
+
+	result := map[string]any{
+		"status":  "created",
+		"profile": profileName,
+		"api_url": apiURL,
+		"auth":    "api_key",
+		"active":  cfg.CurrentProfile == profileName,
+	}
+	if workspaceID != "" {
+		result["workspace_id"] = workspaceID
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+func profileCreateAPIKey() string {
+	if flagAPIKey != "" {
+		return flagAPIKey
+	}
+	return os.Getenv("LANGSMITH_API_KEY")
+}
+
+func profileCreateAPIURL() string {
+	apiURL := lsconfig.DefaultAPIURL
+	if envURL := os.Getenv("LANGSMITH_ENDPOINT"); envURL != "" {
+		apiURL = envURL
+	}
+	if flagAPIURL != "" {
+		apiURL = flagAPIURL
+	}
+	return client.NormalizeURL(apiURL)
 }
 
 func runProfileList(cmd *cobra.Command) error {

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func newProfileCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "profile",
+		Short: "Manage saved LangSmith profiles",
+	}
+	cmd.AddCommand(newProfileSetWorkspaceCmd())
+	return cmd
+}
+
+func newProfileSetWorkspaceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set-workspace WORKSPACE_ID",
+		Short: "Set the default workspace for a profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProfileSetWorkspace(cmd, args[0])
+		},
+	}
+}
+
+func runProfileSetWorkspace(cmd *cobra.Command, workspaceID string) error {
+	if err := validateWorkspaceID(workspaceID); err != nil {
+		return err
+	}
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return err
+	}
+	if cfg.Profiles == nil {
+		cfg.Profiles = make(map[string]lsconfig.Profile)
+	}
+
+	profileName := loginProfileName(cfg)
+	if err := validateProfileName(profileName); err != nil {
+		return err
+	}
+	profile := cfg.Profiles[profileName]
+	profile.WorkspaceID = workspaceID
+	cfg.Profiles[profileName] = profile
+	if cfg.CurrentProfile == "" {
+		cfg.CurrentProfile = profileName
+	}
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	if GetFormat() == "pretty" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Set default workspace for profile %q\n", profileName)
+		return nil
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(map[string]string{
+		"status":       "workspace_set",
+		"profile":      profileName,
+		"workspace_id": workspaceID,
+	})
+}

--- a/internal/cmd/profile_test.go
+++ b/internal/cmd/profile_test.go
@@ -85,3 +85,64 @@ func TestProfileSetWorkspaceInvalidID(t *testing.T) {
 		t.Fatal("expected invalid workspace ID error")
 	}
 }
+
+func TestProfileListDoesNotExposeSecrets(t *testing.T) {
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+	}()
+	flagProfile = ""
+	flagOutputFormat = "json"
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_PROFILE", "")
+	accessToken := "test-access-token"
+	refreshToken := "test-refresh-token"
+	apiKey := "test-api-key"
+	if err := os.WriteFile(configPath, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_url": "https://dev.api.smith.langchain.com",
+      "workspace_id": "00000000-0000-0000-0000-000000000123",
+      "oauth": {
+        "access_token": "`+accessToken+`",
+        "refresh_token": "`+refreshToken+`",
+        "expires_at": "2026-04-30T00:00:00Z"
+      }
+    },
+    "local": {
+      "api_key": "`+apiKey+`",
+      "api_url": "http://localhost:1980"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, err := executeCommand(t, "profile", "list")
+	if err != nil {
+		t.Fatalf("profile list returned error: %v\nstdout: %s", err, stdout)
+	}
+	if strings.Contains(stdout, accessToken) || strings.Contains(stdout, refreshToken) || strings.Contains(stdout, apiKey) {
+		t.Fatalf("profile list output exposed a secret: %s", stdout)
+	}
+
+	var result []profileListItem
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 profiles, got %d", len(result))
+	}
+	if result[0].Name != "dev" || !result[0].Active || result[0].Auth != "oauth" {
+		t.Fatalf("unexpected active profile: %+v", result[0])
+	}
+	if result[1].Name != "local" || result[1].Auth != "api_key" {
+		t.Fatalf("unexpected second profile: %+v", result[1])
+	}
+}

--- a/internal/cmd/profile_test.go
+++ b/internal/cmd/profile_test.go
@@ -224,6 +224,207 @@ func TestProfileCreateInvalidWorkspaceID(t *testing.T) {
 	}
 }
 
+func TestProfileShowDoesNotExposeSecrets(t *testing.T) {
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+	}()
+	flagProfile = ""
+	flagOutputFormat = "json"
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_PROFILE", "")
+	apiKey := "test-profile-api-key"
+	accessToken := "test-access-token"
+	refreshToken := "test-refresh-token"
+	if err := os.WriteFile(configPath, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_key": "`+apiKey+`",
+      "api_url": "https://dev.api.smith.langchain.com",
+      "workspace_id": "00000000-0000-0000-0000-000000000123",
+      "oauth": {
+        "access_token": "`+accessToken+`",
+        "refresh_token": "`+refreshToken+`",
+        "expires_at": "2026-04-30T00:00:00Z"
+      }
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, err := executeCommand(t, "profile", "show", "dev")
+	if err != nil {
+		t.Fatalf("profile show returned error: %v\nstdout: %s", err, stdout)
+	}
+	if strings.Contains(stdout, apiKey) || strings.Contains(stdout, accessToken) || strings.Contains(stdout, refreshToken) {
+		t.Fatalf("profile show output exposed a secret: %s", stdout)
+	}
+
+	var result profileShowItem
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout)
+	}
+	if result.Name != "dev" || !result.Active || result.Auth != "oauth" {
+		t.Fatalf("unexpected profile show result: %+v", result)
+	}
+	if result.APIKey == "" || result.APIKey == apiKey {
+		t.Fatalf("expected masked api key, got %q", result.APIKey)
+	}
+	if result.OAuthExpiresAt != "2026-04-30T00:00:00Z" {
+		t.Fatalf("unexpected oauth expiry: %q", result.OAuthExpiresAt)
+	}
+}
+
+func TestProfileShowNotFound(t *testing.T) {
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "config.json"))
+
+	_, err := executeCommand(t, "profile", "show", "missing")
+	if err == nil {
+		t.Fatal("expected profile not found error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func TestProfileUse(t *testing.T) {
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+	}()
+	flagProfile = ""
+	flagOutputFormat = "json"
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	if err := os.WriteFile(configPath, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_key": "dev-api-key"
+    },
+    "prod": {
+      "api_key": "prod-api-key"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, err := executeCommand(t, "profile", "use", "prod")
+	if err != nil {
+		t.Fatalf("profile use returned error: %v\nstdout: %s", err, stdout)
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout)
+	}
+	if result["status"] != "switched" || result["profile"] != "prod" {
+		t.Fatalf("unexpected profile use result: %+v", result)
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.CurrentProfile != "prod" {
+		t.Fatalf("expected prod current profile, got %q", cfg.CurrentProfile)
+	}
+}
+
+func TestProfileUseNotFound(t *testing.T) {
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "config.json"))
+
+	_, err := executeCommand(t, "profile", "use", "missing")
+	if err == nil {
+		t.Fatal("expected profile not found error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func TestProfileDelete(t *testing.T) {
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+	}()
+	flagProfile = ""
+	flagOutputFormat = "json"
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	if err := os.WriteFile(configPath, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_key": "dev-api-key"
+    },
+    "prod": {
+      "api_key": "prod-api-key"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, err := executeCommand(t, "profile", "delete", "dev")
+	if err != nil {
+		t.Fatalf("profile delete returned error: %v\nstdout: %s", err, stdout)
+	}
+	if strings.Contains(stdout, "dev-api-key") {
+		t.Fatalf("profile delete output exposed api key: %s", stdout)
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout)
+	}
+	if result["status"] != "deleted" || result["profile"] != "dev" {
+		t.Fatalf("unexpected profile delete result: %+v", result)
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Profiles["dev"]; ok {
+		t.Fatal("expected dev profile to be deleted")
+	}
+	if _, ok := cfg.Profiles["prod"]; !ok {
+		t.Fatal("expected unrelated profile to remain")
+	}
+	if cfg.CurrentProfile != "" {
+		t.Fatalf("expected current profile to be cleared, got %q", cfg.CurrentProfile)
+	}
+}
+
+func TestProfileDeleteNotFound(t *testing.T) {
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "config.json"))
+
+	_, err := executeCommand(t, "profile", "delete", "missing")
+	if err == nil {
+		t.Fatal("expected profile not found error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
 func TestProfileSetWorkspace(t *testing.T) {
 	oldKey := flagAPIKey
 	oldURL := flagAPIURL

--- a/internal/cmd/profile_test.go
+++ b/internal/cmd/profile_test.go
@@ -26,11 +26,21 @@ func TestProfileSetWorkspace(t *testing.T) {
 	flagProfile = ""
 	flagOutputFormat = "json"
 
-	configPath := filepath.Join(t.TempDir(), "config.toml")
+	configPath := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
 	t.Setenv("LANGSMITH_PROFILE", "")
 	accessToken := "test-access-token"
-	if err := os.WriteFile(configPath, []byte("current_profile = \"local\"\n\n[local]\n\n[local.oauth]\naccess_token = \""+accessToken+"\"\n"), 0600); err != nil {
+	if err := os.WriteFile(configPath, []byte(`{
+  "current_profile": "local",
+  "profiles": {
+    "local": {
+      "oauth": {
+        "access_token": "`+accessToken+`"
+      }
+    }
+  }
+}
+`), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -68,7 +78,7 @@ func TestProfileSetWorkspaceInvalidID(t *testing.T) {
 	oldProfile := flagProfile
 	defer func() { flagProfile = oldProfile }()
 	flagProfile = ""
-	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "config.toml"))
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "config.json"))
 
 	_, err := executeCommand(t, "profile", "set-workspace", "not-a-uuid")
 	if err == nil {

--- a/internal/cmd/profile_test.go
+++ b/internal/cmd/profile_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
+)
+
+func TestProfileSetWorkspace(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+	flagOutputFormat = "json"
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_PROFILE", "")
+	accessToken := "test-access-token"
+	if err := os.WriteFile(configPath, []byte("current_profile = \"local\"\n\n[local]\n\n[local.oauth]\naccess_token = \""+accessToken+"\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	workspaceID := "00000000-0000-0000-0000-000000000456"
+	stdout, err := executeCommand(t, "profile", "set-workspace", workspaceID)
+	if err != nil {
+		t.Fatalf("set-workspace returned error: %v\nstdout: %s", err, stdout)
+	}
+	if strings.Contains(stdout, accessToken) {
+		t.Fatalf("profile output exposed access token")
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout)
+	}
+	if result["profile"] != "local" || result["workspace_id"] != workspaceID {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := cfg.Profiles["local"]
+	if profile.WorkspaceID != workspaceID {
+		t.Fatalf("expected workspace ID %q, got %q", workspaceID, profile.WorkspaceID)
+	}
+	if profile.OAuth.AccessToken != accessToken {
+		t.Fatalf("access token was not preserved")
+	}
+}
+
+func TestProfileSetWorkspaceInvalidID(t *testing.T) {
+	oldProfile := flagProfile
+	defer func() { flagProfile = oldProfile }()
+	flagProfile = ""
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "config.toml"))
+
+	_, err := executeCommand(t, "profile", "set-workspace", "not-a-uuid")
+	if err == nil {
+		t.Fatal("expected invalid workspace ID error")
+	}
+}

--- a/internal/cmd/profile_test.go
+++ b/internal/cmd/profile_test.go
@@ -10,6 +10,220 @@ import (
 	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
 )
 
+func TestProfileCreate(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+	flagOutputFormat = "json"
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	apiKey := "test-api-key"
+	workspaceID := "00000000-0000-0000-0000-000000000123"
+	stdout, err := executeCommand(t,
+		"profile", "create", "dev",
+		"--api-key", apiKey,
+		"--api-url", "https://api.smith.langchain.com/api/v1",
+		"--workspace-id", workspaceID,
+	)
+	if err != nil {
+		t.Fatalf("profile create returned error: %v\nstdout: %s", err, stdout)
+	}
+	if strings.Contains(stdout, apiKey) {
+		t.Fatalf("profile create output exposed api key: %s", stdout)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout)
+	}
+	if result["status"] != "created" || result["profile"] != "dev" || result["auth"] != "api_key" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if result["api_url"] != "https://api.smith.langchain.com" {
+		t.Fatalf("expected normalized api_url, got %+v", result["api_url"])
+	}
+	if result["workspace_id"] != workspaceID {
+		t.Fatalf("expected workspace_id %q, got %+v", workspaceID, result["workspace_id"])
+	}
+	if result["active"] != true {
+		t.Fatalf("expected first profile to be active, got %+v", result["active"])
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.CurrentProfile != "dev" {
+		t.Fatalf("expected dev current profile, got %q", cfg.CurrentProfile)
+	}
+	profile := cfg.Profiles["dev"]
+	if profile.APIKey != apiKey {
+		t.Fatalf("api key was not saved")
+	}
+	if profile.APIURL != "https://api.smith.langchain.com" {
+		t.Fatalf("expected normalized profile api url, got %q", profile.APIURL)
+	}
+	if profile.WorkspaceID != workspaceID {
+		t.Fatalf("expected workspace ID %q, got %q", workspaceID, profile.WorkspaceID)
+	}
+}
+
+func TestProfileCreateUsesEnvAPIKeyAndEndpoint(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+	flagOutputFormat = "json"
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_API_KEY", "env-api-key")
+	t.Setenv("LANGSMITH_ENDPOINT", "http://localhost:1980/api/v1")
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	stdout, err := executeCommand(t, "profile", "create", "local")
+	if err != nil {
+		t.Fatalf("profile create returned error: %v\nstdout: %s", err, stdout)
+	}
+	if strings.Contains(stdout, "env-api-key") {
+		t.Fatalf("profile create output exposed api key: %s", stdout)
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := cfg.Profiles["local"]
+	if profile.APIKey != "env-api-key" {
+		t.Fatalf("expected api key from env")
+	}
+	if profile.APIURL != "http://localhost:1980" {
+		t.Fatalf("expected normalized env endpoint, got %q", profile.APIURL)
+	}
+}
+
+func TestProfileCreateRequiresAPIKey(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "config.json"))
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	_, err := executeCommand(t, "profile", "create", "dev")
+	if err == nil {
+		t.Fatal("expected missing api key error")
+	}
+	if !strings.Contains(err.Error(), "api key required") {
+		t.Fatalf("expected api key required error, got %v", err)
+	}
+}
+
+func TestProfileCreateAlreadyExists(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+	if err := os.WriteFile(configPath, []byte(`{
+  "profiles": {
+    "dev": {
+      "api_key": "existing-api-key",
+      "api_url": "https://api.smith.langchain.com"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := executeCommand(t, "profile", "create", "dev", "--api-key", "new-api-key")
+	if err == nil {
+		t.Fatal("expected duplicate profile error")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected already exists error, got %v", err)
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Profiles["dev"].APIKey != "existing-api-key" {
+		t.Fatal("existing profile was overwritten")
+	}
+}
+
+func TestProfileCreateInvalidWorkspaceID(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "config.json"))
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	_, err := executeCommand(t, "profile", "create", "dev", "--api-key", "test-api-key", "--workspace-id", "not-a-uuid")
+	if err == nil {
+		t.Fatal("expected invalid workspace ID error")
+	}
+}
+
 func TestProfileSetWorkspace(t *testing.T) {
 	oldKey := flagAPIKey
 	oldURL := flagAPIURL

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -143,10 +143,10 @@ func resolveClientOptions(refreshOAuth bool) (client.Options, error) {
 	}
 
 	if v := os.Getenv("LANGSMITH_ENDPOINT"); v != "" {
-		opts.APIURL = v
+		opts.APIURL = client.NormalizeURL(v)
 	}
 	if flagAPIURL != "" {
-		opts.APIURL = flagAPIURL
+		opts.APIURL = client.NormalizeURL(flagAPIURL)
 	}
 
 	if v := os.Getenv("LANGSMITH_TENANT_ID"); v != "" {
@@ -160,7 +160,7 @@ func resolveClientOptions(refreshOAuth bool) (client.Options, error) {
 		opts.APIKey = flagAPIKey
 	case os.Getenv("LANGSMITH_API_KEY") != "":
 		opts.APIKey = os.Getenv("LANGSMITH_API_KEY")
-	case hasProfile && profile.AccessToken() != "":
+	case hasProfile && (profile.AccessToken() != "" || (refreshOAuth && profile.OAuth.RefreshToken != "")):
 		if refreshOAuth && profile.OAuth.RefreshToken != "" &&
 			(profile.AccessToken() == "" || profile.TokenExpiresSoon(time.Now(), time.Minute)) {
 			token, err := refreshProfileToken(context.Background(), opts.APIURL, profile.OAuth.RefreshToken)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -87,10 +87,10 @@ func GetAPIKey() string {
 	return opts.APIKey
 }
 
-// GetBearerToken resolves the bearer token from env → profile.
-func GetBearerToken() string {
+// GetOAuthAccessToken resolves the access token from the active OAuth profile.
+func GetOAuthAccessToken() string {
 	opts, _ := resolveClientOptions(false)
-	return opts.BearerToken
+	return opts.OAuthAccessToken
 }
 
 // GetAPIURL resolves the API URL from flag → env → profile → default.
@@ -116,7 +116,7 @@ func MustGetClient() *client.Client {
 	if err != nil {
 		ExitError(err.Error())
 	}
-	if opts.APIKey == "" && opts.BearerToken == "" {
+	if opts.APIKey == "" && opts.OAuthAccessToken == "" {
 		ExitError("not authenticated; run 'langsmith login', set LANGSMITH_API_KEY, or pass --api-key")
 	}
 	return client.NewWithOptions(opts)
@@ -160,8 +160,6 @@ func resolveClientOptions(refreshOAuth bool) (client.Options, error) {
 		opts.APIKey = flagAPIKey
 	case os.Getenv("LANGSMITH_API_KEY") != "":
 		opts.APIKey = os.Getenv("LANGSMITH_API_KEY")
-	case os.Getenv("LANGSMITH_BEARER_TOKEN") != "":
-		opts.BearerToken = os.Getenv("LANGSMITH_BEARER_TOKEN")
 	case hasProfile && profile.AccessToken() != "":
 		if refreshOAuth && profile.OAuth.RefreshToken != "" &&
 			(profile.AccessToken() == "" || profile.TokenExpiresSoon(time.Now(), time.Minute)) {
@@ -175,7 +173,7 @@ func resolveClientOptions(refreshOAuth bool) (client.Options, error) {
 				return opts, fmt.Errorf("saving refreshed OAuth token: %w", err)
 			}
 		}
-		opts.BearerToken = profile.AccessToken()
+		opts.OAuthAccessToken = profile.AccessToken()
 	case hasProfile && profile.APIKey != "":
 		opts.APIKey = profile.APIKey
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/cmd/api"
+	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +16,7 @@ import (
 var (
 	flagAPIKey       string
 	flagAPIURL       string
+	flagProfile      string
 	flagOutputFormat string
 )
 
@@ -28,8 +32,10 @@ access to traces, runs, datasets, evaluators, experiments, and threads.
 All commands output JSON by default for easy parsing.
 
 Authentication:
-  Set LANGSMITH_API_KEY as an environment variable, or pass --api-key.
+  Run 'langsmith login', set LANGSMITH_API_KEY, or pass --api-key.
   Optionally set LANGSMITH_ENDPOINT for self-hosted instances.
+  Use --profile or LANGSMITH_PROFILE to select a saved profile.
+  Set a default workspace with 'langsmith profile set-workspace <workspace-id>'.
   Set LANGSMITH_PROJECT as a default project name for trace/run queries.
 
 Quick start:
@@ -50,6 +56,7 @@ Output:
 
 	rootCmd.PersistentFlags().StringVar(&flagAPIKey, "api-key", "", "LangSmith API key [env: LANGSMITH_API_KEY]")
 	rootCmd.PersistentFlags().StringVar(&flagAPIURL, "api-url", "", "LangSmith API URL [env: LANGSMITH_ENDPOINT]")
+	rootCmd.PersistentFlags().StringVar(&flagProfile, "profile", "", "Named profile to use [env: LANGSMITH_PROFILE]")
 	rootCmd.PersistentFlags().StringVar(&flagOutputFormat, "format", "json", "Output format: json or pretty")
 
 	// Register all subcommand groups
@@ -65,32 +72,37 @@ Output:
 	rootCmd.AddCommand(newInsightsCmd())
 	rootCmd.AddCommand(newFleetCmd())
 	rootCmd.AddCommand(newPromptCmd())
+	rootCmd.AddCommand(newLoginCmd())
+	rootCmd.AddCommand(newProfileCmd())
+	rootCmd.AddCommand(newWorkspaceCmd())
 	rootCmd.AddCommand(newUpdateCmd(rawVersion))
 	rootCmd.AddCommand(api.NewCmd())
 
 	return rootCmd
 }
 
-// GetAPIKey resolves the API key from flag → env → error.
+// GetAPIKey resolves the API key from flag → env → profile.
 func GetAPIKey() string {
-	if flagAPIKey != "" {
-		return flagAPIKey
-	}
-	if v := os.Getenv("LANGSMITH_API_KEY"); v != "" {
-		return v
-	}
-	return ""
+	opts, _ := resolveClientOptions(false)
+	return opts.APIKey
 }
 
-// GetAPIURL resolves the API URL from flag → env → default.
+// GetBearerToken resolves the bearer token from env → profile.
+func GetBearerToken() string {
+	opts, _ := resolveClientOptions(false)
+	return opts.BearerToken
+}
+
+// GetAPIURL resolves the API URL from flag → env → profile → default.
 func GetAPIURL() string {
-	if flagAPIURL != "" {
-		return flagAPIURL
-	}
-	if v := os.Getenv("LANGSMITH_ENDPOINT"); v != "" {
-		return v
-	}
-	return "https://api.smith.langchain.com"
+	opts, _ := resolveClientOptions(false)
+	return opts.APIURL
+}
+
+// GetWorkspaceID resolves the workspace ID from env → profile.
+func GetWorkspaceID() string {
+	opts, _ := resolveClientOptions(false)
+	return opts.WorkspaceID
 }
 
 // GetFormat returns the output format.
@@ -100,11 +112,75 @@ func GetFormat() string {
 
 // MustGetClient creates a LangSmith client or exits with an error.
 func MustGetClient() *client.Client {
-	apiKey := GetAPIKey()
-	if apiKey == "" {
-		ExitError("LANGSMITH_API_KEY not set")
+	opts, err := resolveClientOptions(true)
+	if err != nil {
+		ExitError(err.Error())
 	}
-	return client.New(apiKey, GetAPIURL())
+	if opts.APIKey == "" && opts.BearerToken == "" {
+		ExitError("not authenticated; run 'langsmith login', set LANGSMITH_API_KEY, or pass --api-key")
+	}
+	return client.NewWithOptions(opts)
+}
+
+func resolveClientOptions(refreshOAuth bool) (client.Options, error) {
+	opts := client.Options{APIURL: lsconfig.DefaultAPIURL}
+
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return opts, err
+	}
+	envProfile := os.Getenv("LANGSMITH_PROFILE")
+	profileName, profile, hasProfile := cfg.ResolveProfile(flagProfile, envProfile)
+	if (flagProfile != "" || envProfile != "") && !hasProfile {
+		return opts, fmt.Errorf("profile not found: %s", profileName)
+	}
+
+	if hasProfile {
+		if profile.APIURL != "" {
+			opts.APIURL = profile.APIURL
+		}
+		opts.WorkspaceID = profile.WorkspaceID
+	}
+
+	if v := os.Getenv("LANGSMITH_ENDPOINT"); v != "" {
+		opts.APIURL = v
+	}
+	if flagAPIURL != "" {
+		opts.APIURL = flagAPIURL
+	}
+
+	if v := os.Getenv("LANGSMITH_TENANT_ID"); v != "" {
+		opts.WorkspaceID = v
+	}
+	if v := os.Getenv("LANGSMITH_WORKSPACE_ID"); v != "" {
+		opts.WorkspaceID = v
+	}
+	switch {
+	case flagAPIKey != "":
+		opts.APIKey = flagAPIKey
+	case os.Getenv("LANGSMITH_API_KEY") != "":
+		opts.APIKey = os.Getenv("LANGSMITH_API_KEY")
+	case os.Getenv("LANGSMITH_BEARER_TOKEN") != "":
+		opts.BearerToken = os.Getenv("LANGSMITH_BEARER_TOKEN")
+	case hasProfile && profile.AccessToken() != "":
+		if refreshOAuth && profile.OAuth.RefreshToken != "" &&
+			(profile.AccessToken() == "" || profile.TokenExpiresSoon(time.Now(), time.Minute)) {
+			token, err := refreshProfileToken(context.Background(), opts.APIURL, profile.OAuth.RefreshToken)
+			if err != nil {
+				return opts, fmt.Errorf("refreshing OAuth token for profile %q: %w; run 'langsmith login --profile %s' to reauthenticate", profileName, err, profileName)
+			}
+			applyTokenResponse(&profile, token, time.Now())
+			cfg.Profiles[profileName] = profile
+			if err := cfg.Save(); err != nil {
+				return opts, fmt.Errorf("saving refreshed OAuth token: %w", err)
+			}
+		}
+		opts.BearerToken = profile.AccessToken()
+	case hasProfile && profile.APIKey != "":
+		opts.APIKey = profile.APIKey
+	}
+
+	return opts, nil
 }
 
 // ExitError prints a JSON error to stderr and exits.

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -181,7 +181,7 @@ func TestGetAPIURL_DefaultValue(t *testing.T) {
 	}
 }
 
-func TestGetBearerToken_ProfileFallback(t *testing.T) {
+func TestGetOAuthAccessToken_ProfileFallback(t *testing.T) {
 	oldKey := flagAPIKey
 	oldURL := flagAPIURL
 	oldProfile := flagProfile
@@ -197,14 +197,13 @@ func TestGetBearerToken_ProfileFallback(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	t.Setenv("LANGSMITH_CONFIG_FILE", path)
 	t.Setenv("LANGSMITH_API_KEY", "")
-	t.Setenv("LANGSMITH_BEARER_TOKEN", "")
 	t.Setenv("LANGSMITH_ENDPOINT", "")
 	if err := os.WriteFile(path, []byte("current_profile = \"prod\"\n\n[prod]\napi_url = \"https://profile.example.com\"\nworkspace_id = \"ws-123\"\n\n[prod.oauth]\naccess_token = \"test-access-token\"\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
-	if got := GetBearerToken(); got != "test-access-token" {
-		t.Fatalf("expected profile bearer token, got %q", got)
+	if got := GetOAuthAccessToken(); got != "test-access-token" {
+		t.Fatalf("expected profile OAuth access token, got %q", got)
 	}
 	if got := GetAPIURL(); got != "https://profile.example.com" {
 		t.Fatalf("expected profile API URL, got %q", got)
@@ -234,8 +233,8 @@ func TestGetAPIKey_EnvOverridesProfileBearer(t *testing.T) {
 	if got := GetAPIKey(); got != "from-env" {
 		t.Fatalf("expected env API key, got %q", got)
 	}
-	if got := GetBearerToken(); got != "" {
-		t.Fatalf("expected profile bearer token to be ignored, got %q", got)
+	if got := GetOAuthAccessToken(); got != "" {
+		t.Fatalf("expected profile OAuth access token to be ignored, got %q", got)
 	}
 }
 

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -168,6 +171,23 @@ func TestGetAPIURL_EnvFallback(t *testing.T) {
 	}
 }
 
+func TestGetAPIURL_NormalizesOverrides(t *testing.T) {
+	old := flagAPIURL
+	defer func() { flagAPIURL = old }()
+	flagAPIURL = ""
+	isolateConfig(t)
+
+	t.Setenv("LANGSMITH_ENDPOINT", "https://env.example.com/api/v1")
+	if got := GetAPIURL(); got != "https://env.example.com" {
+		t.Fatalf("expected normalized env URL, got %q", got)
+	}
+
+	flagAPIURL = "https://flag.example.com/api/v1"
+	if got := GetAPIURL(); got != "https://flag.example.com" {
+		t.Fatalf("expected normalized flag URL, got %q", got)
+	}
+}
+
 func TestGetAPIURL_DefaultValue(t *testing.T) {
 	isolateConfig(t)
 	old := flagAPIURL
@@ -178,6 +198,66 @@ func TestGetAPIURL_DefaultValue(t *testing.T) {
 
 	if got := GetAPIURL(); got != "https://api.smith.langchain.com" {
 		t.Errorf("expected default URL, got %q", got)
+	}
+}
+
+func TestResolveClientOptionsRefreshesProfileWithoutAccessToken(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		if got := r.FormValue("refresh_token"); got != "old-refresh-token" {
+			t.Fatalf("unexpected refresh token %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(oauthTokenResponse{
+			AccessToken:  "new-access-token",
+			ExpiresIn:    300,
+			RefreshToken: "new-refresh-token",
+		})
+	}))
+	defer ts.Close()
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	if err := os.WriteFile(path, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_url": "`+ts.URL+`",
+      "oauth": {
+        "refresh_token": "old-refresh-token"
+      }
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	opts, err := resolveClientOptions(true)
+	if err != nil {
+		t.Fatalf("resolveClientOptions returned error: %v", err)
+	}
+	if opts.OAuthAccessToken != "new-access-token" {
+		t.Fatalf("expected refreshed OAuth token, got %q", opts.OAuthAccessToken)
 	}
 }
 

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -8,7 +8,7 @@ import (
 
 func isolateConfig(t *testing.T) {
 	t.Helper()
-	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "missing.toml"))
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "missing.json"))
 }
 
 // ---------- Command tree structure ----------
@@ -194,11 +194,23 @@ func TestGetOAuthAccessToken_ProfileFallback(t *testing.T) {
 	flagAPIURL = ""
 	flagProfile = ""
 
-	path := filepath.Join(t.TempDir(), "config.toml")
+	path := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("LANGSMITH_CONFIG_FILE", path)
 	t.Setenv("LANGSMITH_API_KEY", "")
 	t.Setenv("LANGSMITH_ENDPOINT", "")
-	if err := os.WriteFile(path, []byte("current_profile = \"prod\"\n\n[prod]\napi_url = \"https://profile.example.com\"\nworkspace_id = \"ws-123\"\n\n[prod.oauth]\naccess_token = \"test-access-token\"\n"), 0600); err != nil {
+	if err := os.WriteFile(path, []byte(`{
+  "current_profile": "prod",
+  "profiles": {
+    "prod": {
+      "api_url": "https://profile.example.com",
+      "workspace_id": "ws-123",
+      "oauth": {
+        "access_token": "test-access-token"
+      }
+    }
+  }
+}
+`), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -223,10 +235,19 @@ func TestGetAPIKey_EnvOverridesProfileBearer(t *testing.T) {
 	flagAPIKey = ""
 	flagProfile = ""
 
-	path := filepath.Join(t.TempDir(), "config.toml")
+	path := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("LANGSMITH_CONFIG_FILE", path)
 	t.Setenv("LANGSMITH_API_KEY", "from-env")
-	if err := os.WriteFile(path, []byte("[default]\n\n[default.oauth]\naccess_token = \"test-access-token\"\n"), 0600); err != nil {
+	if err := os.WriteFile(path, []byte(`{
+  "profiles": {
+    "default": {
+      "oauth": {
+        "access_token": "test-access-token"
+      }
+    }
+  }
+}
+`), 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -2,14 +2,20 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
+
+func isolateConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "missing.toml"))
+}
 
 // ---------- Command tree structure ----------
 
 func TestRootCmd_HasAllSubcommands(t *testing.T) {
 	root := NewRootCmd("1.0.0", "1.0.0")
-	expected := []string{"project", "trace", "run", "thread", "dataset", "example", "evaluator", "experiment", "self-update", "api"}
+	expected := []string{"project", "trace", "run", "thread", "dataset", "example", "evaluator", "experiment", "login", "profile", "workspace", "self-update", "api"}
 	cmds := root.Commands()
 
 	names := make(map[string]bool, len(cmds))
@@ -82,9 +88,21 @@ func TestRootCmd_PersistentFlags_Format(t *testing.T) {
 	}
 }
 
+func TestRootCmd_PersistentFlags_Profile(t *testing.T) {
+	root := NewRootCmd("dev", "dev")
+	f := root.PersistentFlags().Lookup("profile")
+	if f == nil {
+		t.Fatal("--profile flag not found")
+	}
+	if f.DefValue != "" {
+		t.Errorf("expected default empty, got %q", f.DefValue)
+	}
+}
+
 // ---------- getAPIKey ----------
 
 func TestGetAPIKey_FlagPrecedence(t *testing.T) {
+	isolateConfig(t)
 	old := flagAPIKey
 	defer func() { flagAPIKey = old }()
 
@@ -97,6 +115,7 @@ func TestGetAPIKey_FlagPrecedence(t *testing.T) {
 }
 
 func TestGetAPIKey_EnvFallback(t *testing.T) {
+	isolateConfig(t)
 	old := flagAPIKey
 	defer func() { flagAPIKey = old }()
 
@@ -109,6 +128,7 @@ func TestGetAPIKey_EnvFallback(t *testing.T) {
 }
 
 func TestGetAPIKey_Empty(t *testing.T) {
+	isolateConfig(t)
 	old := flagAPIKey
 	defer func() { flagAPIKey = old }()
 
@@ -123,6 +143,7 @@ func TestGetAPIKey_Empty(t *testing.T) {
 // ---------- getAPIURL ----------
 
 func TestGetAPIURL_FlagPrecedence(t *testing.T) {
+	isolateConfig(t)
 	old := flagAPIURL
 	defer func() { flagAPIURL = old }()
 
@@ -135,6 +156,7 @@ func TestGetAPIURL_FlagPrecedence(t *testing.T) {
 }
 
 func TestGetAPIURL_EnvFallback(t *testing.T) {
+	isolateConfig(t)
 	old := flagAPIURL
 	defer func() { flagAPIURL = old }()
 
@@ -147,6 +169,7 @@ func TestGetAPIURL_EnvFallback(t *testing.T) {
 }
 
 func TestGetAPIURL_DefaultValue(t *testing.T) {
+	isolateConfig(t)
 	old := flagAPIURL
 	defer func() { flagAPIURL = old }()
 
@@ -155,6 +178,64 @@ func TestGetAPIURL_DefaultValue(t *testing.T) {
 
 	if got := GetAPIURL(); got != "https://api.smith.langchain.com" {
 		t.Errorf("expected default URL, got %q", got)
+	}
+}
+
+func TestGetBearerToken_ProfileFallback(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_BEARER_TOKEN", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	if err := os.WriteFile(path, []byte("current_profile = \"prod\"\n\n[prod]\napi_url = \"https://profile.example.com\"\nworkspace_id = \"ws-123\"\n\n[prod.oauth]\naccess_token = \"test-access-token\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := GetBearerToken(); got != "test-access-token" {
+		t.Fatalf("expected profile bearer token, got %q", got)
+	}
+	if got := GetAPIURL(); got != "https://profile.example.com" {
+		t.Fatalf("expected profile API URL, got %q", got)
+	}
+	if got := GetWorkspaceID(); got != "ws-123" {
+		t.Fatalf("expected profile workspace, got %q", got)
+	}
+}
+
+func TestGetAPIKey_EnvOverridesProfileBearer(t *testing.T) {
+	oldKey := flagAPIKey
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagProfile = ""
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "from-env")
+	if err := os.WriteFile(path, []byte("[default]\n\n[default.oauth]\naccess_token = \"test-access-token\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := GetAPIKey(); got != "from-env" {
+		t.Fatalf("expected env API key, got %q", got)
+	}
+	if got := GetBearerToken(); got != "" {
+		t.Fatalf("expected profile bearer token to be ignored, got %q", got)
 	}
 }
 

--- a/internal/cmd/testutil_test.go
+++ b/internal/cmd/testutil_test.go
@@ -44,15 +44,18 @@ func setupTestEnv(t *testing.T, serverURL string) func() {
 	t.Helper()
 	oldKey := flagAPIKey
 	oldURL := flagAPIURL
+	oldProfile := flagProfile
 	oldFmt := flagOutputFormat
 
 	flagAPIKey = "test-api-key"
 	flagAPIURL = serverURL
+	flagProfile = ""
 	flagOutputFormat = "json"
 
 	return func() {
 		flagAPIKey = oldKey
 		flagAPIURL = oldURL
+		flagProfile = oldProfile
 		flagOutputFormat = oldFmt
 	}
 }

--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+type workspaceListItem struct {
+	ID             string   `json:"id"`
+	OrganizationID string   `json:"organization_id,omitempty"`
+	DisplayName    string   `json:"display_name"`
+	TenantHandle   string   `json:"tenant_handle,omitempty"`
+	CreatedAt      string   `json:"created_at,omitempty"`
+	IsPersonal     bool     `json:"is_personal"`
+	IsDeleted      bool     `json:"is_deleted"`
+	ReadOnly       bool     `json:"read_only"`
+	RoleID         string   `json:"role_id,omitempty"`
+	RoleName       string   `json:"role_name,omitempty"`
+	Permissions    []string `json:"permissions,omitempty"`
+	DataPlaneURL   string   `json:"data_plane_url,omitempty"`
+}
+
+func newWorkspaceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "workspace",
+		Short: "List and select LangSmith workspaces",
+	}
+	cmd.AddCommand(newWorkspaceListCmd())
+	cmd.AddCommand(newWorkspaceSetDefaultCmd())
+	return cmd
+}
+
+func newWorkspaceListCmd() *cobra.Command {
+	var includeDeleted bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List workspaces visible to the current profile",
+		Run: func(cmd *cobra.Command, args []string) {
+			c := MustGetClient()
+			endpoint := "/api/v1/workspaces"
+			if includeDeleted {
+				q := url.Values{"include_deleted": {"true"}}
+				endpoint += "?" + q.Encode()
+			}
+
+			var workspaces []workspaceListItem
+			if err := c.RawGet(context.Background(), endpoint, &workspaces); err != nil {
+				ExitErrorf("listing workspaces: %v", err)
+			}
+
+			if GetFormat() == "pretty" {
+				renderWorkspaceTable(cmd, workspaces)
+				return
+			}
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(workspaces); err != nil {
+				ExitErrorf("encoding workspaces: %v", err)
+			}
+		},
+	}
+	cmd.Flags().BoolVar(&includeDeleted, "include-deleted", false, "Include deleted workspaces")
+	return cmd
+}
+
+func newWorkspaceSetDefaultCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set-default WORKSPACE_ID",
+		Short: "Set the default workspace for the selected profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProfileSetWorkspace(cmd, args[0])
+		},
+	}
+}
+
+func renderWorkspaceTable(cmd *cobra.Command, workspaces []workspaceListItem) {
+	table := tablewriter.NewWriter(cmd.OutOrStdout())
+	table.SetHeader([]string{"Name", "ID", "Handle", "Role", "Deleted"})
+	table.SetBorder(false)
+	table.SetColumnSeparator("  ")
+	table.SetHeaderLine(true)
+	table.SetAutoWrapText(false)
+	for _, ws := range workspaces {
+		deleted := "false"
+		if ws.IsDeleted {
+			deleted = "true"
+		}
+		table.Append([]string{
+			ws.DisplayName,
+			ws.ID,
+			ws.TenantHandle,
+			workspaceRole(ws),
+			deleted,
+		})
+	}
+	table.Render()
+}
+
+func workspaceRole(ws workspaceListItem) string {
+	if ws.RoleName != "" {
+		return ws.RoleName
+	}
+	if ws.ReadOnly {
+		return "Read only"
+	}
+	if len(ws.Permissions) > 0 {
+		return fmt.Sprintf("%d permissions", len(ws.Permissions))
+	}
+	return ""
+}

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestWorkspaceList(t *testing.T) {
+	cleanup := setupTestEnv(t, "")
+	defer cleanup()
+	isolateConfig(t)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_BEARER_TOKEN", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/workspaces" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("X-Api-Key") != "test-api-key" {
+			t.Fatalf("expected API key header")
+		}
+		_ = json.NewEncoder(w).Encode([]workspaceListItem{{
+			ID:           "00000000-0000-0000-0000-000000000123",
+			DisplayName:  "Default Workspace",
+			TenantHandle: "default",
+			RoleName:     "Admin",
+		}})
+	})
+	stdout, err := executeCommand(t,
+		"--api-key", "test-api-key",
+		"--api-url", ts.URL,
+		"workspace", "list",
+	)
+	if err != nil {
+		t.Fatalf("workspace list returned error: %v\nstdout: %s", err, stdout)
+	}
+	if !strings.Contains(stdout, "Default Workspace") {
+		t.Fatalf("expected workspace in output, got %s", stdout)
+	}
+}
+
+func TestWorkspaceSetDefault(t *testing.T) {
+	cleanup := setupTestEnv(t, "")
+	defer cleanup()
+	isolateConfig(t)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_BEARER_TOKEN", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	workspaceID := "00000000-0000-0000-0000-000000000789"
+	stdout, err := executeCommand(t, "workspace", "set-default", workspaceID)
+	if err != nil {
+		t.Fatalf("workspace set-default returned error: %v\nstdout: %s", err, stdout)
+	}
+	if !strings.Contains(stdout, workspaceID) {
+		t.Fatalf("expected workspace ID in output, got %s", stdout)
+	}
+}

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -12,7 +12,6 @@ func TestWorkspaceList(t *testing.T) {
 	defer cleanup()
 	isolateConfig(t)
 	t.Setenv("LANGSMITH_API_KEY", "")
-	t.Setenv("LANGSMITH_BEARER_TOKEN", "")
 	t.Setenv("LANGSMITH_ENDPOINT", "")
 	t.Setenv("LANGSMITH_PROFILE", "")
 
@@ -49,7 +48,6 @@ func TestWorkspaceSetDefault(t *testing.T) {
 	defer cleanup()
 	isolateConfig(t)
 	t.Setenv("LANGSMITH_API_KEY", "")
-	t.Setenv("LANGSMITH_BEARER_TOKEN", "")
 	t.Setenv("LANGSMITH_ENDPOINT", "")
 	t.Setenv("LANGSMITH_PROFILE", "")
 

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -1,12 +1,40 @@
 package cmdutil
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
+	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
 	"github.com/spf13/cobra"
 )
+
+const oauthClientID = "langsmith-cli"
+
+type oauthTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+type oauthErrorResponse struct {
+	Code             string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+func (e *oauthErrorResponse) Error() string {
+	if e.ErrorDescription == "" {
+		return e.Code
+	}
+	return e.Code + ": " + e.ErrorDescription
+}
 
 // getFlagString looks up a string flag by checking Flags() (which includes
 // inherited persistent flags for child commands) and then PersistentFlags()
@@ -51,11 +79,144 @@ func ResolveFormat(cmd *cobra.Command) string {
 }
 
 // GetClient creates a LangSmith client from cobra flags, returning an error
-// if the API key is not set.
+// if no API key or bearer token is available.
 func GetClient(cmd *cobra.Command) (*client.Client, error) {
-	apiKey := ResolveAPIKey(cmd)
-	if apiKey == "" {
-		return nil, fmt.Errorf("LANGSMITH_API_KEY not set")
+	opts, err := ResolveClientOptions(cmd, true)
+	if err != nil {
+		return nil, err
 	}
-	return client.New(apiKey, ResolveAPIURL(cmd)), nil
+	if opts.APIKey == "" && opts.BearerToken == "" {
+		return nil, fmt.Errorf("not authenticated; run 'langsmith login', set LANGSMITH_API_KEY, or pass --api-key")
+	}
+	return client.NewWithOptions(opts), nil
+}
+
+// ResolveClientOptions resolves auth/routing from cobra flags, env, and saved
+// profiles. This mirrors the top-level CLI auth behavior for standalone
+// helpers such as `langsmith api`.
+func ResolveClientOptions(cmd *cobra.Command, refreshOAuth bool) (client.Options, error) {
+	opts := client.Options{APIURL: lsconfig.DefaultAPIURL}
+
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return opts, err
+	}
+	flagProfile := getFlagString(cmd, "profile")
+	envProfile := strings.TrimSpace(os.Getenv("LANGSMITH_PROFILE"))
+	profileName, profile, hasProfile := cfg.ResolveProfile(flagProfile, envProfile)
+	if (flagProfile != "" || envProfile != "") && !hasProfile {
+		return opts, fmt.Errorf("profile not found: %s", profileName)
+	}
+
+	if hasProfile {
+		if profile.APIURL != "" {
+			opts.APIURL = profile.APIURL
+		}
+		opts.WorkspaceID = profile.WorkspaceID
+	}
+
+	if v := os.Getenv("LANGSMITH_ENDPOINT"); v != "" {
+		opts.APIURL = client.NormalizeURL(v)
+	}
+	if v := getFlagString(cmd, "api-url"); v != "" {
+		opts.APIURL = client.NormalizeURL(v)
+	}
+
+	if v := os.Getenv("LANGSMITH_TENANT_ID"); v != "" {
+		opts.WorkspaceID = v
+	}
+	if v := os.Getenv("LANGSMITH_WORKSPACE_ID"); v != "" {
+		opts.WorkspaceID = v
+	}
+
+	switch {
+	case getFlagString(cmd, "api-key") != "":
+		opts.APIKey = getFlagString(cmd, "api-key")
+	case os.Getenv("LANGSMITH_API_KEY") != "":
+		opts.APIKey = os.Getenv("LANGSMITH_API_KEY")
+	case os.Getenv("LANGSMITH_BEARER_TOKEN") != "":
+		opts.BearerToken = os.Getenv("LANGSMITH_BEARER_TOKEN")
+	case hasProfile && profile.AccessToken() != "":
+		if refreshOAuth && profile.OAuth.RefreshToken != "" &&
+			(profile.AccessToken() == "" || profile.TokenExpiresSoon(time.Now(), time.Minute)) {
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			token, err := refreshProfileToken(ctx, opts.APIURL, profile.OAuth.RefreshToken)
+			if err != nil {
+				return opts, fmt.Errorf("refreshing OAuth token for profile %q: %w; run 'langsmith login --profile %s' to reauthenticate", profileName, err, profileName)
+			}
+			applyTokenResponse(&profile, token, time.Now())
+			cfg.Profiles[profileName] = profile
+			if err := cfg.Save(); err != nil {
+				return opts, fmt.Errorf("saving refreshed OAuth token: %w", err)
+			}
+		}
+		opts.BearerToken = profile.AccessToken()
+	case hasProfile && profile.APIKey != "":
+		opts.APIKey = profile.APIKey
+	}
+
+	return opts, nil
+}
+
+func refreshProfileToken(ctx context.Context, apiURL, refreshToken string) (*oauthTokenResponse, error) {
+	values := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {oauthClientID},
+		"refresh_token": {refreshToken},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, oauthURL(apiURL, "/oauth/token"), strings.NewReader(values.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, decodeOAuthError(body, resp.StatusCode)
+	}
+	var token oauthTokenResponse
+	if err := json.Unmarshal(body, &token); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	if token.AccessToken == "" {
+		return nil, fmt.Errorf("token response did not include an access token")
+	}
+	return &token, nil
+}
+
+func applyTokenResponse(profile *lsconfig.Profile, token *oauthTokenResponse, now time.Time) {
+	profile.OAuth.AccessToken = token.AccessToken
+	if token.RefreshToken != "" {
+		profile.OAuth.RefreshToken = token.RefreshToken
+	}
+	if token.ExpiresIn > 0 {
+		profile.OAuth.ExpiresAt = now.Add(time.Duration(token.ExpiresIn) * time.Second).UTC().Format(time.RFC3339)
+	}
+}
+
+func decodeOAuthError(body []byte, statusCode int) *oauthErrorResponse {
+	var oauthErr oauthErrorResponse
+	if err := json.Unmarshal(body, &oauthErr); err != nil || oauthErr.Code == "" {
+		oauthErr = oauthErrorResponse{
+			Code:             fmt.Sprintf("http_%d", statusCode),
+			ErrorDescription: strings.TrimSpace(string(body)),
+		}
+	}
+	return &oauthErr
+}
+
+func oauthURL(apiURL, path string) string {
+	return strings.TrimRight(client.NormalizeURL(apiURL), "/") + path
 }

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -79,13 +79,13 @@ func ResolveFormat(cmd *cobra.Command) string {
 }
 
 // GetClient creates a LangSmith client from cobra flags, returning an error
-// if no API key or bearer token is available.
+// if no API key or OAuth access token is available.
 func GetClient(cmd *cobra.Command) (*client.Client, error) {
 	opts, err := ResolveClientOptions(cmd, true)
 	if err != nil {
 		return nil, err
 	}
-	if opts.APIKey == "" && opts.BearerToken == "" {
+	if opts.APIKey == "" && opts.OAuthAccessToken == "" {
 		return nil, fmt.Errorf("not authenticated; run 'langsmith login', set LANGSMITH_API_KEY, or pass --api-key")
 	}
 	return client.NewWithOptions(opts), nil
@@ -134,8 +134,6 @@ func ResolveClientOptions(cmd *cobra.Command, refreshOAuth bool) (client.Options
 		opts.APIKey = getFlagString(cmd, "api-key")
 	case os.Getenv("LANGSMITH_API_KEY") != "":
 		opts.APIKey = os.Getenv("LANGSMITH_API_KEY")
-	case os.Getenv("LANGSMITH_BEARER_TOKEN") != "":
-		opts.BearerToken = os.Getenv("LANGSMITH_BEARER_TOKEN")
 	case hasProfile && profile.AccessToken() != "":
 		if refreshOAuth && profile.OAuth.RefreshToken != "" &&
 			(profile.AccessToken() == "" || profile.TokenExpiresSoon(time.Now(), time.Minute)) {
@@ -153,7 +151,7 @@ func ResolveClientOptions(cmd *cobra.Command, refreshOAuth bool) (client.Options
 				return opts, fmt.Errorf("saving refreshed OAuth token: %w", err)
 			}
 		}
-		opts.BearerToken = profile.AccessToken()
+		opts.OAuthAccessToken = profile.AccessToken()
 	case hasProfile && profile.APIKey != "":
 		opts.APIKey = profile.APIKey
 	}

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -134,7 +134,7 @@ func ResolveClientOptions(cmd *cobra.Command, refreshOAuth bool) (client.Options
 		opts.APIKey = getFlagString(cmd, "api-key")
 	case os.Getenv("LANGSMITH_API_KEY") != "":
 		opts.APIKey = os.Getenv("LANGSMITH_API_KEY")
-	case hasProfile && profile.AccessToken() != "":
+	case hasProfile && (profile.AccessToken() != "" || (refreshOAuth && profile.OAuth.RefreshToken != "")):
 		if refreshOAuth && profile.OAuth.RefreshToken != "" &&
 			(profile.AccessToken() == "" || profile.TokenExpiresSoon(time.Now(), time.Minute)) {
 			ctx := cmd.Context()

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -1,6 +1,8 @@
 package cmdutil
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -10,6 +12,7 @@ func newTestCmd() *cobra.Command {
 	root := &cobra.Command{Use: "test"}
 	root.PersistentFlags().String("api-key", "", "")
 	root.PersistentFlags().String("api-url", "", "")
+	root.PersistentFlags().String("profile", "", "")
 	root.PersistentFlags().String("format", "json", "")
 	return root
 }
@@ -102,9 +105,54 @@ func TestGetClient_Success(t *testing.T) {
 
 func TestGetClient_MissingKey(t *testing.T) {
 	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "missing.toml"))
 	cmd := newTestCmd()
 	_, err := GetClient(cmd)
 	if err == nil {
 		t.Fatal("expected error for missing API key")
+	}
+}
+
+func TestGetClient_ProfileBearer(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_BEARER_TOKEN", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	if err := os.WriteFile(path, []byte("current_profile = \"local\"\n\n[local]\napi_url = \"http://localhost:1980\"\nworkspace_id = \"ws-123\"\n\n[local.oauth]\naccess_token = \"test-access-token\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTestCmd()
+	c, err := GetClient(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.BearerToken() != "test-access-token" {
+		t.Fatalf("expected bearer token from profile")
+	}
+	if c.APIURL() != "http://localhost:1980" {
+		t.Fatalf("expected profile API URL, got %q", c.APIURL())
+	}
+}
+
+func TestResolveClientOptions_EnvAPIKeyOverridesProfileBearer(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "from-env")
+	if err := os.WriteFile(path, []byte("[default]\n\n[default.oauth]\naccess_token = \"test-access-token\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTestCmd()
+	opts, err := ResolveClientOptions(cmd, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.APIKey != "from-env" {
+		t.Fatalf("expected env API key, got %q", opts.APIKey)
+	}
+	if opts.BearerToken != "" {
+		t.Fatalf("expected profile bearer token to be ignored")
 	}
 }

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -105,7 +105,7 @@ func TestGetClient_Success(t *testing.T) {
 
 func TestGetClient_MissingKey(t *testing.T) {
 	t.Setenv("LANGSMITH_API_KEY", "")
-	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "missing.toml"))
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "missing.json"))
 	cmd := newTestCmd()
 	_, err := GetClient(cmd)
 	if err == nil {
@@ -114,11 +114,23 @@ func TestGetClient_MissingKey(t *testing.T) {
 }
 
 func TestGetClient_ProfileBearer(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "config.toml")
+	path := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("LANGSMITH_CONFIG_FILE", path)
 	t.Setenv("LANGSMITH_API_KEY", "")
 	t.Setenv("LANGSMITH_ENDPOINT", "")
-	if err := os.WriteFile(path, []byte("current_profile = \"local\"\n\n[local]\napi_url = \"http://localhost:1980\"\nworkspace_id = \"ws-123\"\n\n[local.oauth]\naccess_token = \"test-access-token\"\n"), 0600); err != nil {
+	if err := os.WriteFile(path, []byte(`{
+  "current_profile": "local",
+  "profiles": {
+    "local": {
+      "api_url": "http://localhost:1980",
+      "workspace_id": "ws-123",
+      "oauth": {
+        "access_token": "test-access-token"
+      }
+    }
+  }
+}
+`), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -136,10 +148,19 @@ func TestGetClient_ProfileBearer(t *testing.T) {
 }
 
 func TestResolveClientOptions_EnvAPIKeyOverridesProfileBearer(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "config.toml")
+	path := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("LANGSMITH_CONFIG_FILE", path)
 	t.Setenv("LANGSMITH_API_KEY", "from-env")
-	if err := os.WriteFile(path, []byte("[default]\n\n[default.oauth]\naccess_token = \"test-access-token\"\n"), 0600); err != nil {
+	if err := os.WriteFile(path, []byte(`{
+  "profiles": {
+    "default": {
+      "oauth": {
+        "access_token": "test-access-token"
+      }
+    }
+  }
+}
+`), 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -117,7 +117,6 @@ func TestGetClient_ProfileBearer(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	t.Setenv("LANGSMITH_CONFIG_FILE", path)
 	t.Setenv("LANGSMITH_API_KEY", "")
-	t.Setenv("LANGSMITH_BEARER_TOKEN", "")
 	t.Setenv("LANGSMITH_ENDPOINT", "")
 	if err := os.WriteFile(path, []byte("current_profile = \"local\"\n\n[local]\napi_url = \"http://localhost:1980\"\nworkspace_id = \"ws-123\"\n\n[local.oauth]\naccess_token = \"test-access-token\"\n"), 0600); err != nil {
 		t.Fatal(err)
@@ -128,8 +127,8 @@ func TestGetClient_ProfileBearer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if c.BearerToken() != "test-access-token" {
-		t.Fatalf("expected bearer token from profile")
+	if c.OAuthAccessToken() != "test-access-token" {
+		t.Fatalf("expected OAuth access token from profile")
 	}
 	if c.APIURL() != "http://localhost:1980" {
 		t.Fatalf("expected profile API URL, got %q", c.APIURL())
@@ -152,7 +151,7 @@ func TestResolveClientOptions_EnvAPIKeyOverridesProfileBearer(t *testing.T) {
 	if opts.APIKey != "from-env" {
 		t.Fatalf("expected env API key, got %q", opts.APIKey)
 	}
-	if opts.BearerToken != "" {
-		t.Fatalf("expected profile bearer token to be ignored")
+	if opts.OAuthAccessToken != "" {
+		t.Fatalf("expected profile OAuth access token to be ignored")
 	}
 }

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -1,6 +1,9 @@
 package cmdutil
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -174,5 +177,54 @@ func TestResolveClientOptions_EnvAPIKeyOverridesProfileBearer(t *testing.T) {
 	}
 	if opts.OAuthAccessToken != "" {
 		t.Fatalf("expected profile OAuth access token to be ignored")
+	}
+}
+
+func TestResolveClientOptionsRefreshesProfileWithoutAccessToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		if got := r.FormValue("refresh_token"); got != "old-refresh-token" {
+			t.Fatalf("unexpected refresh token %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(oauthTokenResponse{
+			AccessToken:  "new-access-token",
+			ExpiresIn:    300,
+			RefreshToken: "new-refresh-token",
+		})
+	}))
+	defer ts.Close()
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	if err := os.WriteFile(path, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_url": "`+ts.URL+`",
+      "oauth": {
+        "refresh_token": "old-refresh-token"
+      }
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTestCmd()
+	opts, err := ResolveClientOptions(cmd, true)
+	if err != nil {
+		t.Fatalf("ResolveClientOptions returned error: %v", err)
+	}
+	if opts.OAuthAccessToken != "new-access-token" {
+		t.Fatalf("expected refreshed OAuth token, got %q", opts.OAuthAccessToken)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,14 +1,11 @@
 package config
 
 import (
-	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
-	"strconv"
-	"strings"
 	"time"
 )
 
@@ -19,23 +16,23 @@ const (
 
 // Profile represents one named LangSmith CLI profile.
 type Profile struct {
-	APIKey      string
-	APIURL      string
-	WorkspaceID string
-	OAuth       OAuth
+	APIKey      string `json:"api_key,omitempty"`
+	APIURL      string `json:"api_url,omitempty"`
+	WorkspaceID string `json:"workspace_id,omitempty"`
+	OAuth       OAuth  `json:"oauth,omitempty"`
 }
 
 // OAuth stores OAuth tokens written by `langsmith login`.
 type OAuth struct {
-	AccessToken  string
-	RefreshToken string
-	ExpiresAt    string
+	AccessToken  string `json:"access_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	ExpiresAt    string `json:"expires_at,omitempty"`
 }
 
 // Config is the on-disk LangSmith CLI config.
 type Config struct {
-	CurrentProfile string
-	Profiles       map[string]Profile
+	CurrentProfile string             `json:"current_profile,omitempty"`
+	Profiles       map[string]Profile `json:"profiles,omitempty"`
 }
 
 // DefaultConfigPath returns the LangSmith CLI config path.
@@ -47,7 +44,7 @@ func DefaultConfigPath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolving home directory: %w", err)
 	}
-	return filepath.Join(home, ".langsmith", "config.toml"), nil
+	return filepath.Join(home, ".langsmith", "config.json"), nil
 }
 
 // Load reads the default config path. Missing files return an empty config.
@@ -63,86 +60,21 @@ func Load() (*Config, error) {
 func LoadFrom(path string) (*Config, error) {
 	cfg := &Config{Profiles: make(map[string]Profile)}
 
-	f, err := os.Open(path)
+	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return cfg, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("opening config: %w", err)
-	}
-	defer f.Close()
-
-	var section string
-	scanner := bufio.NewScanner(f)
-	lineNo := 0
-	for scanner.Scan() {
-		lineNo++
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
-			if section == "" {
-				return nil, fmt.Errorf("parsing config line %d: empty profile section", lineNo)
-			}
-			profileName, _, _ := strings.Cut(section, ".")
-			if _, ok := cfg.Profiles[profileName]; !ok {
-				cfg.Profiles[profileName] = Profile{}
-			}
-			continue
-		}
-
-		key, rawValue, ok := strings.Cut(line, "=")
-		if !ok {
-			return nil, fmt.Errorf("parsing config line %d: expected key = value", lineNo)
-		}
-		key = strings.TrimSpace(key)
-		value, err := parseStringValue(strings.TrimSpace(rawValue))
-		if err != nil {
-			return nil, fmt.Errorf("parsing config line %d: %w", lineNo, err)
-		}
-
-		if section == "" {
-			if key == "current_profile" {
-				cfg.CurrentProfile = value
-			}
-			continue
-		}
-
-		profileName, subsection, hasSubsection := strings.Cut(section, ".")
-		profile := cfg.Profiles[profileName]
-		switch key {
-		case "api_key":
-			if !hasSubsection {
-				profile.APIKey = value
-			}
-		case "api_url":
-			if !hasSubsection {
-				profile.APIURL = value
-			}
-		case "workspace_id":
-			if !hasSubsection {
-				profile.WorkspaceID = value
-			}
-		case "access_token":
-			if subsection == "oauth" {
-				profile.OAuth.AccessToken = value
-			}
-		case "refresh_token":
-			if subsection == "oauth" {
-				profile.OAuth.RefreshToken = value
-			}
-		case "expires_at":
-			if subsection == "oauth" {
-				profile.OAuth.ExpiresAt = value
-			}
-		}
-		cfg.Profiles[profileName] = profile
-	}
-	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("reading config: %w", err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return cfg, nil
+	}
+	if err := json.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parsing config JSON: %w", err)
+	}
+	if cfg.Profiles == nil {
+		cfg.Profiles = make(map[string]Profile)
 	}
 	return cfg, nil
 }
@@ -166,31 +98,10 @@ func (c *Config) SaveTo(path string) error {
 	}
 
 	var buf bytes.Buffer
-	if c.CurrentProfile != "" {
-		fmt.Fprintf(&buf, "current_profile = %s\n", strconv.Quote(c.CurrentProfile))
-	}
-
-	names := make([]string, 0, len(c.Profiles))
-	for name := range c.Profiles {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	for _, name := range names {
-		p := c.Profiles[name]
-		if buf.Len() > 0 {
-			buf.WriteByte('\n')
-		}
-		fmt.Fprintf(&buf, "[%s]\n", name)
-		writeString(&buf, "api_key", p.APIKey)
-		writeString(&buf, "api_url", p.APIURL)
-		writeString(&buf, "workspace_id", p.WorkspaceID)
-		if p.OAuth.AccessToken != "" || p.OAuth.RefreshToken != "" || p.OAuth.ExpiresAt != "" {
-			fmt.Fprintf(&buf, "\n[%s.oauth]\n", name)
-			writeString(&buf, "access_token", p.OAuth.AccessToken)
-			writeString(&buf, "refresh_token", p.OAuth.RefreshToken)
-			writeString(&buf, "expires_at", p.OAuth.ExpiresAt)
-		}
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(c); err != nil {
+		return fmt.Errorf("encoding config JSON: %w", err)
 	}
 
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
@@ -266,25 +177,4 @@ func MaskSecret(value string) string {
 		return "****"
 	}
 	return value[:8] + "..." + value[len(value)-4:]
-}
-
-func parseStringValue(raw string) (string, error) {
-	if raw == "" {
-		return "", nil
-	}
-	if strings.HasPrefix(raw, "\"") || strings.HasPrefix(raw, "`") {
-		v, err := strconv.Unquote(raw)
-		if err != nil {
-			return "", fmt.Errorf("invalid quoted string: %w", err)
-		}
-		return v, nil
-	}
-	return raw, nil
-}
-
-func writeString(buf *bytes.Buffer, key, value string) {
-	if value == "" {
-		return
-	}
-	fmt.Fprintf(buf, "%s = %s\n", key, strconv.Quote(value))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,290 @@
+package config
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	ConfigFileEnv = "LANGSMITH_CONFIG_FILE"
+	DefaultAPIURL = "https://api.smith.langchain.com"
+)
+
+// Profile represents one named LangSmith CLI profile.
+type Profile struct {
+	APIKey      string
+	APIURL      string
+	WorkspaceID string
+	OAuth       OAuth
+}
+
+// OAuth stores OAuth tokens written by `langsmith login`.
+type OAuth struct {
+	AccessToken  string
+	RefreshToken string
+	ExpiresAt    string
+}
+
+// Config is the on-disk LangSmith CLI config.
+type Config struct {
+	CurrentProfile string
+	Profiles       map[string]Profile
+}
+
+// DefaultConfigPath returns the LangSmith CLI config path.
+func DefaultConfigPath() (string, error) {
+	if p := os.Getenv(ConfigFileEnv); p != "" {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, ".langsmith", "config.toml"), nil
+}
+
+// Load reads the default config path. Missing files return an empty config.
+func Load() (*Config, error) {
+	path, err := DefaultConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	return LoadFrom(path)
+}
+
+// LoadFrom reads a config file. Missing files return an empty config.
+func LoadFrom(path string) (*Config, error) {
+	cfg := &Config{Profiles: make(map[string]Profile)}
+
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return cfg, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("opening config: %w", err)
+	}
+	defer f.Close()
+
+	var section string
+	scanner := bufio.NewScanner(f)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+			if section == "" {
+				return nil, fmt.Errorf("parsing config line %d: empty profile section", lineNo)
+			}
+			profileName, _, _ := strings.Cut(section, ".")
+			if _, ok := cfg.Profiles[profileName]; !ok {
+				cfg.Profiles[profileName] = Profile{}
+			}
+			continue
+		}
+
+		key, rawValue, ok := strings.Cut(line, "=")
+		if !ok {
+			return nil, fmt.Errorf("parsing config line %d: expected key = value", lineNo)
+		}
+		key = strings.TrimSpace(key)
+		value, err := parseStringValue(strings.TrimSpace(rawValue))
+		if err != nil {
+			return nil, fmt.Errorf("parsing config line %d: %w", lineNo, err)
+		}
+
+		if section == "" {
+			if key == "current_profile" {
+				cfg.CurrentProfile = value
+			}
+			continue
+		}
+
+		profileName, subsection, hasSubsection := strings.Cut(section, ".")
+		profile := cfg.Profiles[profileName]
+		switch key {
+		case "api_key":
+			if !hasSubsection {
+				profile.APIKey = value
+			}
+		case "api_url":
+			if !hasSubsection {
+				profile.APIURL = value
+			}
+		case "workspace_id":
+			if !hasSubsection {
+				profile.WorkspaceID = value
+			}
+		case "access_token":
+			if subsection == "oauth" {
+				profile.OAuth.AccessToken = value
+			}
+		case "refresh_token":
+			if subsection == "oauth" {
+				profile.OAuth.RefreshToken = value
+			}
+		case "expires_at":
+			if subsection == "oauth" {
+				profile.OAuth.ExpiresAt = value
+			}
+		}
+		cfg.Profiles[profileName] = profile
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+	return cfg, nil
+}
+
+// Save writes the config to the default config path with owner-only permissions.
+func (c *Config) Save() error {
+	path, err := DefaultConfigPath()
+	if err != nil {
+		return err
+	}
+	return c.SaveTo(path)
+}
+
+// SaveTo writes the config to path with owner-only permissions.
+func (c *Config) SaveTo(path string) error {
+	if c.Profiles == nil {
+		c.Profiles = make(map[string]Profile)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if c.CurrentProfile != "" {
+		fmt.Fprintf(&buf, "current_profile = %s\n", strconv.Quote(c.CurrentProfile))
+	}
+
+	names := make([]string, 0, len(c.Profiles))
+	for name := range c.Profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		p := c.Profiles[name]
+		if buf.Len() > 0 {
+			buf.WriteByte('\n')
+		}
+		fmt.Fprintf(&buf, "[%s]\n", name)
+		writeString(&buf, "api_key", p.APIKey)
+		writeString(&buf, "api_url", p.APIURL)
+		writeString(&buf, "workspace_id", p.WorkspaceID)
+		if p.OAuth.AccessToken != "" || p.OAuth.RefreshToken != "" || p.OAuth.ExpiresAt != "" {
+			fmt.Fprintf(&buf, "\n[%s.oauth]\n", name)
+			writeString(&buf, "access_token", p.OAuth.AccessToken)
+			writeString(&buf, "refresh_token", p.OAuth.RefreshToken)
+			writeString(&buf, "expires_at", p.OAuth.ExpiresAt)
+		}
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("opening config for write: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(buf.Bytes()); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+	if err := f.Chmod(0600); err != nil {
+		return fmt.Errorf("setting config permissions: %w", err)
+	}
+	return nil
+}
+
+// ResolveProfileName returns the active profile name by precedence.
+func (c *Config) ResolveProfileName(flagProfile, envProfile string) string {
+	if flagProfile != "" {
+		return flagProfile
+	}
+	if envProfile != "" {
+		return envProfile
+	}
+	if c.CurrentProfile != "" {
+		return c.CurrentProfile
+	}
+	if _, ok := c.Profiles["default"]; ok {
+		return "default"
+	}
+	return ""
+}
+
+// ResolveProfile returns the active profile by precedence.
+func (c *Config) ResolveProfile(flagProfile, envProfile string) (string, Profile, bool) {
+	name := c.ResolveProfileName(flagProfile, envProfile)
+	if name == "" {
+		return "", Profile{}, false
+	}
+	p, ok := c.Profiles[name]
+	return name, p, ok
+}
+
+// AccessToken returns the OAuth access token to use for bearer auth.
+func (p Profile) AccessToken() string {
+	return p.OAuth.AccessToken
+}
+
+// TokenExpiresAtTime parses oauth.expires_at.
+func (p Profile) TokenExpiresAtTime() (time.Time, bool) {
+	if p.OAuth.ExpiresAt == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, p.OAuth.ExpiresAt)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// TokenExpiresSoon reports whether the access token should be refreshed.
+func (p Profile) TokenExpiresSoon(now time.Time, leeway time.Duration) bool {
+	expiresAt, ok := p.TokenExpiresAtTime()
+	if !ok {
+		return false
+	}
+	return !expiresAt.After(now.Add(leeway))
+}
+
+// MaskSecret returns a redacted value suitable for CLI output.
+func MaskSecret(value string) string {
+	if len(value) < 12 {
+		return "****"
+	}
+	return value[:8] + "..." + value[len(value)-4:]
+}
+
+func parseStringValue(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	if strings.HasPrefix(raw, "\"") || strings.HasPrefix(raw, "`") {
+		v, err := strconv.Unquote(raw)
+		if err != nil {
+			return "", fmt.Errorf("invalid quoted string: %w", err)
+		}
+		return v, nil
+	}
+	return raw, nil
+}
+
+func writeString(buf *bytes.Buffer, key, value string) {
+	if value == "" {
+		return
+	}
+	fmt.Fprintf(buf, "%s = %s\n", key, strconv.Quote(value))
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestLoadFromMissingFile(t *testing.T) {
-	cfg, err := LoadFrom(filepath.Join(t.TempDir(), "config.toml"))
+	cfg, err := LoadFrom(filepath.Join(t.TempDir(), "config.json"))
 	if err != nil {
 		t.Fatalf("LoadFrom returned error: %v", err)
 	}
@@ -22,16 +22,20 @@ func TestLoadFromMissingFile(t *testing.T) {
 }
 
 func TestLoadFromProfileWithOAuthTokens(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "config.toml")
-	data := `current_profile = "prod"
-
-[prod]
-api_url = "https://example.com"
-
-[prod.oauth]
-access_token = "test-access-token"
-refresh_token = "test-refresh-token"
-expires_at = "2026-04-29T12:00:00Z"
+	path := filepath.Join(t.TempDir(), "config.json")
+	data := `{
+  "current_profile": "prod",
+  "profiles": {
+    "prod": {
+      "api_url": "https://example.com",
+      "oauth": {
+        "access_token": "test-access-token",
+        "refresh_token": "test-refresh-token",
+        "expires_at": "2026-04-29T12:00:00Z"
+      }
+    }
+  }
+}
 `
 	if err := os.WriteFile(path, []byte(data), 0600); err != nil {
 		t.Fatal(err)
@@ -57,7 +61,7 @@ expires_at = "2026-04-29T12:00:00Z"
 }
 
 func TestSaveToRoundTripAndPermissions(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "nested", "config.toml")
+	path := filepath.Join(t.TempDir(), "nested", "config.json")
 	cfg := &Config{
 		CurrentProfile: "prod",
 		Profiles: map[string]Profile{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLoadFromMissingFile(t *testing.T) {
+	cfg, err := LoadFrom(filepath.Join(t.TempDir(), "config.toml"))
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+	if cfg.CurrentProfile != "" {
+		t.Fatalf("expected empty current profile, got %q", cfg.CurrentProfile)
+	}
+	if len(cfg.Profiles) != 0 {
+		t.Fatalf("expected no profiles, got %d", len(cfg.Profiles))
+	}
+}
+
+func TestLoadFromProfileWithOAuthTokens(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	data := `current_profile = "prod"
+
+[prod]
+api_url = "https://example.com"
+
+[prod.oauth]
+access_token = "test-access-token"
+refresh_token = "test-refresh-token"
+expires_at = "2026-04-29T12:00:00Z"
+`
+	if err := os.WriteFile(path, []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+	profile := cfg.Profiles["prod"]
+	if cfg.CurrentProfile != "prod" {
+		t.Fatalf("expected prod current profile, got %q", cfg.CurrentProfile)
+	}
+	if profile.APIURL != "https://example.com" {
+		t.Fatalf("unexpected api url: %q", profile.APIURL)
+	}
+	if profile.AccessToken() != "test-access-token" {
+		t.Fatalf("unexpected access token: %q", profile.AccessToken())
+	}
+	if profile.OAuth.RefreshToken != "test-refresh-token" {
+		t.Fatalf("unexpected refresh token: %q", profile.OAuth.RefreshToken)
+	}
+}
+
+func TestSaveToRoundTripAndPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "config.toml")
+	cfg := &Config{
+		CurrentProfile: "prod",
+		Profiles: map[string]Profile{
+			"prod": {
+				APIURL: "https://example.com",
+				OAuth: OAuth{
+					AccessToken:  "test-access-token",
+					RefreshToken: "test-refresh-token",
+					ExpiresAt:    "2026-04-29T12:00:00Z",
+				},
+			},
+		},
+	}
+
+	if err := cfg.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo returned error: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("expected config permissions 0600, got %o", info.Mode().Perm())
+	}
+
+	loaded, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+	if loaded.Profiles["prod"].OAuth.AccessToken != "test-access-token" {
+		t.Fatalf("profile token did not round-trip")
+	}
+}
+
+func TestResolveProfile(t *testing.T) {
+	cfg := &Config{
+		CurrentProfile: "current",
+		Profiles: map[string]Profile{
+			"default": {APIKey: "default-key"},
+			"current": {APIKey: "current-key"},
+			"env":     {APIKey: "env-key"},
+			"flag":    {APIKey: "flag-key"},
+		},
+	}
+
+	name, profile, ok := cfg.ResolveProfile("flag", "env")
+	if !ok || name != "flag" || profile.APIKey != "flag-key" {
+		t.Fatalf("expected flag profile, got name=%q profile=%+v ok=%v", name, profile, ok)
+	}
+
+	name, profile, ok = cfg.ResolveProfile("", "env")
+	if !ok || name != "env" || profile.APIKey != "env-key" {
+		t.Fatalf("expected env profile, got name=%q profile=%+v ok=%v", name, profile, ok)
+	}
+
+	name, profile, ok = cfg.ResolveProfile("", "")
+	if !ok || name != "current" || profile.APIKey != "current-key" {
+		t.Fatalf("expected current profile, got name=%q profile=%+v ok=%v", name, profile, ok)
+	}
+}
+
+func TestTokenExpiresSoon(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	profile := Profile{OAuth: OAuth{ExpiresAt: now.Add(30 * time.Second).Format(time.RFC3339)}}
+	if !profile.TokenExpiresSoon(now, time.Minute) {
+		t.Fatalf("expected token to expire soon")
+	}
+
+	profile.OAuth.ExpiresAt = now.Add(10 * time.Minute).Format(time.RFC3339)
+	if profile.TokenExpiresSoon(now, time.Minute) {
+		t.Fatalf("expected token not to expire soon")
+	}
+}
+
+func TestMaskSecret(t *testing.T) {
+	if got := MaskSecret("test-access-token"); got != "test-acc...oken" {
+		t.Fatalf("unexpected masked secret: %q", got)
+	}
+	if got := MaskSecret("short"); got != "****" {
+		t.Fatalf("unexpected short masked secret: %q", got)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -78,7 +79,7 @@ func TestSaveToRoundTripAndPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
 		t.Fatalf("expected config permissions 0600, got %o", info.Mode().Perm())
 	}
 


### PR DESCRIPTION
Summary:
- add `langsmith login` with OAuth device-code profile storage and token refresh
- store managed profiles in `~/.langsmith/config.json` with OAuth state nested under each profile
- resolve profile OAuth tokens/workspace IDs across CLI and raw API commands
- use OAuth access tokens as Authorization bearer headers without `LANGSMITH_BEARER_TOKEN`
- add API-key profile lifecycle commands, profile list/workspace defaults, plus workspace list/set-default commands
- bump `github.com/langchain-ai/langsmith-go` to `v0.6.0` so SDK clients can read the same OAuth profile config

Profile format:
`~/.langsmith/config.json` is written by the CLI as a managed JSON file. Users can still mount it in containers or remote hosts when they want a pre-seeded profile.

```json
{
  "current_profile": "local",
  "profiles": {
    "local": {
      "api_url": "http://localhost:1980",
      "workspace_id": "00000000-0000-0000-0000-000000000000",
      "oauth": {
        "access_token": "REDACTED_OAUTH_ACCESS_TOKEN",
        "refresh_token": "REDACTED_OAUTH_REFRESH_TOKEN",
        "expires_at": "2026-04-29T18:00:00Z"
      }
    },
    "prod": {
      "api_url": "https://api.smith.langchain.com",
      "workspace_id": "11111111-1111-1111-1111-111111111111",
      "oauth": {
        "access_token": "REDACTED_OAUTH_ACCESS_TOKEN",
        "refresh_token": "REDACTED_OAUTH_REFRESH_TOKEN",
        "expires_at": "2026-04-29T18:00:00Z"
      }
    },
    "api-key-prod": {
      "api_key": "REDACTED_API_KEY",
      "api_url": "https://api.smith.langchain.com",
      "workspace_id": "11111111-1111-1111-1111-111111111111"
    }
  }
}
```

Commands and outputs:

```sh
langsmith login --api-url http://127.0.0.1:1980 --profile local --workspace-id 593d649c-2548-4069-af4b-c8867e279ee6 --no-browser
```

```json
{
  "oauth_expires_at": "2026-04-30T01:08:51Z",
  "profile": "local",
  "status": "logged_in",
  "workspace_id": "593d649c-2548-4069-af4b-c8867e279ee6"
}
```

```sh
langsmith profile create api-key-prod --api-key "$LANGSMITH_API_KEY" --api-url https://api.smith.langchain.com --workspace-id 11111111-1111-1111-1111-111111111111 --set-current
```

```json
{
  "active": true,
  "api_url": "https://api.smith.langchain.com",
  "auth": "api_key",
  "profile": "api-key-prod",
  "status": "created",
  "workspace_id": "11111111-1111-1111-1111-111111111111"
}
```

```sh
langsmith profile show api-key-prod
```

```json
{
  "name": "api-key-prod",
  "active": true,
  "api_url": "https://api.smith.langchain.com",
  "workspace_id": "11111111-1111-1111-1111-111111111111",
  "auth": "api_key",
  "api_key": "lsv2_pt_...abcd"
}
```

```sh
langsmith profile use dev
```

```json
{
  "profile": "dev",
  "status": "switched"
}
```

```sh
langsmith profile delete api-key-prod
```

```json
{
  "profile": "api-key-prod",
  "status": "deleted"
}
```

```sh
langsmith --profile dev --format pretty profile list
```

```text
  ACTIVE    NAME     API URL                              WORKSPACE ID                            AUTH     EXPIRES AT
---------+-------+-------------------------------------+--------------------------------------+-------+----------------------
  *         dev      https://dev.api.smith.langchain.com    d6684905-655c-429b-bd14-ba302d94c03b    oauth    2026-04-30T02:50:40Z
            local    http://127.0.0.1:1980                  593d649c-2548-4069-af4b-c8867e279ee6    oauth    2026-04-30T01:08:51Z
```

```sh
langsmith --profile dev --format pretty profile set-workspace d6684905-655c-429b-bd14-ba302d94c03b
```

```text
Set default workspace for profile "dev"
```

```sh
langsmith --profile dev --format pretty workspace list
```

```text
                NAME                                    ID                         HANDLE        ROLE     DELETED
------------------------------------+--------------------------------------+----------------+-------+----------
  Dogfooding IA                        ebcdd390-59cd-401f-8503-0897bab25962    dogfood-ia        Admin    false
  LangChain Team                       d6684905-655c-429b-bd14-ba302d94c03b    pollytheparrot    Admin    false
  Test                                 f3d63f77-c68e-4c55-a270-9c7bb9bfbc99    test-123          Admin    false
```

```sh
langsmith --profile dev --format pretty project list --limit 1
```

```text
Tracing Projects
────────────────
          NAME                              ID                     RUNS    LATENCY P50    ERROR RATE    LAST ACTIVE
------------------------+--------------------------------------+------+-------------+------------+--------------
  integ-test-zjgj-96959    8d565e27-6157-44ad-a694-9ab6fdc87e82    N/A     N/A            N/A           N/A
```

```sh
langsmith --profile dev --format pretty dataset list --limit 3
```

```text
Datasets
────────
                NAME                                    ID                                        DESCRIPTION                        EXAMPLES     CREATED
------------------------------------+--------------------------------------+----------------------------------------------------+----------+-------------
  Brendan Test                         2aecf052-d7b5-472e-bac2-fda81440f0ea    brendan test                                                 2    2026-04-02
  bug-repro-long-name                  bac787ee-29f2-4926-bcb2-1cb98581daa4    Repro for long-experiment-name overflow obscuring            1    2026-04-29
  color-scale-bug-min-1777493487025    75671ab2-4c57-4f1c-87bc-909e103e8eaf    Minimal repro for per-page color scale bug                  40    2026-04-29
```

```sh
langsmith --profile dev --format pretty run list --project integ-test-zjgj-96959 --limit 1
```

```text
Runs
────
  TIME    NAME    TYPE    TRACE ID    RUN ID
-------+------+------+----------+---------
```

```sh
langsmith --profile dev api GET "/api/v1/sessions?limit=1" --include
```

```text
HTTP/2.0 200 OK
X-Pagination-Total: 2
Content-Type: application/json

[
  {
    "name": "integ-test-zjgj-96959",
    "id": "8d565e27-6157-44ad-a694-9ab6fdc87e82",
    "tenant_id": "d6684905-655c-429b-bd14-ba302d94c03b"
  }
]
```

Go SDK v0.6.0 profile smoke:

```text
LANGSMITH_PROFILE=dev langsmith.NewClient().Sessions.List(limit=1)

sessions=1
first_session="integ-test-zjgj-96959" id=8d565e27-6157-44ad-a694-9ab6fdc87e82 tenant_id=d6684905-655c-429b-bd14-ba302d94c03b
```

Provider profile notes:
- Vercel CLI stores generated auth/config state in JSON files, which matches the managed-file expectation here: https://vercel.com/docs/project-configuration/global-configuration
- Google Cloud SDK uses named configurations with an active configuration and per-config properties like account/project: https://docs.cloud.google.com/sdk/docs/configurations
- AWS CLI uses named profiles in config/credentials files and nests SSO token acquisition settings under `sso-session` sections: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html

Verification:
- `go test ./... -count=1`
- live dev CLI smoke against LangChain Team workspace `d6684905-655c-429b-bd14-ba302d94c03b`
- Go SDK v0.6.0 smoke via `langsmith.NewClient()` with `LANGSMITH_PROFILE=dev`, returning a LangChain Team session
