### PR TITLE
fix(trace messages): use body["id"] for single --trace-ids lookup

### DIFF
--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -92,11 +92,7 @@ Examples:
 
 			if ff.TraceIDs != "" {
 				ids := splitTrim(ff.TraceIDs)
-				if len(ids) == 1 {
-					body["trace"] = ids[0]
-				} else {
-					body["id"] = ids
-				}
+				body["id"] = ids
 			}
 
 			if ff.RunType != "" {


### PR DESCRIPTION
## Summary

- When `--trace-ids` was given a single ID, the CLI sent `body["trace"] = id` to `POST /v2/traces/messages`. The server interprets `trace` as a single-trace context field and returns recent project traces rather than filtering to that specific trace.
- Multi-ID calls correctly used `body["id"] = ids`, which the server filters by exact match.
- This PR removes the single/multi distinction: all `--trace-ids` calls now always use `body["id"]`, which works correctly for both 1 and N IDs.

This bug caused callers (e.g. the screener eval harness) to never receive the requested labeled trace — the batch contained only recent filler traces — making recall structurally 0 for any positive test case.

## Release Note

Fixed `langsmith trace messages --trace-ids <single-id>` returning wrong traces instead of the specified trace.

## Test Plan

- [x] Manually verified: single-ID lookup now returns the correct trace instead of recent project traces
- [x] Existing tests pass (`go test ./...`)