### PR TITLE
Prompt for workspace during OAuth login

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -131,6 +131,13 @@ type httpResponse struct {
 	body       []byte
 }
 
+type httpErrorBody struct {
+	Error            string `json:"error"`
+	Message          string `json:"message"`
+	ErrorDescription string `json:"error_description"`
+	Detail           any    `json:"detail"`
+}
+
 // doHTTP is the shared low-level helper used by RawDo and rawRequest.
 func (c *Client) doHTTP(ctx context.Context, method, path string, body io.Reader, extraHeaders http.Header) (*httpResponse, error) {
 	url := c.apiURL + path
@@ -211,7 +218,7 @@ func (c *Client) rawRequest(ctx context.Context, method, path string, body any, 
 	}
 
 	if resp.statusCode >= 400 {
-		return fmt.Errorf("HTTP %d: %s", resp.statusCode, string(resp.body))
+		return fmt.Errorf("HTTP %d: %s", resp.statusCode, formatHTTPErrorBody(resp.body))
 	}
 
 	if result != nil {
@@ -221,4 +228,39 @@ func (c *Client) rawRequest(ctx context.Context, method, path string, body any, 
 	}
 
 	return nil
+}
+
+func formatHTTPErrorBody(body []byte) string {
+	raw := strings.TrimSpace(string(body))
+	var parsed httpErrorBody
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return raw
+	}
+
+	code := strings.TrimSpace(parsed.Error)
+	message := strings.TrimSpace(parsed.Message)
+	if message == "" {
+		message = strings.TrimSpace(parsed.ErrorDescription)
+	}
+	if message == "" && parsed.Detail != nil {
+		switch detail := parsed.Detail.(type) {
+		case string:
+			message = strings.TrimSpace(detail)
+		default:
+			if data, err := json.Marshal(detail); err == nil {
+				message = strings.TrimSpace(string(data))
+			}
+		}
+	}
+
+	switch {
+	case code != "" && message != "":
+		return code + ": " + message
+	case code != "":
+		return code
+	case message != "":
+		return message
+	default:
+		return raw
+	}
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -132,6 +132,30 @@ func TestRawGet_HTTPError(t *testing.T) {
 	}
 }
 
