### PR TITLE
fix(issues): return [] not null for empty issues list and events

### DIFF
--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -130,7 +130,7 @@ Examples:
 				}
 				output.OutputTable(columns, rows, fmt.Sprintf("Issues for %s", projectName))
 			} else {
-				var data []map[string]any
+				data := []map[string]any{}
 				for _, issue := range issues {
 					data = append(data, issueToMap(issue))
 				}
@@ -227,7 +227,7 @@ Examples:
 				}
 				output.OutputTable(columns, rows, fmt.Sprintf("Issue events for %s", projectName))
 			} else {
-				var data []map[string]any
+				data := []map[string]any{}
 				for _, e := range events {
 					issueID := any(nil)
 					if e.IssueID != nil {


### PR DESCRIPTION
## Summary

\`issues list\` and \`issues events\` both used \`var data []map[string]any\`, which stays nil when the API returns zero results. \`json.Marshal(nil)\` serializes to \`null\` instead of \`[]\`, breaking any caller that tries to iterate or check the length of the result.

The issues agent calls \`langsmith project issues events --look-back-minutes 360\` on every cron scan. For projects with no recent activity this returns \`null\`, which the agent can't handle cleanly.

Fix: initialize as \`data := []map[string]any{}\` in both commands so empty results always serialize to \`[]\`.

## Test Plan

- [x] All tests pass
- [x] Verified the pattern: zero-event projects now return \`[]\` not \`null\`

## Release Note

Fix \`issues list\` and \`issues events\` returning \`null\` instead of \`[]\` when there are no results.