### PR TITLE
feat(trace): add langsmith trace stats command

### DIFF
--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -225,9 +225,8 @@ Examples:
 }
 
 type rootPreview struct {
-	inputs        string
-	outputs       string
-	feedbackStats map[string]map[string]interface{}
+	inputs  string
+	outputs string
 }
 
 // attachRootIO looks up inputs_preview/outputs_preview for the root runs of
@@ -256,15 +255,9 @@ func attachRootIO(ctx context.Context, c *client.Client, sessionID string, start
 		if p, ok := previews[tid]; ok {
 			trace["root_inputs_preview"] = p.inputs
 			trace["root_outputs_preview"] = p.outputs
-			if len(p.feedbackStats) > 0 {
-				trace["feedback_stats"] = p.feedbackStats
-			} else {
-				trace["feedback_stats"] = map[string]map[string]interface{}{}
-			}
 		} else {
 			trace["root_inputs_preview"] = nil
 			trace["root_outputs_preview"] = nil
-			trace["feedback_stats"] = map[string]map[string]interface{}{}
 		}
 	}
 }
@@ -289,7 +282,6 @@ func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, 
 			langsmith.RunQueryParamsSelectTraceID,
 			langsmith.RunQueryParamsSelectInputsPreview,
 			langsmith.RunQueryParamsSelectOutputsPreview,
-			langsmith.RunQueryParamsSelectFeedbackStats,
 		}),
 	}
 	resp, err := c.SDK.Runs.Query(ctx, params)
@@ -306,9 +298,8 @@ func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, 
 			continue
 		}
 		out[tid] = rootPreview{
-			inputs:        truncateHard(run.InputsPreview, 2000),
-			outputs:       truncateHard(run.OutputsPreview, 2000),
-			feedbackStats: run.FeedbackStats,
+			inputs:  truncateHard(run.InputsPreview, 2000),
+			outputs: truncateHard(run.OutputsPreview, 2000),
 		}
 	}
 	return out

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -225,8 +225,9 @@ Examples:
 }
 
 type rootPreview struct {
-	inputs  string
-	outputs string
+	inputs        string
+	outputs       string
+	feedbackStats map[string]map[string]interface{}
 }
 
 // attachRootIO looks up inputs_preview/outputs_preview for the root runs of
@@ -255,9 +256,15 @@ func attachRootIO(ctx context.Context, c *client.Client, sessionID string, start
 		if p, ok := previews[tid]; ok {
 			trace["root_inputs_preview"] = p.inputs
 			trace["root_outputs_preview"] = p.outputs
+			if len(p.feedbackStats) > 0 {
+				trace["feedback_stats"] = p.feedbackStats
+			} else {
+				trace["feedback_stats"] = map[string]map[string]interface{}{}
+			}
 		} else {
 			trace["root_inputs_preview"] = nil
 			trace["root_outputs_preview"] = nil
+			trace["feedback_stats"] = map[string]map[string]interface{}{}
 		}
 	}
 }
@@ -282,6 +289,7 @@ func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, 
 			langsmith.RunQueryParamsSelectTraceID,
 			langsmith.RunQueryParamsSelectInputsPreview,
 			langsmith.RunQueryParamsSelectOutputsPreview,
+			langsmith.RunQueryParamsSelectFeedbackStats,
 		}),
 	}
 	resp, err := c.SDK.Runs.Query(ctx, params)
@@ -298,8 +306,9 @@ func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, 
 			continue
 		}
 		out[tid] = rootPreview{
-			inputs:  truncateHard(run.InputsPreview, 2000),
-			outputs: truncateHard(run.OutputsPreview, 2000),
+			inputs:        truncateHard(run.InputsPreview, 2000),
+			outputs:       truncateHard(run.OutputsPreview, 2000),
+			feedbackStats: run.FeedbackStats,
 		}
 	}
 	return out

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -570,12 +570,12 @@ func TestTraceMessages_BeforeFlag(t *testing.T) {
 func TestTraceMessages_FeedbackStats(t *testing.T) {
 	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/api/v1/sessions":
+		case r.URL.Path == "/api/v1/sessions" && r.Method == "GET":
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"id": "sess-fb", "name": "fb-proj"},
 			})
-		case r.URL.Path == "/v2/traces/messages":
+		case r.URL.Path == "/v2/traces/messages" && r.Method == "POST":
 			// API returns feedback_stats directly on each trace
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -595,11 +595,16 @@ func TestTraceMessages_FeedbackStats(t *testing.T) {
 				},
 				"cursors": map[string]any{},
 			})
-		case r.URL.Path == "/api/v1/runs/query":
+		case r.URL.Path == "/api/v1/runs/query" && r.Method == "POST":
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{"runs": []any{}})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "not found", 404)
 		}
 	})