+func TestRawGet_JSONHTTPErrorIncludesMessage(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":   "org_scoped_key_requires_workspace",
+			"message": "This API key requires a workspace ID.",
+		})
+	}))
+	defer ts.Close()
+
+	c := New("key", ts.URL)
+	err := c.RawGet(context.Background(), "/fail", nil)
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+	if !strings.Contains(err.Error(), "org_scoped_key_requires_workspace") {
+		t.Fatalf("expected error code, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "workspace ID") {
+		t.Fatalf("expected workspace guidance, got %q", err.Error())
+	}
+}
+
 func TestRawGet_NilResult(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -11,12 +11,14 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/langchain-ai/langsmith-cli/internal/client"
 	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
+	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -135,7 +137,7 @@ func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspa
 		profile.APIURL = apiURL
 	}
 	if workspaceID == "" && profile.WorkspaceID == "" {
-		workspaceID, err = promptWorkspaceID(cmd)
+		workspaceID, err = promptWorkspaceSelection(cmd, apiURL, token.AccessToken)
 		if err != nil {
 			return err
 		}
@@ -209,24 +211,100 @@ func validateWorkspaceID(workspaceID string) error {
 	return nil
 }
 
-func promptWorkspaceID(cmd *cobra.Command) (string, error) {
+func promptWorkspaceSelection(cmd *cobra.Command, apiURL, accessToken string) (string, error) {
 	in := cmd.InOrStdin()
 	if !inputIsTerminal(in) {
+		fmt.Fprintln(cmd.ErrOrStderr(), "No default workspace set because stdin is not interactive. Some commands require a workspace; pass --workspace-id to login or run 'langsmith workspace set-default <workspace-id>'.")
 		return "", nil
 	}
-	fmt.Fprint(cmd.ErrOrStderr(), "Default workspace ID (optional, press Enter to skip): ")
-	line, err := bufio.NewReader(in).ReadString('\n')
-	if err != nil && err != io.EOF {
-		return "", fmt.Errorf("reading workspace ID: %w", err)
+	workspaces, err := listLoginWorkspaces(cmd.Context(), apiURL, accessToken)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Could not list workspaces: %v\n", err)
+		return promptWorkspaceID(cmd)
+	}
+	if len(workspaces) == 1 {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Using default workspace %q (%s)\n", workspaceDisplayName(workspaces[0]), workspaces[0].ID)
+		return workspaces[0].ID, nil
+	}
+	if len(workspaces) > 1 {
+		fmt.Fprintln(cmd.ErrOrStderr(), "Select a default workspace:")
+		for i, workspace := range workspaces {
+			fmt.Fprintf(cmd.ErrOrStderr(), "  %d. %s (%s)\n", i+1, workspaceDisplayName(workspace), workspace.ID)
+		}
+		return promptWorkspaceChoice(cmd, workspaces)
+	}
+	return promptWorkspaceID(cmd)
+}
+
+func workspaceDisplayName(workspace langsmith.WorkspaceListResponse) string {
+	if workspace.DisplayName != "" {
+		return workspace.DisplayName
+	}
+	return workspace.ID
+}
+
+func listLoginWorkspaces(ctx context.Context, apiURL, accessToken string) ([]langsmith.WorkspaceListResponse, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c := client.NewWithOptions(client.Options{
+		APIURL:           apiURL,
+		OAuthAccessToken: accessToken,
+	})
+	workspaces, err := c.SDK.Workspaces.List(ctx, langsmith.WorkspaceListParams{})
+	if err != nil {
+		return nil, err
+	}
+	if workspaces == nil {
+		return nil, nil
+	}
+	return *workspaces, nil
+}
+
+func promptWorkspaceChoice(cmd *cobra.Command, workspaces []langsmith.WorkspaceListResponse) (string, error) {
+	line, err := promptLine(cmd, "Enter number or workspace ID: ")
+	if err != nil {
+		return "", err
+	}
+	choice := strings.TrimSpace(line)
+	if choice == "" {
+		return "", fmt.Errorf("default workspace required for OAuth login")
+	}
+	if n, err := strconv.Atoi(choice); err == nil {
+		if n < 1 || n > len(workspaces) {
+			return "", fmt.Errorf("invalid workspace selection %d", n)
+		}
+		return workspaces[n-1].ID, nil
+	}
+	if err := validateWorkspaceID(choice); err != nil {
+		return "", err
+	}
+	return choice, nil
+}
+
+func promptWorkspaceID(cmd *cobra.Command) (string, error) {
+	line, err := promptLine(cmd, "Default workspace ID: ")
+	if err != nil {
+		return "", err
 	}
 	workspaceID := strings.TrimSpace(line)
 	if workspaceID == "" {
-		return "", nil
+		return "", fmt.Errorf("default workspace required for OAuth login")
 	}
 	if err := validateWorkspaceID(workspaceID); err != nil {
 		return "", err
 	}
 	return workspaceID, nil
+}
+
+func promptLine(cmd *cobra.Command, prompt string) (string, error) {
+	in := cmd.InOrStdin()
+	fmt.Fprint(cmd.ErrOrStderr(), prompt)
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", fmt.Errorf("reading input: %w", err)
+	}
+	return line, nil
 }
 
 func requestDeviceCode(ctx context.Context, apiURL string) (*deviceCodeResponse, error) {

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -127,6 +128,192 @@ func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
 	}
 	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
 		t.Fatalf("expected config permissions 0600, got %o", info.Mode().Perm())
+	}
+}
+
+func TestLoginPromptsWorkspaceSelection(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	oldOpenBrowser := openBrowser
+	oldInputIsTerminal := inputIsTerminal
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+		openBrowser = oldOpenBrowser
+		inputIsTerminal = oldInputIsTerminal
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+	flagOutputFormat = "json"
+	openBrowser = func(string) error { return nil }
+	inputIsTerminal = func(io.Reader) bool { return true }
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+
+	accessToken := "test-access-token"
+	secondWorkspaceID := "00000000-0000-0000-0000-000000000222"
+	receivedWorkspaceAuth := ""
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			_ = json.NewEncoder(w).Encode(deviceCodeResponse{
+				DeviceCode:      "device-code",
+				UserCode:        "ABCD-EFGH",
+				VerificationURI: tsActivateURL(r),
+				ExpiresIn:       60,
+				Interval:        0,
+			})
+		case "/oauth/token":
+			_ = json.NewEncoder(w).Encode(oauthTokenResponse{
+				AccessToken:  accessToken,
+				ExpiresIn:    300,
+				RefreshToken: "test-refresh-token",
+			})
+		case "/api/v1/workspaces":
+			receivedWorkspaceAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"id":           "00000000-0000-0000-0000-000000000111",
+					"display_name": "First Workspace",
+				},
+				{
+					"id":           secondWorkspaceID,
+					"display_name": "Second Workspace",
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	root := NewRootCmd("test", "test")
+	root.SetIn(strings.NewReader("2\n"))
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"login", "--api-url", ts.URL, "--no-browser"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())
+	}
+	if receivedWorkspaceAuth != "Bearer "+accessToken {
+		t.Fatalf("expected workspace list to use OAuth bearer token, got %q", receivedWorkspaceAuth)
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout.String())
+	}
+	if result["workspace_id"] != secondWorkspaceID {
+		t.Fatalf("expected selected workspace ID %q, got %q", secondWorkspaceID, result["workspace_id"])
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.Profiles["default"].WorkspaceID; got != secondWorkspaceID {
+		t.Fatalf("expected saved workspace ID %q, got %q", secondWorkspaceID, got)
+	}
+}
+
+func TestLoginWarnsWhenNonInteractiveWithoutWorkspace(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	oldOpenBrowser := openBrowser
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+		openBrowser = oldOpenBrowser
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+	flagOutputFormat = "json"
+	openBrowser = func(string) error { return nil }
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+
+	workspaceListCalled := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			_ = json.NewEncoder(w).Encode(deviceCodeResponse{
+				DeviceCode:      "device-code",
+				UserCode:        "ABCD-EFGH",
+				VerificationURI: tsActivateURL(r),
+				ExpiresIn:       60,
+				Interval:        0,
+			})
+		case "/oauth/token":
+			_ = json.NewEncoder(w).Encode(oauthTokenResponse{
+				AccessToken:  "test-access-token",
+				ExpiresIn:    300,
+				RefreshToken: "test-refresh-token",
+			})
+		case "/api/v1/workspaces":
+			workspaceListCalled = true
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	root := NewRootCmd("test", "test")
+	root.SetIn(strings.NewReader(""))
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"login", "--api-url", ts.URL, "--no-browser"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "No default workspace set") {
+		t.Fatalf("expected workspace warning, got %q", stderr.String())
+	}
+	if workspaceListCalled {
+		t.Fatal("did not expect workspace list request for non-interactive login")
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout.String())
+	}
+	if result["workspace_id"] != "" {
+		t.Fatalf("expected workspace_id to be omitted, got %q", result["workspace_id"])
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := cfg.Profiles["default"]
+	if profile.OAuth.AccessToken != "test-access-token" {
+		t.Fatal("access token was not saved")
+	}
+	if profile.WorkspaceID != "" {
+		t.Fatalf("expected saved profile to omit workspace ID, got %q", profile.WorkspaceID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- list available workspaces after `langsmith login` completes OAuth and prompt for a default workspace in interactive terminals
- allow non-interactive login to complete without a workspace, but print a warning with `--workspace-id` / `workspace set-default` guidance
- format LangSmith JSON error responses so workspace-required auth errors show the server error code and message

## Commands and observed output
- `langsmith login --api-url https://api.smith.langchain.com --no-browser --timeout 10m`
  - opened `https://smith.langchain.com/activate` and displayed a device code
  - after authorization, printed `Select a default workspace:` with numbered workspace options
  - selecting `1` saved `workspace_id: ebbaf2eb-769b-4505-aca2-d11de10372a4` for LangChain Inc
- `langsmith project list --limit 1` using the saved temp profile returned a project from the selected workspace
- `langsmith workspace list --format pretty` using the saved temp profile returned the workspace table

## Tests
- `go test ./internal/cmd -run TestLogin -count=1`
- `go test ./internal/client -run TestRawGet_JSONHTTPErrorIncludesMessage -count=1`
- `go test ./... -count=1`