### PR TITLE
fix(trace messages): send ids (plural) to match backend field name

### DIFF
--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -92,7 +92,7 @@ Examples:
 
 			if ff.TraceIDs != "" {
 				ids := splitTrim(ff.TraceIDs)
-				body["id"] = ids
+				body["ids"] = ids
 			}
 
 			if ff.RunType != "" {


### PR DESCRIPTION
## Summary

The \`trace messages\` command was sending \`body["id"]\` (singular) when filtering by trace IDs, but the backend \`BatchTraceMessagesRequestBody\` struct expects \`"ids"\` (plural, \`json:"ids"\`). This caused the trace ID filter to be silently dropped — the backend unmarshaled the field to its zero value (nil slice) and returned all traces instead of the requested ones.

In \`internal/cmd/message.go\`:
\`\`\`go
// Before (broken): backend ignores this field, returns unfiltered results
body["id"] = ids

// After (fixed): matches json:"ids" on BatchTraceMessagesRequestBody.Ids
body["ids"] = ids
\`\`\`

The backend \`POST /v2/traces/messages\` reads from \`body.Ids\` (JSON field \`"ids"\`). With the singular key, every \`--trace-ids\` invocation silently returned unfiltered results rather than the specified traces. This is the specific failure mode causing the issues-agent's phase 1b screener to get wrong data when it calls \`langsmith trace messages --trace-ids\`.

## Test Plan

- [x] All existing \`TestTraceMessages\` unit tests pass
- [x] Built binary and verified against production with all four sandbox command patterns:
  - \`trace messages --project <proj> --limit 3 --last-n-minutes 360\` → returns traces correctly  
  - \`trace messages --project <proj> --trace-ids "id1,id2" --limit 5 --last-n-minutes 360\` → returns exactly 2 traces matching the specified IDs  
  - \`LANGSMITH_PROJECT=<proj> trace messages --project <proj> --trace-ids "id" --limit 5\` → returns exactly 1 trace  
  - Verified trace_ids in response match the requested IDs exactly

## Release Note

Fix \`langsmith trace messages --trace-ids\` filter being silently ignored due to wrong JSON field name (\`id\` → \`ids\`).