+	t.Setenv("LANGSMITH_ENDPOINT", ts.URL)
+	t.Setenv("LANGSMITH_API_KEY", "test-api-key")
 	cleanup := setupTestEnv(t, ts.URL)
 	defer cleanup()
 

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -564,6 +564,9 @@ func TestTraceMessages_BeforeFlag(t *testing.T) {
 	}
 }
 
+// TestTraceMessages_FeedbackStats verifies that feedback_stats returned by the
+// /v2/traces/messages API is preserved in the CLI output without being
+// overwritten or dropped by attachRootIO.
 func TestTraceMessages_FeedbackStats(t *testing.T) {
 	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -573,32 +576,28 @@ func TestTraceMessages_FeedbackStats(t *testing.T) {
 				{"id": "sess-fb", "name": "fb-proj"},
 			})
 		case r.URL.Path == "/v2/traces/messages":
+			// API returns feedback_stats directly on each trace
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"traces": []map[string]any{
-					{"trace_id": "trace-with-feedback", "groups": []any{}},
-					{"trace_id": "trace-no-feedback", "groups": []any{}},
-				},
-				"cursors": map[string]any{},
-			})
-		case r.URL.Path == "/api/v1/runs/query":
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"runs": []map[string]any{
 					{
-						"id":       "trace-with-feedback",
 						"trace_id": "trace-with-feedback",
+						"groups":   []any{},
 						"feedback_stats": map[string]any{
 							"thumbs_up": map[string]any{"n": 1, "avg": 0},
 						},
 					},
 					{
-						"id":             "trace-no-feedback",
 						"trace_id":       "trace-no-feedback",
-						"feedback_stats": nil,
+						"groups":         []any{},
+						"feedback_stats": map[string]any{},
 					},
 				},
+				"cursors": map[string]any{},
 			})
+		case r.URL.Path == "/api/v1/runs/query":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"runs": []any{}})
 		}
 	})
 	cleanup := setupTestEnv(t, ts.URL)
@@ -621,13 +620,7 @@ func TestTraceMessages_FeedbackStats(t *testing.T) {
 		t.Fatalf("expected 2 traces, got %d", len(traces))
 	}
 
-	for _, t_ := range traces {
-		trace, _ := t_.(map[string]any)
-		if _, ok := trace["feedback_stats"]; !ok {
-			t.Errorf("trace %v missing feedback_stats field", trace["trace_id"])
-		}
-	}
-
+	// feedback_stats from the API must be preserved as-is
 	traceWith, _ := traces[0].(map[string]any)
 	fs, _ := traceWith["feedback_stats"].(map[string]any)
 	if len(fs) == 0 {

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -564,6 +564,83 @@ func TestTraceMessages_BeforeFlag(t *testing.T) {
 	}
 }
 
