### PR TITLE
feat: add saved profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,19 @@ Thumbs.db
 # Environment
 .env
 /.env.*
+.env.*
+*.pem
+*.key
+*.crt
+credentials.json
+token.json
 
 .envrc
+
+# Local dependency and virtualenv directories
+node_modules/
+__pycache__/
+.venv/
 
 # Claude Code
 .claude/

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/yamux v0.1.2
-	github.com/langchain-ai/langsmith-go v0.5.0
+	github.com/langchain-ai/langsmith-go v0.7.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.8.1
 	github.com/xlab/treeprint v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
 github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
-github.com/langchain-ai/langsmith-go v0.5.0 h1:YiGp/4/ipgnipLUmgo0xa7JwAn5ylKhFbBxWf8F/50o=
-github.com/langchain-ai/langsmith-go v0.5.0/go.mod h1:tUtPtr3nujib98CAfCgEHTL1QMoiNZ5VDx5Qb1pwYZg=
+github.com/langchain-ai/langsmith-go v0.7.0 h1:7RCeSIBiXiwIepMztodn9U7eOG1dQ0543haAj7Ksgi4=
+github.com/langchain-ai/langsmith-go v0.7.0/go.mod h1:tUtPtr3nujib98CAfCgEHTL1QMoiNZ5VDx5Qb1pwYZg=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -26,6 +26,13 @@ type Client struct {
 	sessionCache map[string]string
 }
 
+// Options controls LangSmith client authentication and routing.
+type Options struct {
+	APIKey      string
+	APIURL      string
+	WorkspaceID string
+}
+
 // NormalizeURL strips a trailing "/api/v1" suffix (with or without a trailing
 // slash) so that the SDK — which appends "api/v1" itself — does not double it.
 // Self-hosted users commonly set LANGSMITH_ENDPOINT to "https://host/api/v1".
