### PR TITLE
fix(trace messages): return [] not null for empty results; unwrap nested API errors

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -183,6 +183,12 @@ func (c *Client) rawRequest(ctx context.Context, method, path string, body any, 
 	}
 
 	if resp.statusCode >= 400 {
+		var errBody struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(resp.body, &errBody) == nil && errBody.Error != "" {
+			return fmt.Errorf("HTTP %d: %s", resp.statusCode, errBody.Error)
+		}
 		return fmt.Errorf("HTTP %d: %s", resp.statusCode, string(resp.body))
 	}
 

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -161,7 +161,7 @@ Examples:
 			// Paginate: fetch up to ff.Limit traces using pages of <= maxPageSize
 			const maxPageSize = 10
 			remaining := ff.Limit
-			var allTraces []any
+			allTraces := []any{}
 
 			for {
 				pageSize := maxPageSize


### PR DESCRIPTION
## Summary

Two small correctness fixes to `trace messages`:

**1. `traces: null` → `traces: []` when no results**

`var allTraces []any` stays nil when no traces match, so `json.Marshal` emits `"traces":null`. Code that does `len(data["traces"])` or iterates the array gets a type error. Fixed by initializing as `allTraces := []any{}`.

**2. Unwrap nested JSON error bodies**

The HTTP client was returning errors as `HTTP 400: {"error":"<message>"}` — the backend's JSON error object embedded as a raw string. `ExitError` then re-wrapped that as `{"error":"HTTP 400: {\"error\":\"<message>\"}"}`, making three layers of nesting. Now the client extracts the inner `error` field so the message is just `HTTP 400: <message>`.

Before:
```json
{"error": "HTTP 400: {\"error\":\"Reduce the number of traces or narrow the time range: batch message view exceeded size limit: fetched 21778996 bytes (limit 20000000 bytes)\"\n}"}
```

After:
```json
{"error": "HTTP 400: Reduce the number of traces or narrow the time range: batch message view exceeded size limit: fetched 21778996 bytes (limit 20000000 bytes)"}
```

## Test Plan

- [x] All `internal/...` tests pass
- [x] Built binary and verified error format against production (size-limit 400 now shows clean message)
- [x] Empty-result path confirmed correct in code (nil slice → `[]any{}`)

## Release Note

none