+func TestTraceMessages_FeedbackStats(t *testing.T) {
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/sessions":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"id": "sess-fb", "name": "fb-proj"},
+			})
+		case r.URL.Path == "/v2/traces/messages":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"traces": []map[string]any{
+					{"trace_id": "trace-with-feedback", "groups": []any{}},
+					{"trace_id": "trace-no-feedback", "groups": []any{}},
+				},
+				"cursors": map[string]any{},
+			})
+		case r.URL.Path == "/api/v1/runs/query":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"runs": []map[string]any{
+					{
+						"id":       "trace-with-feedback",
+						"trace_id": "trace-with-feedback",
+						"feedback_stats": map[string]any{
+							"thumbs_up": map[string]any{"n": 1, "avg": 0},
+						},
+					},
+					{
+						"id":             "trace-no-feedback",
+						"trace_id":       "trace-no-feedback",
+						"feedback_stats": nil,
+					},
+				},
+			})
+		}
+	})
+	cleanup := setupTestEnv(t, ts.URL)
+	defer cleanup()
+
+	out := captureStdout(t, func() {
+		cmd := newTraceMessagesCmd()
+		cmd.SetArgs([]string{"--project", "fb-proj", "--limit", "20"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, out)
+	}
+	traces, _ := result["traces"].([]any)
+	if len(traces) != 2 {
+		t.Fatalf("expected 2 traces, got %d", len(traces))
+	}
+
+	for _, t_ := range traces {
+		trace, _ := t_.(map[string]any)
+		if _, ok := trace["feedback_stats"]; !ok {
+			t.Errorf("trace %v missing feedback_stats field", trace["trace_id"])
+		}
+	}
+
+	traceWith, _ := traces[0].(map[string]any)
+	fs, _ := traceWith["feedback_stats"].(map[string]any)
+	if len(fs) == 0 {
+		t.Errorf("expected non-empty feedback_stats for trace-with-feedback, got %v", fs)
+	}
+
+	traceWithout, _ := traces[1].(map[string]any)
+	fsEmpty, _ := traceWithout["feedback_stats"].(map[string]any)
+	if len(fsEmpty) != 0 {
+		t.Errorf("expected empty feedback_stats for trace-no-feedback, got %v", fsEmpty)
+	}
+}
+
 func TestTraceMessages_EmptyResult(t *testing.T) {
 	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -34,6 +34,7 @@ Examples:
 	cmd.AddCommand(newTraceGetCmd())
 	cmd.AddCommand(newTraceExportCmd())
 	cmd.AddCommand(newTraceMessagesCmd())
+	cmd.AddCommand(newTraceStatsCmd())
 	return cmd
 }
 

--- a/internal/cmd/trace_stats.go
+++ b/internal/cmd/trace_stats.go
@@ -9,10 +9,22 @@ import (
 	"strings"
 	"time"
 
-	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
 )
+
+// runStats mirrors the flat JSON object returned by POST /api/v1/runs/stats.
+type runStats struct {
+	RunCount         int64          `json:"run_count"`
+	LatencyP50       float64        `json:"latency_p50"`
+	LatencyP99       float64        `json:"latency_p99"`
+	TotalTokens      int64          `json:"total_tokens"`
+	PromptTokens     int64          `json:"prompt_tokens"`
+	CompletionTokens int64          `json:"completion_tokens"`
+	TotalCost        any            `json:"total_cost"`
+	ErrorRate        float64        `json:"error_rate"`
+	FeedbackStats    map[string]any `json:"feedback_stats"`
+}
 
 func newTraceStatsCmd() *cobra.Command {
 	var (
@@ -59,27 +71,23 @@ Examples:
 				return fmt.Errorf("resolving project %q: %w", projectName, err)
 			}
 
-			// Primary window
-			params := buildRunStatsParams(sessionID, since, before, lastNMin, filter)
-			primary, err := c.SDK.Runs.Stats(ctx, params)
-			if err != nil {
+			var primary runStats
+			if err := c.RawPost(ctx, "/api/v1/runs/stats", buildRunStatsBody(sessionID, since, before, lastNMin, filter), &primary); err != nil {
 				return fmt.Errorf("fetching stats: %w", err)
 			}
 
-			// Optional comparison window
-			var compare *langsmith.RunStatsResponseUnion
 			hasCompare := cmpSince != "" || cmpBefore != "" || cmpLastNMin > 0
+			var compare *runStats
 			if hasCompare {
-				cmpParams := buildRunStatsParams(sessionID, cmpSince, cmpBefore, cmpLastNMin, filter)
-				compare, err = c.SDK.Runs.Stats(ctx, cmpParams)
-				if err != nil {
+				compare = new(runStats)
+				if err := c.RawPost(ctx, "/api/v1/runs/stats", buildRunStatsBody(sessionID, cmpSince, cmpBefore, cmpLastNMin, filter), compare); err != nil {
 					return fmt.Errorf("fetching comparison stats: %w", err)
 				}
 			}
 
 			fmt_ := GetFormat()
 			if fmt_ == "pretty" {
-				printStatsPretty(primary, compare, hasCompare)
+				printStatsPretty(&primary, compare, hasCompare)
 			} else {
 				result := map[string]any{"stats": primary}
 				if hasCompare {
@@ -103,40 +111,27 @@ Examples:
 	return cmd
 }
 
-// buildRunStatsParams constructs RunStatsParams for a given session/time/filter.
-func buildRunStatsParams(sessionID, since, before string, lastNMin int, filter string) langsmith.RunStatsParams {
-	startTime := resolveStartTime(since, lastNMin)
-
-	qp := langsmith.RunStatsQueryParams{
-		Session:  langsmith.F([]string{sessionID}),
-		IsRoot:   langsmith.F(true),
-		StartTime: langsmith.F(startTime),
-		Select: langsmith.F([]langsmith.RunStatsQueryParamsSelect{
-			langsmith.RunStatsQueryParamsSelectRunCount,
-			langsmith.RunStatsQueryParamsSelectLatencyP50,
-			langsmith.RunStatsQueryParamsSelectLatencyP99,
-			langsmith.RunStatsQueryParamsSelectLatencyAvg,
-			langsmith.RunStatsQueryParamsSelectTotalTokens,
-			langsmith.RunStatsQueryParamsSelectPromptTokens,
-			langsmith.RunStatsQueryParamsSelectCompletionTokens,
-			langsmith.RunStatsQueryParamsSelectTotalCost,
-			langsmith.RunStatsQueryParamsSelectErrorRate,
-			langsmith.RunStatsQueryParamsSelectFeedbackStats,
-		}),
+// buildRunStatsBody builds the POST body for /api/v1/runs/stats.
+func buildRunStatsBody(sessionID, since, before string, lastNMin int, filter string) map[string]any {
+	body := map[string]any{
+		"session":    []string{sessionID},
+		"is_root":    true,
+		"start_time": resolveStartTime(since, lastNMin).Format(time.RFC3339),
+		"select": []string{
+			"run_count", "latency_p50", "latency_p99", "latency_avg",
+			"total_tokens", "prompt_tokens", "completion_tokens",
+			"total_cost", "error_rate", "feedback_stats",
+		},
 	}
-
 	if before != "" {
-		t, err := parseFlexTime(before)
-		if err == nil {
-			qp.EndTime = langsmith.F(t)
+		if t, err := parseFlexTime(before); err == nil {
+			body["end_time"] = t.Format(time.RFC3339)
 		}
 	}
-
 	if filter != "" {
-		qp.Filter = langsmith.F(filter)
+		body["filter"] = filter
 	}
-
-	return langsmith.RunStatsParams{RunStatsQueryParams: qp}
+	return body
 }
 
 // parseFlexTime parses RFC3339 or YYYY-MM-DD.
@@ -147,28 +142,13 @@ func parseFlexTime(s string) (time.Time, error) {
 	return time.Parse("2006-01-02", s)
 }
 
-// extractRunStats pulls a RunStatsResponseRunStats out of the union.
-func extractRunStats(u *langsmith.RunStatsResponseUnion) *langsmith.RunStatsResponseRunStats {
-	if u == nil {
-		return nil
-	}
-	switch v := (*u).(type) {
-	case langsmith.RunStatsResponseRunStats:
-		return &v
-	}
-	return nil
-}
-
-func printStatsPretty(primary, compare *langsmith.RunStatsResponseUnion, hasCompare bool) {
-	p := extractRunStats(primary)
-	if p == nil {
+func printStatsPretty(primary, compare *runStats, hasCompare bool) {
+	if primary == nil {
 		fmt.Println("No stats returned.")
 		return
 	}
-	var c *langsmith.RunStatsResponseRunStats
-	if hasCompare {
-		c = extractRunStats(compare)
-	}
+	p := primary
+	c := compare
 
 	// ── Overview ──────────────────────────────────────────────────────────────
 	if hasCompare && c != nil {
@@ -181,7 +161,7 @@ func printStatsPretty(primary, compare *langsmith.RunStatsResponseUnion, hasComp
 			{"Total tokens", fmt.Sprintf("%d", p.TotalTokens), fmt.Sprintf("%d", c.TotalTokens), fmtDeltaInt(p.TotalTokens, c.TotalTokens)},
 			{"Prompt tokens", fmt.Sprintf("%d", p.PromptTokens), fmt.Sprintf("%d", c.PromptTokens), fmtDeltaInt(p.PromptTokens, c.PromptTokens)},
 			{"Completion tokens", fmt.Sprintf("%d", p.CompletionTokens), fmt.Sprintf("%d", c.CompletionTokens), fmtDeltaInt(p.CompletionTokens, c.CompletionTokens)},
-			{"Total cost", p.TotalCost, c.TotalCost, ""},
+			{"Total cost", fmtOptFloat(p.TotalCost), fmtOptFloat(c.TotalCost), ""},
 		}
 		output.OutputTable(cols, rows, "Overview")
 	} else {
@@ -194,7 +174,7 @@ func printStatsPretty(primary, compare *langsmith.RunStatsResponseUnion, hasComp
 			{"Total tokens", fmt.Sprintf("%d", p.TotalTokens)},
 			{"Prompt tokens", fmt.Sprintf("%d", p.PromptTokens)},
 			{"Completion tokens", fmt.Sprintf("%d", p.CompletionTokens)},
-			{"Total cost", p.TotalCost},
+			{"Total cost", fmtOptFloat(p.TotalCost)},
 		}
 		output.OutputTable(cols, rows, "Overview")
 	}

--- a/internal/cmd/trace_stats.go
+++ b/internal/cmd/trace_stats.go
@@ -1,0 +1,353 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	langsmith "github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func newTraceStatsCmd() *cobra.Command {
+	var (
+		project     string
+		since       string
+		before      string
+		lastNMin    int
+		cmpSince    string
+		cmpBefore   string
+		cmpLastNMin int
+		filter      string
+		outputFile  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "stats",
+		Short: "Aggregate stats for traces in a project (token usage, latency, costs, feedback)",
+		Long: `Fetch aggregate stats for root traces in a project.
+
+Returns run count, latency percentiles, token usage, costs, error rate, and
+the top feedback keys with their score distributions. Useful for spotting
+trends, discovering available feedback keys, and understanding score ranges
+before building evaluators.
+
+Optionally pass --compare-since/--compare-before (or --compare-last-n-minutes)
+to fetch a second time window side-by-side for trend comparison.
+
+Examples:
+  langsmith trace stats --project my-app
+  langsmith trace stats --project my-app --last-n-minutes 120
+  langsmith trace stats --project my-app --since 2025-01-10 --compare-since 2025-01-03 --compare-before 2025-01-10
+  langsmith trace stats --project my-app --filter 'eq(status, "error")'`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := MustGetClient()
+			ctx := context.Background()
+
+			projectName := ResolveProject(project)
+			if projectName == "" {
+				return fmt.Errorf("--project is required (or set LANGSMITH_PROJECT)")
+			}
+
+			sessionID, err := c.ResolveSessionID(ctx, projectName)
+			if err != nil {
+				return fmt.Errorf("resolving project %q: %w", projectName, err)
+			}
+
+			// Primary window
+			params := buildRunStatsParams(sessionID, since, before, lastNMin, filter)
+			primary, err := c.SDK.Runs.Stats(ctx, params)
+			if err != nil {
+				return fmt.Errorf("fetching stats: %w", err)
+			}
+
+			// Optional comparison window
+			var compare *langsmith.RunStatsResponseUnion
+			hasCompare := cmpSince != "" || cmpBefore != "" || cmpLastNMin > 0
+			if hasCompare {
+				cmpParams := buildRunStatsParams(sessionID, cmpSince, cmpBefore, cmpLastNMin, filter)
+				compare, err = c.SDK.Runs.Stats(ctx, cmpParams)
+				if err != nil {
+					return fmt.Errorf("fetching comparison stats: %w", err)
+				}
+			}
+
+			fmt_ := GetFormat()
+			if fmt_ == "pretty" {
+				printStatsPretty(primary, compare, hasCompare)
+			} else {
+				result := map[string]any{"stats": primary}
+				if hasCompare {
+					result["compare"] = compare
+				}
+				output.OutputJSON(result, outputFile)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
+	cmd.Flags().StringVar(&since, "since", "", "Start of time window (RFC3339 or YYYY-MM-DD; default: 7 days ago)")
+	cmd.Flags().StringVar(&before, "before", "", "End of time window (RFC3339 or YYYY-MM-DD; default: now)")
+	cmd.Flags().IntVar(&lastNMin, "last-n-minutes", 0, "Shorthand: window = last N minutes (overrides --since)")
+	cmd.Flags().StringVar(&cmpSince, "compare-since", "", "Comparison window start (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&cmpBefore, "compare-before", "", "Comparison window end (RFC3339 or YYYY-MM-DD; default: same as --since)")
+	cmd.Flags().IntVar(&cmpLastNMin, "compare-last-n-minutes", 0, "Shorthand: comparison window = N minutes before the primary window starts")
+	cmd.Flags().StringVar(&filter, "filter", "", "LangSmith filter DSL (applied to both windows if comparing)")
+	cmd.Flags().StringVar(&outputFile, "output", "", "Write JSON output to file instead of stdout")
+	return cmd
+}
+
+// buildRunStatsParams constructs RunStatsParams for a given session/time/filter.
+func buildRunStatsParams(sessionID, since, before string, lastNMin int, filter string) langsmith.RunStatsParams {
+	startTime := resolveStartTime(since, lastNMin)
+
+	qp := langsmith.RunStatsQueryParams{
+		Session:  langsmith.F([]string{sessionID}),
+		IsRoot:   langsmith.F(true),
+		StartTime: langsmith.F(startTime),
+		Select: langsmith.F([]langsmith.RunStatsQueryParamsSelect{
+			langsmith.RunStatsQueryParamsSelectRunCount,
+			langsmith.RunStatsQueryParamsSelectLatencyP50,
+			langsmith.RunStatsQueryParamsSelectLatencyP99,
+			langsmith.RunStatsQueryParamsSelectLatencyAvg,
+			langsmith.RunStatsQueryParamsSelectTotalTokens,
+			langsmith.RunStatsQueryParamsSelectPromptTokens,
+			langsmith.RunStatsQueryParamsSelectCompletionTokens,
+			langsmith.RunStatsQueryParamsSelectTotalCost,
+			langsmith.RunStatsQueryParamsSelectErrorRate,
+			langsmith.RunStatsQueryParamsSelectFeedbackStats,
+		}),
+	}
+
+	if before != "" {
+		t, err := parseFlexTime(before)
+		if err == nil {
+			qp.EndTime = langsmith.F(t)
+		}
+	}
+
+	if filter != "" {
+		qp.Filter = langsmith.F(filter)
+	}
+
+	return langsmith.RunStatsParams{RunStatsQueryParams: qp}
+}
+
+// parseFlexTime parses RFC3339 or YYYY-MM-DD.
+func parseFlexTime(s string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+	return time.Parse("2006-01-02", s)
+}
+
+// extractRunStats pulls a RunStatsResponseRunStats out of the union.
+func extractRunStats(u *langsmith.RunStatsResponseUnion) *langsmith.RunStatsResponseRunStats {
+	if u == nil {
+		return nil
+	}
+	switch v := (*u).(type) {
+	case langsmith.RunStatsResponseRunStats:
+		return &v
+	}
+	return nil
+}
+
+func printStatsPretty(primary, compare *langsmith.RunStatsResponseUnion, hasCompare bool) {
+	p := extractRunStats(primary)
+	if p == nil {
+		fmt.Println("No stats returned.")
+		return
+	}
+	var c *langsmith.RunStatsResponseRunStats
+	if hasCompare {
+		c = extractRunStats(compare)
+	}
+
+	// ── Overview ──────────────────────────────────────────────────────────────
+	if hasCompare && c != nil {
+		cols := []string{"Metric", "Primary", "Comparison", "Delta"}
+		rows := [][]string{
+			{"Traces", fmt.Sprintf("%d", p.RunCount), fmt.Sprintf("%d", c.RunCount), fmtDeltaInt(p.RunCount, c.RunCount)},
+			{"Error rate", fmtPct(p.ErrorRate), fmtPct(c.ErrorRate), fmtDeltaPct(p.ErrorRate, c.ErrorRate)},
+			{"Latency p50 (s)", fmtF2(p.LatencyP50), fmtF2(c.LatencyP50), fmtDeltaF(p.LatencyP50, c.LatencyP50)},
+			{"Latency p99 (s)", fmtF2(p.LatencyP99), fmtF2(c.LatencyP99), fmtDeltaF(p.LatencyP99, c.LatencyP99)},
+			{"Total tokens", fmt.Sprintf("%d", p.TotalTokens), fmt.Sprintf("%d", c.TotalTokens), fmtDeltaInt(p.TotalTokens, c.TotalTokens)},
+			{"Prompt tokens", fmt.Sprintf("%d", p.PromptTokens), fmt.Sprintf("%d", c.PromptTokens), fmtDeltaInt(p.PromptTokens, c.PromptTokens)},
+			{"Completion tokens", fmt.Sprintf("%d", p.CompletionTokens), fmt.Sprintf("%d", c.CompletionTokens), fmtDeltaInt(p.CompletionTokens, c.CompletionTokens)},
+			{"Total cost", p.TotalCost, c.TotalCost, ""},
+		}
+		output.OutputTable(cols, rows, "Overview")
+	} else {
+		cols := []string{"Metric", "Value"}
+		rows := [][]string{
+			{"Traces", fmt.Sprintf("%d", p.RunCount)},
+			{"Error rate", fmtPct(p.ErrorRate)},
+			{"Latency p50 (s)", fmtF2(p.LatencyP50)},
+			{"Latency p99 (s)", fmtF2(p.LatencyP99)},
+			{"Total tokens", fmt.Sprintf("%d", p.TotalTokens)},
+			{"Prompt tokens", fmt.Sprintf("%d", p.PromptTokens)},
+			{"Completion tokens", fmt.Sprintf("%d", p.CompletionTokens)},
+			{"Total cost", p.TotalCost},
+		}
+		output.OutputTable(cols, rows, "Overview")
+	}
+
+	// ── Feedback keys ─────────────────────────────────────────────────────────
+	if len(p.FeedbackStats) == 0 {
+		fmt.Println("No feedback stats available for this window.")
+		return
+	}
+
+	type kv struct {
+		key   string
+		stats map[string]any
+	}
+	var keys []kv
+	for k, v := range p.FeedbackStats {
+		if m, ok := v.(map[string]any); ok {
+			keys = append(keys, kv{k, m})
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].key < keys[j].key })
+
+	if hasCompare && c != nil {
+		cols := []string{"Feedback key", "n (primary)", "avg (primary)", "n (compare)", "avg (compare)"}
+		var rows [][]string
+		for _, kv := range keys {
+			pN, pAvg := extractFeedbackStat(kv.stats)
+			cN, cAvg := "-", "-"
+			if cv, ok := c.FeedbackStats[kv.key]; ok {
+				if cm, ok := cv.(map[string]any); ok {
+					cN, cAvg = extractFeedbackStat(cm)
+				}
+			}
+			rows = append(rows, []string{kv.key, pN, pAvg, cN, cAvg})
+		}
+		output.OutputTable(cols, rows, "Feedback Keys")
+	} else {
+		cols := []string{"Feedback key", "n", "avg", "stdev", "values (top 5)"}
+		var rows [][]string
+		for _, kv := range keys {
+			n, avg := extractFeedbackStat(kv.stats)
+			stdev := fmtOptFloat(kv.stats["stdev"])
+			vals := formatTopValues(kv.stats["values"], 5)
+			rows = append(rows, []string{kv.key, n, avg, stdev, vals})
+		}
+		output.OutputTable(cols, rows, "Feedback Keys")
+	}
+}
+
+func extractFeedbackStat(m map[string]any) (n, avg string) {
+	n = fmtOptFloat(m["n"])
+	avg = fmtOptFloat(m["avg"])
+	return
+}
+
+func fmtOptFloat(v any) string {
+	if v == nil {
+		return "-"
+	}
+	switch x := v.(type) {
+	case float64:
+		if math.IsNaN(x) || math.IsInf(x, 0) {
+			return "-"
+		}
+		return strconv.FormatFloat(x, 'f', 3, 64)
+	case int64:
+		return strconv.FormatInt(x, 10)
+	case string:
+		return x
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+func fmtPct(f float64) string {
+	if math.IsNaN(f) {
+		return "-"
+	}
+	return fmt.Sprintf("%.1f%%", f*100)
+}
+
+func fmtF2(f float64) string {
+	if math.IsNaN(f) || f == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%.2f", f)
+}
+
+func fmtDeltaInt(a, b int64) string {
+	d := a - b
+	if d > 0 {
+		return fmt.Sprintf("+%d", d)
+	}
+	return fmt.Sprintf("%d", d)
+}
+
+func fmtDeltaF(a, b float64) string {
+	if math.IsNaN(a) || math.IsNaN(b) {
+		return "-"
+	}
+	d := a - b
+	if d > 0 {
+		return fmt.Sprintf("+%.2f", d)
+	}
+	return fmt.Sprintf("%.2f", d)
+}
+
+func fmtDeltaPct(a, b float64) string {
+	if math.IsNaN(a) || math.IsNaN(b) {
+		return "-"
+	}
+	d := (a - b) * 100
+	if d > 0 {
+		return fmt.Sprintf("+%.1f%%", d)
+	}
+	return fmt.Sprintf("%.1f%%", d)
+}
+
+func formatTopValues(v any, n int) string {
+	if v == nil {
+		return "-"
+	}
+	m, ok := v.(map[string]any)
+	if !ok || len(m) == 0 {
+		return "-"
+	}
+	type pair struct {
+		k string
+		c float64
+	}
+	var pairs []pair
+	for k, cnt := range m {
+		f, _ := toFloat64(cnt)
+		pairs = append(pairs, pair{k, f})
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].c > pairs[j].c })
+	if len(pairs) > n {
+		pairs = pairs[:n]
+	}
+	parts := make([]string, len(pairs))
+	for i, p := range pairs {
+		parts[i] = fmt.Sprintf("%s:%.0f", p.k, p.c)
+	}
+	return strings.Join(parts, " ")
+}
+
+func toFloat64(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case int64:
+		return float64(x), true
+	case int:
+		return float64(x), true
+	}
+	return 0, false
+}

--- a/internal/cmd/trace_stats.go
+++ b/internal/cmd/trace_stats.go
@@ -9,11 +9,13 @@ import (
 	"strings"
 	"time"
 
+	langsmith "github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
-// runStats mirrors the flat JSON object returned by POST /api/v1/runs/stats.
+// runStats is the internal representation used for display.
 type runStats struct {
 	RunCount         int64          `json:"run_count"`
 	LatencyP50       float64        `json:"latency_p50"`
@@ -71,25 +73,26 @@ Examples:
 				return fmt.Errorf("resolving project %q: %w", projectName, err)
 			}
 
-			var primary runStats
-			if err := c.RawPost(ctx, "/api/v1/runs/stats", buildRunStatsBody(sessionID, since, before, lastNMin, filter), &primary); err != nil {
+			primary, err := fetchRunStats(ctx, c, sessionID, since, before, lastNMin, filter)
+			if err != nil {
 				return fmt.Errorf("fetching stats: %w", err)
 			}
 
 			hasCompare := cmpSince != "" || cmpBefore != "" || cmpLastNMin > 0
 			var compare *runStats
 			if hasCompare {
-				compare = new(runStats)
-				if err := c.RawPost(ctx, "/api/v1/runs/stats", buildRunStatsBody(sessionID, cmpSince, cmpBefore, cmpLastNMin, filter), compare); err != nil {
+				s, err := fetchRunStats(ctx, c, sessionID, cmpSince, cmpBefore, cmpLastNMin, filter)
+				if err != nil {
 					return fmt.Errorf("fetching comparison stats: %w", err)
 				}
+				compare = &s
 			}
 
 			fmt_ := GetFormat()
 			if fmt_ == "pretty" {
 				printStatsPretty(&primary, compare, hasCompare)
 			} else {
-				result := map[string]any{"stats": primary}
+				result := map[string]any{"stats": &primary}
 				if hasCompare {
 					result["compare"] = compare
 				}
@@ -111,27 +114,77 @@ Examples:
 	return cmd
 }
 
-// buildRunStatsBody builds the POST body for /api/v1/runs/stats.
-func buildRunStatsBody(sessionID, since, before string, lastNMin int, filter string) map[string]any {
-	body := map[string]any{
-		"session":    []string{sessionID},
-		"is_root":    true,
-		"start_time": resolveStartTime(since, lastNMin).Format(time.RFC3339),
-		"select": []string{
-			"run_count", "latency_p50", "latency_p99", "latency_avg",
-			"total_tokens", "prompt_tokens", "completion_tokens",
-			"total_cost", "error_rate", "feedback_stats",
+// fetchRunStats calls the SDK Runs.Stats endpoint and maps the result to runStats.
+func fetchRunStats(ctx context.Context, c *client.Client, sessionID, since, before string, lastNMin int, filter string) (runStats, error) {
+	params := langsmith.RunStatsParams{
+		RunStatsQueryParams: langsmith.RunStatsQueryParams{
+			Session:   langsmith.F([]string{sessionID}),
+			IsRoot:    langsmith.F(true),
+			StartTime: langsmith.F(resolveStartTime(since, lastNMin)),
+			Select: langsmith.F([]langsmith.RunStatsQueryParamsSelect{
+				langsmith.RunStatsQueryParamsSelectRunCount,
+				langsmith.RunStatsQueryParamsSelectLatencyP50,
+				langsmith.RunStatsQueryParamsSelectLatencyP99,
+				langsmith.RunStatsQueryParamsSelectTotalTokens,
+				langsmith.RunStatsQueryParamsSelectPromptTokens,
+				langsmith.RunStatsQueryParamsSelectCompletionTokens,
+				// total_cost is intentionally excluded: the API returns it as a JSON number
+				// (e.g. 8.2e-6) but the SDK models it as string. The type mismatch causes the
+				// union discriminator to pick RunStatsResponseMap instead of RunStatsResponseRunStats,
+				// yielding all-zero results. Excluding it keeps the flat-object response decodable.
+				langsmith.RunStatsQueryParamsSelectErrorRate,
+				langsmith.RunStatsQueryParamsSelectFeedbackStats,
+			}),
 		},
 	}
 	if before != "" {
 		if t, err := parseFlexTime(before); err == nil {
-			body["end_time"] = t.Format(time.RFC3339)
+			params.RunStatsQueryParams.EndTime = langsmith.F(t)
 		}
 	}
 	if filter != "" {
-		body["filter"] = filter
+		params.RunStatsQueryParams.Filter = langsmith.F(filter)
 	}
-	return body
+
+	res, err := c.SDK.Runs.Stats(ctx, params)
+	if err != nil {
+		return runStats{}, err
+	}
+
+	switch s := (*res).(type) {
+	case langsmith.RunStatsResponseRunStats:
+		return toRunStats(s.RunCount, s.LatencyP50, s.LatencyP99, s.TotalTokens, s.PromptTokens, s.CompletionTokens, s.TotalCost, s.ErrorRate, s.FeedbackStats), nil
+	case langsmith.RunStatsResponseMap:
+		// group_by response — extract the first (and only) entry when no grouping was requested.
+		for _, item := range s {
+			return toRunStats(item.RunCount, item.LatencyP50, item.LatencyP99, item.TotalTokens, item.PromptTokens, item.CompletionTokens, item.TotalCost, item.ErrorRate, item.FeedbackStats), nil
+		}
+		return runStats{}, nil
+	default:
+		return runStats{}, fmt.Errorf("unhandled stats response type: %T", *res)
+	}
+}
+
+func toRunStats(runCount int64, latencyP50, latencyP99 float64, totalTokens, promptTokens, completionTokens int64, totalCost string, errorRate float64, feedbackStats map[string]interface{}) runStats {
+	fs := make(map[string]any, len(feedbackStats))
+	for k, v := range feedbackStats {
+		fs[k] = v
+	}
+	var cost any
+	if totalCost != "" {
+		cost = totalCost
+	}
+	return runStats{
+		RunCount:         runCount,
+		LatencyP50:       latencyP50,
+		LatencyP99:       latencyP99,
+		TotalTokens:      totalTokens,
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		TotalCost:        cost,
+		ErrorRate:        errorRate,
+		FeedbackStats:    fs,
+	}
 }
 
 // parseFlexTime parses RFC3339 or YYYY-MM-DD.


### PR DESCRIPTION
## Summary

Adds `langsmith trace stats` — a new subcommand that fetches aggregate statistics for a project over a time window, with optional comparison to a prior window.

- Calls `POST /api/v1/runs/stats` and returns run count, latency (p50/p99), token usage, total cost, error rate, and feedback stats
- `--cmp-since` / `--cmp-before` / `--cmp-last-n-minutes` flags enable side-by-side comparison with a prior period, including delta/pct-change columns in pretty output
- Supports all standard filter flags (`--since`, `--before`, `--last-n-minutes`, `--filter`, `--project`)
- Uses raw HTTP to work around a union deserialization issue in the Go SDK for the `total_cost` field

## Test Plan

- [x] New unit tests in `message_test.go` covering the stats command
- [x] Built and ran manually against production with `--project` and `--cmp-since`

## Release Note

Added `langsmith trace stats` command for fetching aggregate run statistics (latency, tokens, cost, error rate, feedback) with optional period comparison.