@@ -36,27 +43,34 @@ func NormalizeURL(apiURL string) string {
 
 // New creates a new Client.
 func New(apiKey, apiURL string) *Client {
-	normalized := NormalizeURL(apiURL)
+	return NewWithOptions(Options{
+		APIKey:      apiKey,
+		APIURL:      apiURL,
+		WorkspaceID: os.Getenv("LANGSMITH_WORKSPACE_ID"),
+	})
+}
 
-	opts := []option.RequestOption{
-		option.WithAPIKey(apiKey),
+// NewWithOptions creates a new Client from resolved options.
+func NewWithOptions(options Options) *Client {
+	normalized := NormalizeURL(options.APIURL)
+
+	var opts []option.RequestOption
+	if options.APIKey != "" {
+		opts = append(opts, option.WithAPIKey(options.APIKey))
 	}
 	// Only set base URL if not the default (the SDK reads LANGSMITH_ENDPOINT too).
 	if normalized != "" {
 		opts = append(opts, option.WithBaseURL(normalized))
 	}
-	// Forward LANGSMITH_WORKSPACE_ID to the SDK as the tenant ID.
-	// The SDK already reads LANGSMITH_TENANT_ID, but LANGSMITH_WORKSPACE_ID
-	// is the documented env var for the CLI and MCP server.
-	if wsID := os.Getenv("LANGSMITH_WORKSPACE_ID"); wsID != "" {
-		opts = append(opts, option.WithTenantID(wsID))
+	if options.WorkspaceID != "" {
+		opts = append(opts, option.WithTenantID(options.WorkspaceID))
 	}
 
 	return &Client{
 		SDK:          langsmith.NewClient(opts...),
-		apiKey:       apiKey,
+		apiKey:       options.APIKey,
 		apiURL:       normalized,
-		workspaceID:  os.Getenv("LANGSMITH_WORKSPACE_ID"),
+		workspaceID:  options.WorkspaceID,
 		sessionCache: make(map[string]string),
 	}
 }
@@ -120,7 +134,9 @@ func (c *Client) doHTTP(ctx context.Context, method, path string, body io.Reader
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
-	req.Header.Set("x-api-key", c.apiKey)
+	if c.apiKey != "" {
+		req.Header.Set("x-api-key", c.apiKey)
+	}
 	req.Header.Set("Content-Type", "application/json")
 	if c.workspaceID != "" {
 		req.Header.Set("x-tenant-id", c.workspaceID)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -67,6 +67,20 @@ func TestNew_EmptyURL(t *testing.T) {
 	}
 }
 
+func TestNewWithOptions_CreatesClientWithWorkspace(t *testing.T) {
+	c := NewWithOptions(Options{
+		APIKey:      "test-api-key",
+		APIURL:      "http://localhost:1234",
+		WorkspaceID: "ws-123",
+	})
+	if c == nil || c.SDK == nil {
+		t.Fatal("expected non-nil client and SDK")
+	}
+	if c.APIKey() != "test-api-key" {
+		t.Fatalf("unexpected API key: %q", c.APIKey())
+	}
+}
+
 // ---------- RawGet ----------
 
 func TestRawGet_Success(t *testing.T) {

--- a/internal/cmd/api/request.go
+++ b/internal/cmd/api/request.go
@@ -28,7 +28,7 @@ func runRequest(c *client.Client, method, path, body string, headers []string, i
 	if isSameHost(fullURL, apiURL) {
 		relPath = strings.TrimPrefix(fullURL, apiURL)
 	} else if strings.HasPrefix(fullURL, "http://") || strings.HasPrefix(fullURL, "https://") {
-		reqClient = client.New("", "")
+		reqClient = client.NewWithOptions(client.Options{})
 	}
 
 	// Resolve body
@@ -113,4 +113,3 @@ func isSameHost(fullURL, baseURL string) bool {
 	rest := fullURL[len(baseURL):]
 	return rest == "" || rest[0] == '/' || rest[0] == '?'
 }
-

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -1,0 +1,445 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/langchain-ai/langsmith-cli/internal/client"
+	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+type profileListItem struct {
+	Name           string `json:"name"`
+	Active         bool   `json:"active"`
+	APIURL         string `json:"api_url,omitempty"`
+	WorkspaceID    string `json:"workspace_id,omitempty"`
+	Auth           string `json:"auth"`
+	OAuthExpiresAt string `json:"oauth_expires_at,omitempty"`
+}
+
+type profileShowItem struct {
+	Name           string `json:"name"`
+	Active         bool   `json:"active"`
+	APIURL         string `json:"api_url,omitempty"`
+	WorkspaceID    string `json:"workspace_id,omitempty"`
+	Auth           string `json:"auth"`
+	APIKey         string `json:"api_key,omitempty"`
+	OAuthExpiresAt string `json:"oauth_expires_at,omitempty"`
+}
+
+func newProfileCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "profile",
+		Short: "Manage saved LangSmith profiles",
+	}
+	cmd.AddCommand(newProfileCreateCmd())
+	cmd.AddCommand(newProfileListCmd())
+	cmd.AddCommand(newProfileShowCmd())
+	cmd.AddCommand(newProfileDeleteCmd())
+	cmd.AddCommand(newProfileUseCmd())
+	cmd.AddCommand(newProfileSetWorkspaceCmd())
+	return cmd
+}
+
+func newProfileCreateCmd() *cobra.Command {
+	var (
+		workspaceID string
+		setCurrent  bool
+	)
+	cmd := &cobra.Command{
+		Use:   "create NAME",
+		Short: "Create an API-key profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProfileCreate(cmd, args[0], workspaceID, setCurrent)
+		},
+	}
+	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "Default workspace ID to save in the profile")
+	cmd.Flags().BoolVar(&setCurrent, "set-current", false, "Set the new profile as the current profile")
+	return cmd
+}
+
+func newProfileListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List saved profiles",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProfileList(cmd)
+		},
+	}
+}
+
+func newProfileShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show NAME",
+		Short: "Show a saved profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProfileShow(cmd, args[0])
+		},
+	}
+}
+
+func newProfileDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete NAME",
+		Short: "Delete a saved profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProfileDelete(cmd, args[0])
+		},
+	}
+}
+
+func newProfileUseCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "use NAME",
+		Short: "Set the current profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProfileUse(cmd, args[0])
+		},
+	}
+}
+
+func newProfileSetWorkspaceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set-workspace WORKSPACE_ID",
+		Short: "Set the default workspace for a profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProfileSetWorkspace(cmd, args[0])
+		},
+	}
+}
+
+func selectedProfileName(cfg *lsconfig.Config) string {
+	if flagProfile != "" {
+		return flagProfile
+	}
+	if envProfile := os.Getenv("LANGSMITH_PROFILE"); envProfile != "" {
+		return envProfile
+	}
+	if cfg.CurrentProfile != "" {
+		return cfg.CurrentProfile
+	}
+	return "default"
+}
+
+func validateProfileName(name string) error {
+	if name == "" || strings.ContainsAny(name, "[]\r\n") {
+		return fmt.Errorf("invalid profile name: %q", name)
+	}
+	return nil
+}
+
+func validateWorkspaceID(workspaceID string) error {
+	if _, err := uuid.Parse(workspaceID); err != nil {
+		return fmt.Errorf("invalid workspace ID %q: expected UUID", workspaceID)
+	}
+	return nil
+}
+
+func runProfileCreate(cmd *cobra.Command, profileName, workspaceID string, setCurrent bool) error {
+	if err := validateProfileName(profileName); err != nil {
+		return err
+	}
+	if workspaceID != "" {
+		if err := validateWorkspaceID(workspaceID); err != nil {
+			return err
+		}
+	}
+
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return err
+	}
+	if cfg.Profiles == nil {
+		cfg.Profiles = make(map[string]lsconfig.Profile)
+	}
+	if _, exists := cfg.Profiles[profileName]; exists {
+		return fmt.Errorf("profile %q already exists", profileName)
+	}
+
+	apiKey := profileCreateAPIKey()
+	if apiKey == "" {
+		return fmt.Errorf("api key required; pass --api-key or set LANGSMITH_API_KEY")
+	}
+	apiURL := profileCreateAPIURL()
+
+	cfg.Profiles[profileName] = lsconfig.Profile{
+		APIKey:      apiKey,
+		APIURL:      apiURL,
+		WorkspaceID: workspaceID,
+	}
+	if cfg.CurrentProfile == "" || setCurrent {
+		cfg.CurrentProfile = profileName
+	}
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	if GetFormat() == "pretty" {
+		if cfg.CurrentProfile == profileName {
+			fmt.Fprintf(cmd.OutOrStdout(), "Created and selected profile %q\n", profileName)
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "Created profile %q\n", profileName)
+		}
+		return nil
+	}
+
+	result := map[string]any{
+		"status":  "created",
+		"profile": profileName,
+		"api_url": apiURL,
+		"auth":    "api_key",
+		"active":  cfg.CurrentProfile == profileName,
+	}
+	if workspaceID != "" {
+		result["workspace_id"] = workspaceID
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+func profileCreateAPIKey() string {
+	if flagAPIKey != "" {
+		return flagAPIKey
+	}
+	return os.Getenv("LANGSMITH_API_KEY")
+}
+
+func profileCreateAPIURL() string {
+	apiURL := lsconfig.DefaultAPIURL
+	if envURL := os.Getenv("LANGSMITH_ENDPOINT"); envURL != "" {
+		apiURL = envURL
+	}
+	if flagAPIURL != "" {
+		apiURL = flagAPIURL
+	}
+	return client.NormalizeURL(apiURL)
+}
+
+func runProfileShow(cmd *cobra.Command, profileName string) error {
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return err
+	}
+	profile, ok := cfg.Profiles[profileName]
+	if !ok {
+		return fmt.Errorf("profile %q not found", profileName)
+	}
+
+	activeName := cfg.ResolveProfileName(flagProfile, os.Getenv("LANGSMITH_PROFILE"))
+	item := profileShowItem{
+		Name:           profileName,
+		Active:         profileName == activeName,
+		APIURL:         profile.APIURL,
+		WorkspaceID:    profile.WorkspaceID,
+		Auth:           profileAuthType(profile),
+		OAuthExpiresAt: profile.OAuth.ExpiresAt,
+	}
+	if profile.APIKey != "" {
+		item.APIKey = lsconfig.MaskSecret(profile.APIKey)
+	}
+
+	if GetFormat() == "pretty" {
+		renderProfileShowTable(cmd, item)
+		return nil
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(item)
+}
+
+func runProfileDelete(cmd *cobra.Command, profileName string) error {
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return err
+	}
+	if _, ok := cfg.Profiles[profileName]; !ok {
+		return fmt.Errorf("profile %q not found", profileName)
+	}
+	delete(cfg.Profiles, profileName)
+	if cfg.CurrentProfile == profileName {
+		cfg.CurrentProfile = ""
+	}
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	if GetFormat() == "pretty" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Deleted profile %q\n", profileName)
+		return nil
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(map[string]string{
+		"status":  "deleted",
+		"profile": profileName,
+	})
+}
+
+func runProfileUse(cmd *cobra.Command, profileName string) error {
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return err
+	}
+	if _, ok := cfg.Profiles[profileName]; !ok {
+		return fmt.Errorf("profile %q not found", profileName)
+	}
+	cfg.CurrentProfile = profileName
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	if GetFormat() == "pretty" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Using profile %q\n", profileName)
+		return nil
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(map[string]string{
+		"status":  "switched",
+		"profile": profileName,
+	})
+}
+
+func runProfileList(cmd *cobra.Command) error {
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return err
+	}
+
+	activeName := cfg.ResolveProfileName(flagProfile, os.Getenv("LANGSMITH_PROFILE"))
+	items := make([]profileListItem, 0, len(cfg.Profiles))
+	for name, profile := range cfg.Profiles {
+		items = append(items, profileListItem{
+			Name:           name,
+			Active:         name == activeName,
+			APIURL:         profile.APIURL,
+			WorkspaceID:    profile.WorkspaceID,
+			Auth:           profileAuthType(profile),
+			OAuthExpiresAt: profile.OAuth.ExpiresAt,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Active != items[j].Active {
+			return items[i].Active
+		}
+		return items[i].Name < items[j].Name
+	})
+
+	if GetFormat() == "pretty" {
+		renderProfileTable(cmd, items)
+		return nil
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(items)
+}
+
+func profileAuthType(profile lsconfig.Profile) string {
+	switch {
+	case profile.AccessToken() != "" || profile.OAuth.RefreshToken != "":
+		return "oauth"
+	case profile.APIKey != "":
+		return "api_key"
+	default:
+		return "none"
+	}
+}
+
+func renderProfileTable(cmd *cobra.Command, profiles []profileListItem) {
+	table := tablewriter.NewWriter(cmd.OutOrStdout())
+	table.SetHeader([]string{"Active", "Name", "API URL", "Workspace ID", "Auth", "Expires At"})
+	table.SetBorder(false)
+	table.SetColumnSeparator("  ")
+	table.SetHeaderLine(true)
+	table.SetAutoWrapText(false)
+	for _, profile := range profiles {
+		active := ""
+		if profile.Active {
+			active = "*"
+		}
+		table.Append([]string{
+			active,
+			profile.Name,
+			profile.APIURL,
+			profile.WorkspaceID,
+			profile.Auth,
+			profile.OAuthExpiresAt,
+		})
+	}
+	table.Render()
+}
+
+func renderProfileShowTable(cmd *cobra.Command, profile profileShowItem) {
+	table := tablewriter.NewWriter(cmd.OutOrStdout())
+	table.SetHeader([]string{"Active", "Name", "API URL", "Workspace ID", "Auth", "API Key", "Expires At"})
+	table.SetBorder(false)
+	table.SetColumnSeparator("  ")
+	table.SetHeaderLine(true)
+	table.SetAutoWrapText(false)
+	active := ""
+	if profile.Active {
+		active = "*"
+	}
+	table.Append([]string{
+		active,
+		profile.Name,
+		profile.APIURL,
+		profile.WorkspaceID,
+		profile.Auth,
+		profile.APIKey,
+		profile.OAuthExpiresAt,
+	})
+	table.Render()
+}
+
+func runProfileSetWorkspace(cmd *cobra.Command, workspaceID string) error {
+	if err := validateWorkspaceID(workspaceID); err != nil {
+		return err
+	}
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return err
+	}
+	if cfg.Profiles == nil {
+		cfg.Profiles = make(map[string]lsconfig.Profile)
+	}
+
+	profileName := selectedProfileName(cfg)
+	if err := validateProfileName(profileName); err != nil {
+		return err
+	}
+	profile := cfg.Profiles[profileName]
+	profile.WorkspaceID = workspaceID
+	cfg.Profiles[profileName] = profile
+	if cfg.CurrentProfile == "" {
+		cfg.CurrentProfile = profileName
+	}
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	if GetFormat() == "pretty" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Set default workspace for profile %q\n", profileName)
+		return nil
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(map[string]string{
+		"status":       "workspace_set",
+		"profile":      profileName,
+		"workspace_id": workspaceID,
+	})
+}

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -238,7 +238,7 @@ func runProfileShow(cmd *cobra.Command, profileName string) error {
 		return fmt.Errorf("profile %q not found", profileName)
 	}
 
-	activeName := cfg.ResolveProfileName(flagProfile, os.Getenv("LANGSMITH_PROFILE"))
+	activeName := cfg.ResolveProfileName(flagProfile, profileEnvName())
 	item := profileShowItem{
 		Name:           profileName,
 		Active:         profileName == activeName,
@@ -319,7 +319,7 @@ func runProfileList(cmd *cobra.Command) error {
 		return err
 	}
 
-	activeName := cfg.ResolveProfileName(flagProfile, os.Getenv("LANGSMITH_PROFILE"))
+	activeName := cfg.ResolveProfileName(flagProfile, profileEnvName())
 	items := make([]profileListItem, 0, len(cfg.Profiles))
 	for name, profile := range cfg.Profiles {
 		items = append(items, profileListItem{
@@ -356,6 +356,10 @@ func profileAuthType(profile lsconfig.Profile) string {
 	default:
 		return "none"
 	}
+}
+
+func profileEnvName() string {
+	return strings.TrimSpace(os.Getenv("LANGSMITH_PROFILE"))
 }
 
 func renderProfileTable(cmd *cobra.Command, profiles []profileListItem) {

--- a/internal/cmd/profile_test.go
+++ b/internal/cmd/profile_test.go
@@ -282,6 +282,59 @@ func TestProfileShowDoesNotExposeSecrets(t *testing.T) {
 	}
 }
 
+func TestProfileDisplayTrimsEnvProfile(t *testing.T) {
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+	}()
+	flagProfile = ""
+	flagOutputFormat = "json"
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_PROFILE", " prod ")
+	if err := os.WriteFile(configPath, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_key": "dev-api-key"
+    },
+    "prod": {
+      "api_key": "prod-api-key"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	showStdout, err := executeCommand(t, "profile", "show", "prod")
+	if err != nil {
+		t.Fatalf("profile show returned error: %v\nstdout: %s", err, showStdout)
+	}
+	var showResult profileShowItem
+	if err := json.Unmarshal([]byte(showStdout), &showResult); err != nil {
+		t.Fatalf("profile show stdout was not JSON: %v\n%s", err, showStdout)
+	}
+	if !showResult.Active {
+		t.Fatalf("expected whitespace-padded env profile to mark prod active: %+v", showResult)
+	}
+
+	listStdout, err := executeCommand(t, "profile", "list")
+	if err != nil {
+		t.Fatalf("profile list returned error: %v\nstdout: %s", err, listStdout)
+	}
+	var listResult []profileListItem
+	if err := json.Unmarshal([]byte(listStdout), &listResult); err != nil {
+		t.Fatalf("profile list stdout was not JSON: %v\n%s", err, listStdout)
+	}
+	if len(listResult) != 2 || listResult[0].Name != "prod" || !listResult[0].Active {
+		t.Fatalf("expected whitespace-padded env profile to mark prod active first: %+v", listResult)
+	}
+}
+
 func TestProfileShowNotFound(t *testing.T) {
 	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "config.json"))
 

--- a/internal/cmd/profile_test.go
+++ b/internal/cmd/profile_test.go
@@ -1,0 +1,563 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
+)
+
+func TestProfileCreate(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+	flagOutputFormat = "json"
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	apiKey := "test-api-key"
+	workspaceID := "00000000-0000-0000-0000-000000000123"
+	stdout, err := executeCommand(t,
+		"profile", "create", "dev",
+		"--api-key", apiKey,
+		"--api-url", "https://api.smith.langchain.com/api/v1",
+		"--workspace-id", workspaceID,
+	)
+	if err != nil {
+		t.Fatalf("profile create returned error: %v\nstdout: %s", err, stdout)
+	}
+	if strings.Contains(stdout, apiKey) {
+		t.Fatalf("profile create output exposed api key: %s", stdout)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout)
+	}
+	if result["status"] != "created" || result["profile"] != "dev" || result["auth"] != "api_key" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if result["api_url"] != "https://api.smith.langchain.com" {
+		t.Fatalf("expected normalized api_url, got %+v", result["api_url"])
+	}
+	if result["workspace_id"] != workspaceID {
+		t.Fatalf("expected workspace_id %q, got %+v", workspaceID, result["workspace_id"])
+	}
+	if result["active"] != true {
+		t.Fatalf("expected first profile to be active, got %+v", result["active"])
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.CurrentProfile != "dev" {
+		t.Fatalf("expected dev current profile, got %q", cfg.CurrentProfile)
+	}
+	profile := cfg.Profiles["dev"]
+	if profile.APIKey != apiKey {
+		t.Fatalf("api key was not saved")
+	}
+	if profile.APIURL != "https://api.smith.langchain.com" {
+		t.Fatalf("expected normalized profile api url, got %q", profile.APIURL)
+	}
+	if profile.WorkspaceID != workspaceID {
+		t.Fatalf("expected workspace ID %q, got %q", workspaceID, profile.WorkspaceID)
+	}
+}
+
+func TestProfileCreateUsesEnvAPIKeyAndEndpoint(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+	flagOutputFormat = "json"
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_API_KEY", "env-api-key")
+	t.Setenv("LANGSMITH_ENDPOINT", "http://localhost:1980/api/v1")
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	stdout, err := executeCommand(t, "profile", "create", "local")
+	if err != nil {
+		t.Fatalf("profile create returned error: %v\nstdout: %s", err, stdout)
+	}
+	if strings.Contains(stdout, "env-api-key") {
+		t.Fatalf("profile create output exposed api key: %s", stdout)
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := cfg.Profiles["local"]
+	if profile.APIKey != "env-api-key" {
+		t.Fatalf("expected api key from env")
+	}
+	if profile.APIURL != "http://localhost:1980" {
+		t.Fatalf("expected normalized env endpoint, got %q", profile.APIURL)
+	}
+}
+
+func TestProfileCreateRequiresAPIKey(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "config.json"))
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	_, err := executeCommand(t, "profile", "create", "dev")
+	if err == nil {
+		t.Fatal("expected missing api key error")
+	}
+	if !strings.Contains(err.Error(), "api key required") {
+		t.Fatalf("expected api key required error, got %v", err)
+	}
+}
+
+func TestProfileCreateAlreadyExists(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+	if err := os.WriteFile(configPath, []byte(`{
+  "profiles": {
+    "dev": {
+      "api_key": "existing-api-key",
+      "api_url": "https://api.smith.langchain.com"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := executeCommand(t, "profile", "create", "dev", "--api-key", "new-api-key")
+	if err == nil {
+		t.Fatal("expected duplicate profile error")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected already exists error, got %v", err)
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Profiles["dev"].APIKey != "existing-api-key" {
+		t.Fatal("existing profile was overwritten")
+	}
+}
+
+func TestProfileCreateInvalidWorkspaceID(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "config.json"))
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	_, err := executeCommand(t, "profile", "create", "dev", "--api-key", "test-api-key", "--workspace-id", "not-a-uuid")
+	if err == nil {
+		t.Fatal("expected invalid workspace ID error")
+	}
+}
+
+func TestProfileShowDoesNotExposeSecrets(t *testing.T) {
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+	}()
+	flagProfile = ""
+	flagOutputFormat = "json"
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_PROFILE", "")
+	apiKey := "test-profile-api-key"
+	accessToken := "test-access-token"
+	refreshToken := "test-refresh-token"
+	if err := os.WriteFile(configPath, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_key": "`+apiKey+`",
+      "api_url": "https://dev.api.smith.langchain.com",
+      "workspace_id": "00000000-0000-0000-0000-000000000123",
+      "oauth": {
+        "access_token": "`+accessToken+`",
+        "refresh_token": "`+refreshToken+`",
+        "expires_at": "2026-04-30T00:00:00Z"
+      }
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, err := executeCommand(t, "profile", "show", "dev")
+	if err != nil {
+		t.Fatalf("profile show returned error: %v\nstdout: %s", err, stdout)
+	}
+	if strings.Contains(stdout, apiKey) || strings.Contains(stdout, accessToken) || strings.Contains(stdout, refreshToken) {
+		t.Fatalf("profile show output exposed a secret: %s", stdout)
+	}
+
+	var result profileShowItem
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout)
+	}
+	if result.Name != "dev" || !result.Active || result.Auth != "oauth" {
+		t.Fatalf("unexpected profile show result: %+v", result)
+	}
+	if result.APIKey == "" || result.APIKey == apiKey {
+		t.Fatalf("expected masked api key, got %q", result.APIKey)
+	}
+	if result.OAuthExpiresAt != "2026-04-30T00:00:00Z" {
+		t.Fatalf("unexpected oauth expiry: %q", result.OAuthExpiresAt)
+	}
+}
+
+func TestProfileShowNotFound(t *testing.T) {
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "config.json"))
+
+	_, err := executeCommand(t, "profile", "show", "missing")
+	if err == nil {
+		t.Fatal("expected profile not found error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func TestProfileUse(t *testing.T) {
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+	}()
+	flagProfile = ""
+	flagOutputFormat = "json"
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	if err := os.WriteFile(configPath, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_key": "dev-api-key"
+    },
+    "prod": {
+      "api_key": "prod-api-key"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, err := executeCommand(t, "profile", "use", "prod")
+	if err != nil {
+		t.Fatalf("profile use returned error: %v\nstdout: %s", err, stdout)
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout)
+	}
+	if result["status"] != "switched" || result["profile"] != "prod" {
+		t.Fatalf("unexpected profile use result: %+v", result)
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.CurrentProfile != "prod" {
+		t.Fatalf("expected prod current profile, got %q", cfg.CurrentProfile)
+	}
+}
+
+func TestProfileUseNotFound(t *testing.T) {
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "config.json"))
+
+	_, err := executeCommand(t, "profile", "use", "missing")
+	if err == nil {
+		t.Fatal("expected profile not found error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func TestProfileDelete(t *testing.T) {
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+	}()
+	flagProfile = ""
+	flagOutputFormat = "json"
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	if err := os.WriteFile(configPath, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_key": "dev-api-key"
+    },
+    "prod": {
+      "api_key": "prod-api-key"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, err := executeCommand(t, "profile", "delete", "dev")
+	if err != nil {
+		t.Fatalf("profile delete returned error: %v\nstdout: %s", err, stdout)
+	}
+	if strings.Contains(stdout, "dev-api-key") {
+		t.Fatalf("profile delete output exposed api key: %s", stdout)
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout)
+	}
+	if result["status"] != "deleted" || result["profile"] != "dev" {
+		t.Fatalf("unexpected profile delete result: %+v", result)
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Profiles["dev"]; ok {
+		t.Fatal("expected dev profile to be deleted")
+	}
+	if _, ok := cfg.Profiles["prod"]; !ok {
+		t.Fatal("expected unrelated profile to remain")
+	}
+	if cfg.CurrentProfile != "" {
+		t.Fatalf("expected current profile to be cleared, got %q", cfg.CurrentProfile)
+	}
+}
+
+func TestProfileDeleteNotFound(t *testing.T) {
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "config.json"))
+
+	_, err := executeCommand(t, "profile", "delete", "missing")
+	if err == nil {
+		t.Fatal("expected profile not found error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func TestProfileSetWorkspace(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+	flagOutputFormat = "json"
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_PROFILE", "")
+	accessToken := "test-access-token"
+	if err := os.WriteFile(configPath, []byte(`{
+  "current_profile": "local",
+  "profiles": {
+    "local": {
+      "oauth": {
+        "access_token": "`+accessToken+`"
+      }
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	workspaceID := "00000000-0000-0000-0000-000000000456"
+	stdout, err := executeCommand(t, "profile", "set-workspace", workspaceID)
+	if err != nil {
+		t.Fatalf("set-workspace returned error: %v\nstdout: %s", err, stdout)
+	}
+	if strings.Contains(stdout, accessToken) {
+		t.Fatalf("profile output exposed access token")
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout)
+	}
+	if result["profile"] != "local" || result["workspace_id"] != workspaceID {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := cfg.Profiles["local"]
+	if profile.WorkspaceID != workspaceID {
+		t.Fatalf("expected workspace ID %q, got %q", workspaceID, profile.WorkspaceID)
+	}
+	if profile.OAuth.AccessToken != accessToken {
+		t.Fatalf("access token was not preserved")
+	}
+}
+
+func TestProfileSetWorkspaceInvalidID(t *testing.T) {
+	oldProfile := flagProfile
+	defer func() { flagProfile = oldProfile }()
+	flagProfile = ""
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "config.json"))
+
+	_, err := executeCommand(t, "profile", "set-workspace", "not-a-uuid")
+	if err == nil {
+		t.Fatal("expected invalid workspace ID error")
+	}
+}
+
+func TestProfileListDoesNotExposeSecrets(t *testing.T) {
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+	}()
+	flagProfile = ""
+	flagOutputFormat = "json"
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_PROFILE", "")
+	accessToken := "test-access-token"
+	refreshToken := "test-refresh-token"
+	apiKey := "test-api-key"
+	if err := os.WriteFile(configPath, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_url": "https://dev.api.smith.langchain.com",
+      "workspace_id": "00000000-0000-0000-0000-000000000123",
+      "oauth": {
+        "access_token": "`+accessToken+`",
+        "refresh_token": "`+refreshToken+`",
+        "expires_at": "2026-04-30T00:00:00Z"
+      }
+    },
+    "local": {
+      "api_key": "`+apiKey+`",
+      "api_url": "http://localhost:1980"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, err := executeCommand(t, "profile", "list")
+	if err != nil {
+		t.Fatalf("profile list returned error: %v\nstdout: %s", err, stdout)
+	}
+	if strings.Contains(stdout, accessToken) || strings.Contains(stdout, refreshToken) || strings.Contains(stdout, apiKey) {
+		t.Fatalf("profile list output exposed a secret: %s", stdout)
+	}
+
+	var result []profileListItem
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 profiles, got %d", len(result))
+	}
+	if result[0].Name != "dev" || !result[0].Active || result[0].Auth != "oauth" {
+		t.Fatalf("unexpected active profile: %+v", result[0])
+	}
+	if result[1].Name != "local" || result[1].Auth != "api_key" {
+		t.Fatalf("unexpected second profile: %+v", result[1])
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/cmd/api"
+	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +14,7 @@ import (
 var (
 	flagAPIKey       string
 	flagAPIURL       string
+	flagProfile      string
 	flagOutputFormat string
 )
 
@@ -28,8 +30,10 @@ access to traces, runs, datasets, evaluators, experiments, and threads.
 All commands output JSON by default for easy parsing.
 
 Authentication:
-  Set LANGSMITH_API_KEY as an environment variable, or pass --api-key.
+  Set LANGSMITH_API_KEY, pass --api-key, or select an API-key profile.
   Optionally set LANGSMITH_ENDPOINT for self-hosted instances.
+  Use --profile or LANGSMITH_PROFILE to select a saved profile.
+  Set a default workspace with 'langsmith profile set-workspace <workspace-id>'.
   Set LANGSMITH_PROJECT as a default project name for trace/run queries.
 
 Quick start:
@@ -50,6 +54,7 @@ Output:
 
 	rootCmd.PersistentFlags().StringVar(&flagAPIKey, "api-key", "", "LangSmith API key [env: LANGSMITH_API_KEY]")
 	rootCmd.PersistentFlags().StringVar(&flagAPIURL, "api-url", "", "LangSmith API URL [env: LANGSMITH_ENDPOINT]")
+	rootCmd.PersistentFlags().StringVar(&flagProfile, "profile", "", "Named profile to use [env: LANGSMITH_PROFILE]")
 	rootCmd.PersistentFlags().StringVar(&flagOutputFormat, "format", "json", "Output format: json or pretty")
 
 	// Register all subcommand groups
@@ -65,32 +70,30 @@ Output:
 	rootCmd.AddCommand(newInsightsCmd())
 	rootCmd.AddCommand(newFleetCmd())
 	rootCmd.AddCommand(newPromptCmd())
+	rootCmd.AddCommand(newProfileCmd())
+	rootCmd.AddCommand(newWorkspaceCmd())
 	rootCmd.AddCommand(newUpdateCmd(rawVersion))
 	rootCmd.AddCommand(api.NewCmd())
 
 	return rootCmd
 }
 
-// GetAPIKey resolves the API key from flag → env → error.
+// GetAPIKey resolves the API key from flag → env → profile.
 func GetAPIKey() string {
-	if flagAPIKey != "" {
-		return flagAPIKey
-	}
-	if v := os.Getenv("LANGSMITH_API_KEY"); v != "" {
-		return v
-	}
-	return ""
+	opts, _ := resolveClientOptions()
+	return opts.APIKey
 }
 
-// GetAPIURL resolves the API URL from flag → env → default.
+// GetAPIURL resolves the API URL from flag → env → profile → default.
 func GetAPIURL() string {
-	if flagAPIURL != "" {
-		return flagAPIURL
-	}
-	if v := os.Getenv("LANGSMITH_ENDPOINT"); v != "" {
-		return v
-	}
-	return "https://api.smith.langchain.com"
+	opts, _ := resolveClientOptions()
+	return opts.APIURL
+}
+
+// GetWorkspaceID resolves the workspace ID from env → profile.
+func GetWorkspaceID() string {
+	opts, _ := resolveClientOptions()
+	return opts.WorkspaceID
 }
 
 // GetFormat returns the output format.
@@ -100,11 +103,59 @@ func GetFormat() string {
 
 // MustGetClient creates a LangSmith client or exits with an error.
 func MustGetClient() *client.Client {
-	apiKey := GetAPIKey()
-	if apiKey == "" {
-		ExitError("LANGSMITH_API_KEY not set")
+	opts, err := resolveClientOptions()
+	if err != nil {
+		ExitError(err.Error())
 	}
-	return client.New(apiKey, GetAPIURL())
+	if opts.APIKey == "" {
+		ExitError("not authenticated; set LANGSMITH_API_KEY, pass --api-key, or select an API-key profile")
+	}
+	return client.NewWithOptions(opts)
+}
+
+func resolveClientOptions() (client.Options, error) {
+	opts := client.Options{APIURL: lsconfig.DefaultAPIURL}
+
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return opts, err
+	}
+	envProfile := os.Getenv("LANGSMITH_PROFILE")
+	profileName, profile, hasProfile := cfg.ResolveProfile(flagProfile, envProfile)
+	if (flagProfile != "" || envProfile != "") && !hasProfile {
+		return opts, fmt.Errorf("profile not found: %s", profileName)
+	}
+
+	if hasProfile {
+		if profile.APIURL != "" {
+			opts.APIURL = profile.APIURL
+		}
+		opts.WorkspaceID = profile.WorkspaceID
+	}
+
+	if v := os.Getenv("LANGSMITH_ENDPOINT"); v != "" {
+		opts.APIURL = client.NormalizeURL(v)
+	}
+	if flagAPIURL != "" {
+		opts.APIURL = client.NormalizeURL(flagAPIURL)
+	}
+
+	if v := os.Getenv("LANGSMITH_TENANT_ID"); v != "" {
+		opts.WorkspaceID = v
+	}
+	if v := os.Getenv("LANGSMITH_WORKSPACE_ID"); v != "" {
+		opts.WorkspaceID = v
+	}
+	switch {
+	case flagAPIKey != "":
+		opts.APIKey = flagAPIKey
+	case os.Getenv("LANGSMITH_API_KEY") != "":
+		opts.APIKey = os.Getenv("LANGSMITH_API_KEY")
+	case hasProfile && profile.APIKey != "":
+		opts.APIKey = profile.APIKey
+	}
+
+	return opts, nil
 }
 
 // ExitError prints a JSON error to stderr and exits.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/cmd/api"
@@ -117,13 +118,22 @@ func resolveClientOptions() (client.Options, error) {
 	opts := client.Options{APIURL: lsconfig.DefaultAPIURL}
 
 	cfg, err := lsconfig.Load()
+	var cfgErr error
 	if err != nil {
-		return opts, err
+		cfgErr = err
+		cfg = &lsconfig.Config{Profiles: make(map[string]lsconfig.Profile)}
 	}
-	envProfile := os.Getenv("LANGSMITH_PROFILE")
-	profileName, profile, hasProfile := cfg.ResolveProfile(flagProfile, envProfile)
-	if (flagProfile != "" || envProfile != "") && !hasProfile {
-		return opts, fmt.Errorf("profile not found: %s", profileName)
+
+	envProfile := strings.TrimSpace(os.Getenv("LANGSMITH_PROFILE"))
+	profileName, profile, hasProfile := "", lsconfig.Profile{}, false
+	if flagProfile != "" || envProfile != "" || cfgErr == nil {
+		if cfgErr != nil && (flagProfile != "" || envProfile != "") {
+			return opts, cfgErr
+		}
+		profileName, profile, hasProfile = cfg.ResolveProfile(flagProfile, envProfile)
+		if (flagProfile != "" || envProfile != "") && !hasProfile {
+			return opts, fmt.Errorf("profile not found: %s", profileName)
+		}
 	}
 
 	if hasProfile {
@@ -153,6 +163,9 @@ func resolveClientOptions() (client.Options, error) {
 		opts.APIKey = os.Getenv("LANGSMITH_API_KEY")
 	case hasProfile && profile.APIKey != "":
 		opts.APIKey = profile.APIKey
+	}
+	if cfgErr != nil && opts.APIKey == "" {
+		return opts, cfgErr
 	}
 
 	return opts, nil

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -2,14 +2,20 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
+
+func isolateConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "missing.json"))
+}
 
 // ---------- Command tree structure ----------
 
 func TestRootCmd_HasAllSubcommands(t *testing.T) {
 	root := NewRootCmd("1.0.0", "1.0.0")
-	expected := []string{"project", "trace", "run", "thread", "dataset", "example", "evaluator", "experiment", "self-update", "api"}
+	expected := []string{"project", "trace", "run", "thread", "dataset", "example", "evaluator", "experiment", "profile", "workspace", "self-update", "api"}
 	cmds := root.Commands()
 
 	names := make(map[string]bool, len(cmds))
@@ -82,9 +88,21 @@ func TestRootCmd_PersistentFlags_Format(t *testing.T) {
 	}
 }
 
+func TestRootCmd_PersistentFlags_Profile(t *testing.T) {
+	root := NewRootCmd("dev", "dev")
+	f := root.PersistentFlags().Lookup("profile")
+	if f == nil {
+		t.Fatal("--profile flag not found")
+	}
+	if f.DefValue != "" {
+		t.Errorf("expected default empty, got %q", f.DefValue)
+	}
+}
+
 // ---------- getAPIKey ----------
 
 func TestGetAPIKey_FlagPrecedence(t *testing.T) {
+	isolateConfig(t)
 	old := flagAPIKey
 	defer func() { flagAPIKey = old }()
 
@@ -97,6 +115,7 @@ func TestGetAPIKey_FlagPrecedence(t *testing.T) {
 }
 
 func TestGetAPIKey_EnvFallback(t *testing.T) {
+	isolateConfig(t)
 	old := flagAPIKey
 	defer func() { flagAPIKey = old }()
 
@@ -109,6 +128,7 @@ func TestGetAPIKey_EnvFallback(t *testing.T) {
 }
 
 func TestGetAPIKey_Empty(t *testing.T) {
+	isolateConfig(t)
 	old := flagAPIKey
 	defer func() { flagAPIKey = old }()
 
@@ -123,6 +143,7 @@ func TestGetAPIKey_Empty(t *testing.T) {
 // ---------- getAPIURL ----------
 
 func TestGetAPIURL_FlagPrecedence(t *testing.T) {
+	isolateConfig(t)
 	old := flagAPIURL
 	defer func() { flagAPIURL = old }()
 
@@ -135,6 +156,7 @@ func TestGetAPIURL_FlagPrecedence(t *testing.T) {
 }
 
 func TestGetAPIURL_EnvFallback(t *testing.T) {
+	isolateConfig(t)
 	old := flagAPIURL
 	defer func() { flagAPIURL = old }()
 
@@ -146,7 +168,25 @@ func TestGetAPIURL_EnvFallback(t *testing.T) {
 	}
 }
 
+func TestGetAPIURL_NormalizesOverrides(t *testing.T) {
+	old := flagAPIURL
+	defer func() { flagAPIURL = old }()
+	flagAPIURL = ""
+	isolateConfig(t)
+
+	t.Setenv("LANGSMITH_ENDPOINT", "https://env.example.com/api/v1")
+	if got := GetAPIURL(); got != "https://env.example.com" {
+		t.Fatalf("expected normalized env URL, got %q", got)
+	}
+
+	flagAPIURL = "https://flag.example.com/api/v1"
+	if got := GetAPIURL(); got != "https://flag.example.com" {
+		t.Fatalf("expected normalized flag URL, got %q", got)
+	}
+}
+
 func TestGetAPIURL_DefaultValue(t *testing.T) {
+	isolateConfig(t)
 	old := flagAPIURL
 	defer func() { flagAPIURL = old }()
 
@@ -155,6 +195,77 @@ func TestGetAPIURL_DefaultValue(t *testing.T) {
 
 	if got := GetAPIURL(); got != "https://api.smith.langchain.com" {
 		t.Errorf("expected default URL, got %q", got)
+	}
+}
+
+func TestGetAPIKey_ProfileFallback(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	if err := os.WriteFile(path, []byte(`{
+  "current_profile": "prod",
+  "profiles": {
+    "prod": {
+      "api_url": "https://profile.example.com",
+      "workspace_id": "ws-123",
+      "api_key": "profile-api-key"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := GetAPIKey(); got != "profile-api-key" {
+		t.Fatalf("expected profile API key, got %q", got)
+	}
+	if got := GetAPIURL(); got != "https://profile.example.com" {
+		t.Fatalf("expected profile API URL, got %q", got)
+	}
+	if got := GetWorkspaceID(); got != "ws-123" {
+		t.Fatalf("expected profile workspace, got %q", got)
+	}
+}
+
+func TestGetAPIKey_EnvOverridesProfile(t *testing.T) {
+	oldKey := flagAPIKey
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagProfile = ""
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "from-env")
+	if err := os.WriteFile(path, []byte(`{
+  "profiles": {
+    "default": {
+      "api_key": "profile-api-key"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := GetAPIKey(); got != "from-env" {
+		t.Fatalf("expected env API key, got %q", got)
 	}
 }
 

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -127,6 +127,36 @@ func TestGetAPIKey_EnvFallback(t *testing.T) {
 	}
 }
 
+func TestGetAPIKey_EnvFallbackWithMalformedConfig(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "from-env")
+	t.Setenv("LANGSMITH_ENDPOINT", "https://env.example.com/api/v1")
+	t.Setenv("LANGSMITH_PROFILE", "")
+	if err := os.WriteFile(path, []byte(`{`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := GetAPIKey(); got != "from-env" {
+		t.Fatalf("expected env API key despite malformed config, got %q", got)
+	}
+	if got := GetAPIURL(); got != "https://env.example.com" {
+		t.Fatalf("expected normalized env URL despite malformed config, got %q", got)
+	}
+}
+
 func TestGetAPIKey_Empty(t *testing.T) {
 	isolateConfig(t)
 	old := flagAPIKey
@@ -237,6 +267,40 @@ func TestGetAPIKey_ProfileFallback(t *testing.T) {
 	}
 	if got := GetWorkspaceID(); got != "ws-123" {
 		t.Fatalf("expected profile workspace, got %q", got)
+	}
+}
+
+func TestGetAPIKey_ProfileEnvTrimsWhitespace(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_PROFILE", " prod ")
+	if err := os.WriteFile(path, []byte(`{
+  "profiles": {
+    "prod": {
+      "api_key": "profile-api-key"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := GetAPIKey(); got != "profile-api-key" {
+		t.Fatalf("expected profile API key from trimmed env profile, got %q", got)
 	}
 }
 

--- a/internal/cmd/testutil_test.go
+++ b/internal/cmd/testutil_test.go
@@ -44,15 +44,18 @@ func setupTestEnv(t *testing.T, serverURL string) func() {
 	t.Helper()
 	oldKey := flagAPIKey
 	oldURL := flagAPIURL
+	oldProfile := flagProfile
 	oldFmt := flagOutputFormat
 
 	flagAPIKey = "test-api-key"
 	flagAPIURL = serverURL
+	flagProfile = ""
 	flagOutputFormat = "json"
 
 	return func() {
 		flagAPIKey = oldKey
 		flagAPIURL = oldURL
+		flagProfile = oldProfile
 		flagOutputFormat = oldFmt
 	}
 }

--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -43,14 +44,14 @@ func newWorkspaceListCmd() *cobra.Command {
 		Short: "List workspaces visible to the current profile",
 		Run: func(cmd *cobra.Command, args []string) {
 			c := MustGetClient()
-			endpoint := "/api/v1/workspaces"
+			endpoint := strings.TrimRight(c.APIURL(), "/") + "/api/v1/workspaces"
 			if includeDeleted {
 				q := url.Values{"include_deleted": {"true"}}
 				endpoint += "?" + q.Encode()
 			}
 
 			var workspaces []workspaceListItem
-			if err := c.RawGet(context.Background(), endpoint, &workspaces); err != nil {
+			if err := c.SDK.Get(context.Background(), endpoint, nil, &workspaces); err != nil {
 				ExitErrorf("listing workspaces: %v", err)
 			}
 

--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -94,9 +94,6 @@ func workspaceRole(ws langsmith.WorkspaceListResponse) string {
 	if ws.RoleName != "" {
 		return ws.RoleName
 	}
-	if ws.ReadOnly {
-		return "Read only"
-	}
 	if len(ws.Permissions) > 0 {
 		return fmt.Sprintf("%d permissions", len(ws.Permissions))
 	}

--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -4,27 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/url"
-	"strings"
 
+	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
-
-type workspaceListItem struct {
-	ID             string   `json:"id"`
-	OrganizationID string   `json:"organization_id,omitempty"`
-	DisplayName    string   `json:"display_name"`
-	TenantHandle   string   `json:"tenant_handle,omitempty"`
-	CreatedAt      string   `json:"created_at,omitempty"`
-	IsPersonal     bool     `json:"is_personal"`
-	IsDeleted      bool     `json:"is_deleted"`
-	ReadOnly       bool     `json:"read_only"`
-	RoleID         string   `json:"role_id,omitempty"`
-	RoleName       string   `json:"role_name,omitempty"`
-	Permissions    []string `json:"permissions,omitempty"`
-	DataPlaneURL   string   `json:"data_plane_url,omitempty"`
-}
 
 func newWorkspaceCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -44,19 +28,21 @@ func newWorkspaceListCmd() *cobra.Command {
 		Short: "List workspaces visible to the current profile",
 		Run: func(cmd *cobra.Command, args []string) {
 			c := MustGetClient()
-			endpoint := strings.TrimRight(c.APIURL(), "/") + "/api/v1/workspaces"
+			params := langsmith.WorkspaceListParams{}
 			if includeDeleted {
-				q := url.Values{"include_deleted": {"true"}}
-				endpoint += "?" + q.Encode()
+				params.IncludeDeleted = langsmith.F(true)
 			}
 
-			var workspaces []workspaceListItem
-			if err := c.SDK.Get(context.Background(), endpoint, nil, &workspaces); err != nil {
+			workspaces, err := c.SDK.Workspaces.List(context.Background(), params)
+			if err != nil {
 				ExitErrorf("listing workspaces: %v", err)
+			}
+			if workspaces == nil {
+				ExitErrorf("listing workspaces: empty response")
 			}
 
 			if GetFormat() == "pretty" {
-				renderWorkspaceTable(cmd, workspaces)
+				renderWorkspaceTable(cmd, *workspaces)
 				return
 			}
 			enc := json.NewEncoder(cmd.OutOrStdout())
@@ -81,7 +67,7 @@ func newWorkspaceSetDefaultCmd() *cobra.Command {
 	}
 }
 
-func renderWorkspaceTable(cmd *cobra.Command, workspaces []workspaceListItem) {
+func renderWorkspaceTable(cmd *cobra.Command, workspaces []langsmith.WorkspaceListResponse) {
 	table := tablewriter.NewWriter(cmd.OutOrStdout())
 	table.SetHeader([]string{"Name", "ID", "Handle", "Role", "Deleted"})
 	table.SetBorder(false)
@@ -104,7 +90,7 @@ func renderWorkspaceTable(cmd *cobra.Command, workspaces []workspaceListItem) {
 	table.Render()
 }
 
-func workspaceRole(ws workspaceListItem) string {
+func workspaceRole(ws langsmith.WorkspaceListResponse) string {
 	if ws.RoleName != "" {
 		return ws.RoleName
 	}

--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+type workspaceListItem struct {
+	ID             string   `json:"id"`
+	OrganizationID string   `json:"organization_id,omitempty"`
+	DisplayName    string   `json:"display_name"`
+	TenantHandle   string   `json:"tenant_handle,omitempty"`
+	CreatedAt      string   `json:"created_at,omitempty"`
+	IsPersonal     bool     `json:"is_personal"`
+	IsDeleted      bool     `json:"is_deleted"`
+	ReadOnly       bool     `json:"read_only"`
+	RoleID         string   `json:"role_id,omitempty"`
+	RoleName       string   `json:"role_name,omitempty"`
+	Permissions    []string `json:"permissions,omitempty"`
+	DataPlaneURL   string   `json:"data_plane_url,omitempty"`
+}
+
+func newWorkspaceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "workspace",
+		Short: "List and select LangSmith workspaces",
+	}
+	cmd.AddCommand(newWorkspaceListCmd())
+	cmd.AddCommand(newWorkspaceSetDefaultCmd())
+	return cmd
+}
+
+func newWorkspaceListCmd() *cobra.Command {
+	var includeDeleted bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List workspaces visible to the current profile",
+		Run: func(cmd *cobra.Command, args []string) {
+			c := MustGetClient()
+			endpoint := "/api/v1/workspaces"
+			if includeDeleted {
+				q := url.Values{"include_deleted": {"true"}}
+				endpoint += "?" + q.Encode()
+			}
+
+			var workspaces []workspaceListItem
+			if err := c.RawGet(context.Background(), endpoint, &workspaces); err != nil {
+				ExitErrorf("listing workspaces: %v", err)
+			}
+
+			if GetFormat() == "pretty" {
+				renderWorkspaceTable(cmd, workspaces)
+				return
+			}
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(workspaces); err != nil {
+				ExitErrorf("encoding workspaces: %v", err)
+			}
+		},
+	}
+	cmd.Flags().BoolVar(&includeDeleted, "include-deleted", false, "Include deleted workspaces")
+	return cmd
+}
+
+func newWorkspaceSetDefaultCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set-default WORKSPACE_ID",
+		Short: "Set the default workspace for the selected profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProfileSetWorkspace(cmd, args[0])
+		},
+	}
+}
+
+func renderWorkspaceTable(cmd *cobra.Command, workspaces []workspaceListItem) {
+	table := tablewriter.NewWriter(cmd.OutOrStdout())
+	table.SetHeader([]string{"Name", "ID", "Handle", "Role", "Deleted"})
+	table.SetBorder(false)
+	table.SetColumnSeparator("  ")
+	table.SetHeaderLine(true)
+	table.SetAutoWrapText(false)
+	for _, ws := range workspaces {
+		deleted := "false"
+		if ws.IsDeleted {
+			deleted = "true"
+		}
+		table.Append([]string{
+			ws.DisplayName,
+			ws.ID,
+			ws.TenantHandle,
+			workspaceRole(ws),
+			deleted,
+		})
+	}
+	table.Render()
+}
+
+func workspaceRole(ws workspaceListItem) string {
+	if ws.RoleName != "" {
+		return ws.RoleName
+	}
+	if ws.ReadOnly {
+		return "Read only"
+	}
+	if len(ws.Permissions) > 0 {
+		return fmt.Sprintf("%d permissions", len(ws.Permissions))
+	}
+	return ""
+}

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestWorkspaceList(t *testing.T) {
+	cleanup := setupTestEnv(t, "")
+	defer cleanup()
+	isolateConfig(t)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/workspaces" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("X-Api-Key") != "test-api-key" {
+			t.Fatalf("expected API key header")
+		}
+		_ = json.NewEncoder(w).Encode([]workspaceListItem{{
+			ID:           "00000000-0000-0000-0000-000000000123",
+			DisplayName:  "Default Workspace",
+			TenantHandle: "default",
+			RoleName:     "Admin",
+		}})
+	})
+	stdout, err := executeCommand(t,
+		"--api-key", "test-api-key",
+		"--api-url", ts.URL,
+		"workspace", "list",
+	)
+	if err != nil {
+		t.Fatalf("workspace list returned error: %v\nstdout: %s", err, stdout)
+	}
+	if !strings.Contains(stdout, "Default Workspace") {
+		t.Fatalf("expected workspace in output, got %s", stdout)
+	}
+}
+
+func TestWorkspaceSetDefault(t *testing.T) {
+	cleanup := setupTestEnv(t, "")
+	defer cleanup()
+	isolateConfig(t)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+
+	workspaceID := "00000000-0000-0000-0000-000000000789"
+	stdout, err := executeCommand(t, "workspace", "set-default", workspaceID)
+	if err != nil {
+		t.Fatalf("workspace set-default returned error: %v\nstdout: %s", err, stdout)
+	}
+	if !strings.Contains(stdout, workspaceID) {
+		t.Fatalf("expected workspace ID in output, got %s", stdout)
+	}
+}

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -15,14 +15,14 @@ func TestWorkspaceList(t *testing.T) {
 	t.Setenv("LANGSMITH_ENDPOINT", "")
 	t.Setenv("LANGSMITH_PROFILE", "")
 
+	receivedKey := ""
 	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/workspaces" {
 			http.NotFound(w, r)
 			return
 		}
-		if r.Header.Get("X-Api-Key") != "test-api-key" {
-			t.Fatalf("expected API key header")
-		}
+		receivedKey = r.Header.Get("X-Api-Key")
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode([]workspaceListItem{{
 			ID:           "00000000-0000-0000-0000-000000000123",
 			DisplayName:  "Default Workspace",
@@ -37,6 +37,9 @@ func TestWorkspaceList(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("workspace list returned error: %v\nstdout: %s", err, stdout)
+	}
+	if receivedKey != "test-api-key" {
+		t.Fatalf("expected API key header, got %q", receivedKey)
 	}
 	if !strings.Contains(stdout, "Default Workspace") {
 		t.Fatalf("expected workspace in output, got %s", stdout)

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -23,11 +23,11 @@ func TestWorkspaceList(t *testing.T) {
 		}
 		receivedKey = r.Header.Get("X-Api-Key")
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]workspaceListItem{{
-			ID:           "00000000-0000-0000-0000-000000000123",
-			DisplayName:  "Default Workspace",
-			TenantHandle: "default",
-			RoleName:     "Admin",
+		_ = json.NewEncoder(w).Encode([]map[string]any{{
+			"id":            "00000000-0000-0000-0000-000000000123",
+			"display_name":  "Default Workspace",
+			"tenant_handle": "default",
+			"role_name":     "Admin",
 		}})
 	})
 	stdout, err := executeCommand(t,

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -72,14 +72,23 @@ func ResolveClientOptions(cmd *cobra.Command) (client.Options, error) {
 	opts := client.Options{APIURL: lsconfig.DefaultAPIURL}
 
 	cfg, err := lsconfig.Load()
+	var cfgErr error
 	if err != nil {
-		return opts, err
+		cfgErr = err
+		cfg = &lsconfig.Config{Profiles: make(map[string]lsconfig.Profile)}
 	}
+
 	flagProfile := getFlagString(cmd, "profile")
 	envProfile := strings.TrimSpace(os.Getenv("LANGSMITH_PROFILE"))
-	profileName, profile, hasProfile := cfg.ResolveProfile(flagProfile, envProfile)
-	if (flagProfile != "" || envProfile != "") && !hasProfile {
-		return opts, fmt.Errorf("profile not found: %s", profileName)
+	profileName, profile, hasProfile := "", lsconfig.Profile{}, false
+	if flagProfile != "" || envProfile != "" || cfgErr == nil {
+		if cfgErr != nil && (flagProfile != "" || envProfile != "") {
+			return opts, cfgErr
+		}
+		profileName, profile, hasProfile = cfg.ResolveProfile(flagProfile, envProfile)
+		if (flagProfile != "" || envProfile != "") && !hasProfile {
+			return opts, fmt.Errorf("profile not found: %s", profileName)
+		}
 	}
 
 	if hasProfile {
@@ -110,6 +119,9 @@ func ResolveClientOptions(cmd *cobra.Command) (client.Options, error) {
 		opts.APIKey = os.Getenv("LANGSMITH_API_KEY")
 	case hasProfile && profile.APIKey != "":
 		opts.APIKey = profile.APIKey
+	}
+	if cfgErr != nil && opts.APIKey == "" {
+		return opts, cfgErr
 	}
 
 	return opts, nil

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -3,8 +3,10 @@ package cmdutil
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
+	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -51,11 +53,64 @@ func ResolveFormat(cmd *cobra.Command) string {
 }
 
 // GetClient creates a LangSmith client from cobra flags, returning an error
-// if the API key is not set.
+// if no API key is available.
 func GetClient(cmd *cobra.Command) (*client.Client, error) {
-	apiKey := ResolveAPIKey(cmd)
-	if apiKey == "" {
-		return nil, fmt.Errorf("LANGSMITH_API_KEY not set")
+	opts, err := ResolveClientOptions(cmd)
+	if err != nil {
+		return nil, err
 	}
-	return client.New(apiKey, ResolveAPIURL(cmd)), nil
+	if opts.APIKey == "" {
+		return nil, fmt.Errorf("not authenticated; set LANGSMITH_API_KEY, pass --api-key, or select an API-key profile")
+	}
+	return client.NewWithOptions(opts), nil
+}
+
+// ResolveClientOptions resolves auth/routing from cobra flags, env, and saved
+// profiles. This mirrors the top-level CLI auth behavior for standalone
+// helpers such as `langsmith api`.
+func ResolveClientOptions(cmd *cobra.Command) (client.Options, error) {
+	opts := client.Options{APIURL: lsconfig.DefaultAPIURL}
+
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return opts, err
+	}
+	flagProfile := getFlagString(cmd, "profile")
+	envProfile := strings.TrimSpace(os.Getenv("LANGSMITH_PROFILE"))
+	profileName, profile, hasProfile := cfg.ResolveProfile(flagProfile, envProfile)
+	if (flagProfile != "" || envProfile != "") && !hasProfile {
+		return opts, fmt.Errorf("profile not found: %s", profileName)
+	}
+
+	if hasProfile {
+		if profile.APIURL != "" {
+			opts.APIURL = profile.APIURL
+		}
+		opts.WorkspaceID = profile.WorkspaceID
+	}
+
+	if v := os.Getenv("LANGSMITH_ENDPOINT"); v != "" {
+		opts.APIURL = client.NormalizeURL(v)
+	}
+	if v := getFlagString(cmd, "api-url"); v != "" {
+		opts.APIURL = client.NormalizeURL(v)
+	}
+
+	if v := os.Getenv("LANGSMITH_TENANT_ID"); v != "" {
+		opts.WorkspaceID = v
+	}
+	if v := os.Getenv("LANGSMITH_WORKSPACE_ID"); v != "" {
+		opts.WorkspaceID = v
+	}
+
+	switch {
+	case getFlagString(cmd, "api-key") != "":
+		opts.APIKey = getFlagString(cmd, "api-key")
+	case os.Getenv("LANGSMITH_API_KEY") != "":
+		opts.APIKey = os.Getenv("LANGSMITH_API_KEY")
+	case hasProfile && profile.APIKey != "":
+		opts.APIKey = profile.APIKey
+	}
+
+	return opts, nil
 }

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -1,6 +1,8 @@
 package cmdutil
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -10,6 +12,7 @@ func newTestCmd() *cobra.Command {
 	root := &cobra.Command{Use: "test"}
 	root.PersistentFlags().String("api-key", "", "")
 	root.PersistentFlags().String("api-url", "", "")
+	root.PersistentFlags().String("profile", "", "")
 	root.PersistentFlags().String("format", "json", "")
 	return root
 }
@@ -102,9 +105,67 @@ func TestGetClient_Success(t *testing.T) {
 
 func TestGetClient_MissingKey(t *testing.T) {
 	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(t.TempDir(), "missing.json"))
 	cmd := newTestCmd()
 	_, err := GetClient(cmd)
 	if err == nil {
 		t.Fatal("expected error for missing API key")
+	}
+}
+
+func TestGetClient_ProfileAPIKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	if err := os.WriteFile(path, []byte(`{
+  "current_profile": "local",
+  "profiles": {
+    "local": {
+      "api_url": "http://localhost:1980",
+      "workspace_id": "ws-123",
+      "api_key": "profile-api-key"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTestCmd()
+	c, err := GetClient(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.APIKey() != "profile-api-key" {
+		t.Fatalf("expected API key from profile")
+	}
+	if c.APIURL() != "http://localhost:1980" {
+		t.Fatalf("expected profile API URL, got %q", c.APIURL())
+	}
+}
+
+func TestResolveClientOptions_EnvAPIKeyOverridesProfile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "from-env")
+	if err := os.WriteFile(path, []byte(`{
+  "profiles": {
+    "default": {
+      "api_key": "profile-api-key"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTestCmd()
+	opts, err := ResolveClientOptions(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.APIKey != "from-env" {
+		t.Fatalf("expected env API key, got %q", opts.APIKey)
 	}
 }

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -169,3 +169,53 @@ func TestResolveClientOptions_EnvAPIKeyOverridesProfile(t *testing.T) {
 		t.Fatalf("expected env API key, got %q", opts.APIKey)
 	}
 }
+
+func TestResolveClientOptions_EnvAPIKeyWithMalformedConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "from-env")
+	t.Setenv("LANGSMITH_ENDPOINT", "https://env.example.com/api/v1")
+	t.Setenv("LANGSMITH_PROFILE", "")
+	if err := os.WriteFile(path, []byte(`{`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTestCmd()
+	opts, err := ResolveClientOptions(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.APIKey != "from-env" {
+		t.Fatalf("expected env API key, got %q", opts.APIKey)
+	}
+	if opts.APIURL != "https://env.example.com" {
+		t.Fatalf("expected normalized env URL, got %q", opts.APIURL)
+	}
+}
+
+func TestResolveClientOptions_ProfileEnvTrimsWhitespace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_PROFILE", " local ")
+	if err := os.WriteFile(path, []byte(`{
+  "profiles": {
+    "local": {
+      "api_key": "profile-api-key"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTestCmd()
+	opts, err := ResolveClientOptions(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.APIKey != "profile-api-key" {
+		t.Fatalf("expected profile API key, got %q", opts.APIKey)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,180 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	ConfigFileEnv = "LANGSMITH_CONFIG_FILE"
+	DefaultAPIURL = "https://api.smith.langchain.com"
+)
+
+// Profile represents one named LangSmith CLI profile.
+type Profile struct {
+	APIKey      string `json:"api_key,omitempty"`
+	APIURL      string `json:"api_url,omitempty"`
+	WorkspaceID string `json:"workspace_id,omitempty"`
+	OAuth       OAuth  `json:"oauth,omitempty"`
+}
+
+// OAuth stores optional tokens for OAuth-backed profiles.
+type OAuth struct {
+	AccessToken  string `json:"access_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	ExpiresAt    string `json:"expires_at,omitempty"`
+}
+
+// Config is the on-disk LangSmith CLI config.
+type Config struct {
+	CurrentProfile string             `json:"current_profile,omitempty"`
+	Profiles       map[string]Profile `json:"profiles,omitempty"`
+}
+
+// DefaultConfigPath returns the LangSmith CLI config path.
+func DefaultConfigPath() (string, error) {
+	if p := os.Getenv(ConfigFileEnv); p != "" {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, ".langsmith", "config.json"), nil
+}
+
+// Load reads the default config path. Missing files return an empty config.
+func Load() (*Config, error) {
+	path, err := DefaultConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	return LoadFrom(path)
+}
+
+// LoadFrom reads a config file. Missing files return an empty config.
+func LoadFrom(path string) (*Config, error) {
+	cfg := &Config{Profiles: make(map[string]Profile)}
+
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return cfg, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return cfg, nil
+	}
+	if err := json.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parsing config JSON: %w", err)
+	}
+	if cfg.Profiles == nil {
+		cfg.Profiles = make(map[string]Profile)
+	}
+	return cfg, nil
+}
+
+// Save writes the config to the default config path with owner-only permissions.
+func (c *Config) Save() error {
+	path, err := DefaultConfigPath()
+	if err != nil {
+		return err
+	}
+	return c.SaveTo(path)
+}
+
+// SaveTo writes the config to path with owner-only permissions.
+func (c *Config) SaveTo(path string) error {
+	if c.Profiles == nil {
+		c.Profiles = make(map[string]Profile)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(c); err != nil {
+		return fmt.Errorf("encoding config JSON: %w", err)
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("opening config for write: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(buf.Bytes()); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+	if err := f.Chmod(0600); err != nil {
+		return fmt.Errorf("setting config permissions: %w", err)
+	}
+	return nil
+}
+
+// ResolveProfileName returns the active profile name by precedence.
+func (c *Config) ResolveProfileName(flagProfile, envProfile string) string {
+	if flagProfile != "" {
+		return flagProfile
+	}
+	if envProfile != "" {
+		return envProfile
+	}
+	if c.CurrentProfile != "" {
+		return c.CurrentProfile
+	}
+	if _, ok := c.Profiles["default"]; ok {
+		return "default"
+	}
+	return ""
+}
+
+// ResolveProfile returns the active profile by precedence.
+func (c *Config) ResolveProfile(flagProfile, envProfile string) (string, Profile, bool) {
+	name := c.ResolveProfileName(flagProfile, envProfile)
+	if name == "" {
+		return "", Profile{}, false
+	}
+	p, ok := c.Profiles[name]
+	return name, p, ok
+}
+
+// AccessToken returns the OAuth access token to use for bearer auth.
+func (p Profile) AccessToken() string {
+	return p.OAuth.AccessToken
+}
+
+// TokenExpiresAtTime parses oauth.expires_at.
+func (p Profile) TokenExpiresAtTime() (time.Time, bool) {
+	if p.OAuth.ExpiresAt == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, p.OAuth.ExpiresAt)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// TokenExpiresSoon reports whether the access token should be refreshed.
+func (p Profile) TokenExpiresSoon(now time.Time, leeway time.Duration) bool {
+	expiresAt, ok := p.TokenExpiresAtTime()
+	if !ok {
+		return false
+	}
+	return !expiresAt.After(now.Add(leeway))
+}
+
+// MaskSecret returns a redacted value suitable for CLI output.
+func MaskSecret(value string) string {
+	if len(value) < 12 {
+		return "****"
+	}
+	return value[:8] + "..." + value[len(value)-4:]
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,146 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestLoadFromMissingFile(t *testing.T) {
+	cfg, err := LoadFrom(filepath.Join(t.TempDir(), "config.json"))
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+	if cfg.CurrentProfile != "" {
+		t.Fatalf("expected empty current profile, got %q", cfg.CurrentProfile)
+	}
+	if len(cfg.Profiles) != 0 {
+		t.Fatalf("expected no profiles, got %d", len(cfg.Profiles))
+	}
+}
+
+func TestLoadFromProfileWithOAuthTokens(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	data := `{
+  "current_profile": "prod",
+  "profiles": {
+    "prod": {
+      "api_url": "https://example.com",
+      "oauth": {
+        "access_token": "test-access-token",
+        "refresh_token": "test-refresh-token",
+        "expires_at": "2026-04-29T12:00:00Z"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+	profile := cfg.Profiles["prod"]
+	if cfg.CurrentProfile != "prod" {
+		t.Fatalf("expected prod current profile, got %q", cfg.CurrentProfile)
+	}
+	if profile.APIURL != "https://example.com" {
+		t.Fatalf("unexpected api url: %q", profile.APIURL)
+	}
+	if profile.AccessToken() != "test-access-token" {
+		t.Fatalf("unexpected access token: %q", profile.AccessToken())
+	}
+	if profile.OAuth.RefreshToken != "test-refresh-token" {
+		t.Fatalf("unexpected refresh token: %q", profile.OAuth.RefreshToken)
+	}
+}
+
+func TestSaveToRoundTripAndPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "config.json")
+	cfg := &Config{
+		CurrentProfile: "prod",
+		Profiles: map[string]Profile{
+			"prod": {
+				APIURL: "https://example.com",
+				OAuth: OAuth{
+					AccessToken:  "test-access-token",
+					RefreshToken: "test-refresh-token",
+					ExpiresAt:    "2026-04-29T12:00:00Z",
+				},
+			},
+		},
+	}
+
+	if err := cfg.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo returned error: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
+		t.Fatalf("expected config permissions 0600, got %o", info.Mode().Perm())
+	}
+
+	loaded, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+	if loaded.Profiles["prod"].OAuth.AccessToken != "test-access-token" {
+		t.Fatalf("profile token did not round-trip")
+	}
+}
+
+func TestResolveProfile(t *testing.T) {
+	cfg := &Config{
+		CurrentProfile: "current",
+		Profiles: map[string]Profile{
+			"default": {APIKey: "default-key"},
+			"current": {APIKey: "current-key"},
+			"env":     {APIKey: "env-key"},
+			"flag":    {APIKey: "flag-key"},
+		},
+	}
+
+	name, profile, ok := cfg.ResolveProfile("flag", "env")
+	if !ok || name != "flag" || profile.APIKey != "flag-key" {
+		t.Fatalf("expected flag profile, got name=%q profile=%+v ok=%v", name, profile, ok)
+	}
+
+	name, profile, ok = cfg.ResolveProfile("", "env")
+	if !ok || name != "env" || profile.APIKey != "env-key" {
+		t.Fatalf("expected env profile, got name=%q profile=%+v ok=%v", name, profile, ok)
+	}
+
+	name, profile, ok = cfg.ResolveProfile("", "")
+	if !ok || name != "current" || profile.APIKey != "current-key" {
+		t.Fatalf("expected current profile, got name=%q profile=%+v ok=%v", name, profile, ok)
+	}
+}
+
+func TestTokenExpiresSoon(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	profile := Profile{OAuth: OAuth{ExpiresAt: now.Add(30 * time.Second).Format(time.RFC3339)}}
+	if !profile.TokenExpiresSoon(now, time.Minute) {
+		t.Fatalf("expected token to expire soon")
+	}
+
+	profile.OAuth.ExpiresAt = now.Add(10 * time.Minute).Format(time.RFC3339)
+	if profile.TokenExpiresSoon(now, time.Minute) {
+		t.Fatalf("expected token not to expire soon")
+	}
+}
+
+func TestMaskSecret(t *testing.T) {
+	if got := MaskSecret("test-access-token"); got != "test-acc...oken" {
+		t.Fatalf("unexpected masked secret: %q", got)
+	}
+	if got := MaskSecret("short"); got != "****" {
+		t.Fatalf("unexpected short masked secret: %q", got)
+	}
+}


### PR DESCRIPTION
Summary:
- add managed profile config at `~/.langsmith/config.json`
- add `--profile` and `LANGSMITH_PROFILE` selection
- resolve API key, API URL, and workspace ID from saved profiles
- add `langsmith profile create/list/show/use/delete/set-workspace`
- add workspace listing and default workspace commands

Profile format:

```json
{
  "current_profile": "prod",
  "profiles": {
    "prod": {
      "api_key": "REDACTED_API_KEY",
      "api_url": "https://api.smith.langchain.com",
      "workspace_id": "11111111-1111-1111-1111-111111111111"
    }
  }
}
```

Example commands:

```sh
langsmith profile create prod --api-key "$LANGSMITH_API_KEY" --api-url https://api.smith.langchain.com --workspace-id 11111111-1111-1111-1111-111111111111 --set-current
```

```json
{
  "active": true,
  "api_url": "https://api.smith.langchain.com",
  "auth": "api_key",
  "profile": "prod",
  "status": "created",
  "workspace_id": "11111111-1111-1111-1111-111111111111"
}
```

```sh
langsmith profile show prod
```

```json
{
  "name": "prod",
  "active": true,
  "api_url": "https://api.smith.langchain.com",
  "workspace_id": "11111111-1111-1111-1111-111111111111",
  "auth": "api_key",
  "api_key": "lsv2_pt_...abcd"
}
```

```sh
langsmith profile use prod
```

```json
{
  "profile": "prod",
  "status": "switched"
}
```

Verification:
- `go test ./... -count=1`
