### PR TITLE
refactor: use SDK for sandbox commands

### DIFF
--- a/internal/cmd/sandbox_auth.go
+++ b/internal/cmd/sandbox_auth.go
@@ -15,17 +15,17 @@ type sandboxEndpoint struct {
 // for operations that only need the dataplane URL regardless of status.
 func resolveSandbox(ctx context.Context, name string) (sandboxEndpoint, error) {
 	c := MustGetClient()
-	var box boxResponse
-	if err := c.RawGet(ctx, "/v2/sandboxes/boxes/"+name, &box); err != nil {
+	box, err := c.SDK.Sandboxes.Boxes.Get(ctx, name)
+	if err != nil {
 		return sandboxEndpoint{}, fmt.Errorf("getting sandbox: %w", err)
 	}
 	if box.Status != "ready" {
 		return sandboxEndpoint{}, fmt.Errorf("sandbox %q is not ready (status: %s)", name, box.Status)
 	}
-	if box.DataplaneURL == nil || *box.DataplaneURL == "" {
+	if box.DataplaneURL == "" {
 		return sandboxEndpoint{}, fmt.Errorf("sandbox %q has no dataplane URL", name)
 	}
-	return sandboxEndpoint{DataplaneURL: *box.DataplaneURL}, nil
+	return sandboxEndpoint{DataplaneURL: box.DataplaneURL}, nil
 }
 
 // resolveSandboxURL resolves a sandbox name to its dataplane URL without
@@ -33,14 +33,14 @@ func resolveSandbox(ctx context.Context, name string) (sandboxEndpoint, error) {
 // sandbox is still starting.
 func resolveSandboxURL(ctx context.Context, name string) (string, error) {
 	c := MustGetClient()
-	var box boxResponse
-	if err := c.RawGet(ctx, "/v2/sandboxes/boxes/"+name, &box); err != nil {
+	box, err := c.SDK.Sandboxes.Boxes.Get(ctx, name)
+	if err != nil {
 		return "", fmt.Errorf("getting sandbox: %w", err)
 	}
-	if box.DataplaneURL == nil || *box.DataplaneURL == "" {
+	if box.DataplaneURL == "" {
 		return "", fmt.Errorf("sandbox %q has no dataplane URL", name)
 	}
-	return *box.DataplaneURL, nil
+	return box.DataplaneURL, nil
 }
 
 // sandboxAuthHeaders returns the auth headers for sandbox dataplane requests.

--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -8,42 +8,18 @@ import (
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	"github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 
-// Sandbox API types.
-
-type boxResponse struct {
-	ID              string  `json:"id"`
-	Name            string  `json:"name"`
-	SnapshotID      *string `json:"snapshot_id,omitempty"`
-	VCPUs           int     `json:"vcpus,omitempty"`
-	MemBytes        int64   `json:"mem_bytes,omitempty"`
-	FsCapacityBytes *int64  `json:"fs_capacity_bytes,omitempty"`
-	Status          string  `json:"status"`
-	DataplaneURL    *string `json:"dataplane_url,omitempty"`
-	CreatedAt       string  `json:"created_at"`
-	UpdatedAt       string  `json:"updated_at"`
-}
-
-type boxListResponse struct {
-	Sandboxes []boxResponse `json:"sandboxes"`
-}
-
-type boxStatusResponse struct {
-	Status        string  `json:"status"`
-	StatusMessage *string `json:"status_message,omitempty"`
-}
-
 const defaultBoxPollInterval = 2 * time.Second
 
-// waitForBoxReady polls until the sandbox reaches "ready" or a terminal state.
-func waitForBoxReady(ctx context.Context, c *client.Client, name string, timeout time.Duration) (boxStatusResponse, error) {
+func waitForBoxReady(ctx context.Context, c *client.Client, name string, timeout time.Duration) (*langsmith.SandboxBoxGetStatusResponse, error) {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		var resp boxStatusResponse
-		if err := c.RawGet(ctx, "/v2/sandboxes/boxes/"+name+"/status", &resp); err != nil {
-			return boxStatusResponse{}, err
+		resp, err := c.SDK.Sandboxes.Boxes.GetStatus(ctx, name)
+		if err != nil {
+			return nil, err
 		}
 		switch resp.Status {
 		case "ready":
@@ -53,7 +29,7 @@ func waitForBoxReady(ctx context.Context, c *client.Client, name string, timeout
 		}
 		time.Sleep(defaultBoxPollInterval)
 	}
-	return boxStatusResponse{}, fmt.Errorf("timed out after %s waiting for sandbox", timeout)
+	return nil, fmt.Errorf("timed out after %s waiting for sandbox", timeout)
 }
 
 func newSandboxCreateCmd() *cobra.Command {
@@ -117,33 +93,33 @@ Examples:
 				ExitErrorf("invalid --memory: %v", err)
 			}
 
-			body := map[string]any{
-				"name":        name,
-				"snapshot_id": snapshotID,
-				"vcpus":       vcpus,
-				"mem_bytes":   memBytes,
+			params := langsmith.SandboxBoxNewParams{
+				Name:       langsmith.F(name),
+				SnapshotID: langsmith.F(snapshotID),
+				Vcpus:      langsmith.F(int64(vcpus)),
+				MemBytes:   langsmith.F(memBytes),
 			}
 			if rootfs != "" {
 				rootfsBytes, err := parseByteSize(rootfs)
 				if err != nil {
 					ExitErrorf("invalid --rootfs-capacity: %v", err)
 				}
-				body["fs_capacity_bytes"] = rootfsBytes
+				params.FsCapacityBytes = langsmith.F(rootfsBytes)
 			}
 			if proxyConfig != "" {
 				pc, err := loadJSONArg(proxyConfig)
 				if err != nil {
 					ExitErrorf("invalid --proxy-config: %v", err)
 				}
-				body["proxy_config"] = pc
+				params.ProxyConfig = langsmith.Raw[langsmith.SandboxBoxNewParamsProxyConfig](pc)
 			}
 			if wait {
-				body["wait_for_ready"] = true
-				body["timeout"] = timeoutSec
+				params.WaitForReady = langsmith.F(true)
+				params.Timeout = langsmith.F(int64(timeoutSec))
 			}
 
-			var resp boxResponse
-			if err := c.RawPost(ctx, "/v2/sandboxes/boxes", body, &resp); err != nil {
+			resp, err := c.SDK.Sandboxes.Boxes.New(ctx, params)
+			if err != nil {
 				ExitErrorf("creating sandbox: %v", err)
 			}
 
@@ -170,8 +146,8 @@ func newSandboxListCmd() *cobra.Command {
 			c := MustGetClient()
 			ctx := context.Background()
 
-			var resp boxListResponse
-			if err := c.RawGet(ctx, "/v2/sandboxes/boxes", &resp); err != nil {
+			resp, err := c.SDK.Sandboxes.Boxes.List(ctx, langsmith.SandboxBoxListParams{})
+			if err != nil {
 				ExitErrorf("listing sandboxes: %v", err)
 			}
 
@@ -182,24 +158,23 @@ func newSandboxListCmd() *cobra.Command {
 				var rows [][]string
 				for _, b := range resp.Sandboxes {
 					snap := "-"
-					if b.SnapshotID != nil {
-						if len(*b.SnapshotID) > 8 {
-							snap = (*b.SnapshotID)[:8] + "..."
-						} else {
-							snap = *b.SnapshotID
+					if b.SnapshotID != "" {
+						snap = b.SnapshotID
+						if len(snap) > 8 {
+							snap = snap[:8] + "..."
 						}
 					}
 					diskStr := "-"
-					if b.FsCapacityBytes != nil {
-						diskStr = formatBytes(*b.FsCapacityBytes)
+					if b.FsCapacityBytes > 0 {
+						diskStr = formatBytes(b.FsCapacityBytes)
 					}
 					mem := "-"
 					if b.MemBytes > 0 {
 						mem = formatBytes(b.MemBytes)
 					}
 					vcpusStr := "-"
-					if b.VCPUs > 0 {
-						vcpusStr = fmt.Sprintf("%d", b.VCPUs)
+					if b.Vcpus > 0 {
+						vcpusStr = fmt.Sprintf("%d", b.Vcpus)
 					}
 					rows = append(rows, []string{
 						b.Name, b.Status, vcpusStr, mem, diskStr, snap, formatTime(b.CreatedAt),
@@ -223,8 +198,8 @@ func newSandboxGetCmd() *cobra.Command {
 			c := MustGetClient()
 			ctx := context.Background()
 
-			var resp boxResponse
-			if err := c.RawGet(ctx, "/v2/sandboxes/boxes/"+args[0], &resp); err != nil {
+			resp, err := c.SDK.Sandboxes.Boxes.Get(ctx, args[0])
+			if err != nil {
 				ExitErrorf("getting sandbox: %v", err)
 			}
 
@@ -257,38 +232,38 @@ for the proxy config JSON format.`,
 			c := MustGetClient()
 			ctx := context.Background()
 
-			body := map[string]any{}
+			params := langsmith.SandboxBoxUpdateParams{}
 			if cmd.Flags().Changed("vcpus") {
-				body["vcpus"] = vcpus
+				params.Vcpus = langsmith.F(int64(vcpus))
 			}
 			if cmd.Flags().Changed("memory") {
 				memBytes, err := parseByteSize(memory)
 				if err != nil {
 					ExitErrorf("invalid --memory: %v", err)
 				}
-				body["mem_bytes"] = memBytes
+				params.MemBytes = langsmith.F(memBytes)
 			}
 			if cmd.Flags().Changed("rootfs-capacity") {
 				rootfsBytes, err := parseByteSize(rootfs)
 				if err != nil {
 					ExitErrorf("invalid --rootfs-capacity: %v", err)
 				}
-				body["fs_capacity_bytes"] = rootfsBytes
+				params.FsCapacityBytes = langsmith.F(rootfsBytes)
 			}
 			if cmd.Flags().Changed("proxy-config") {
 				pc, err := loadJSONArg(proxyConfig)
 				if err != nil {
 					ExitErrorf("invalid --proxy-config: %v", err)
 				}
-				body["proxy_config"] = pc
+				params.ProxyConfig = langsmith.Raw[langsmith.SandboxBoxUpdateParamsProxyConfig](pc)
 			}
 
-			if len(body) == 0 {
+			if !cmd.Flags().Changed("vcpus") && !cmd.Flags().Changed("memory") && !cmd.Flags().Changed("rootfs-capacity") && !cmd.Flags().Changed("proxy-config") {
 				ExitError("nothing to update (use --vcpus, --memory, --rootfs-capacity, or --proxy-config)")
 			}
 
-			var resp boxResponse
-			if err := c.RawPatch(ctx, "/v2/sandboxes/boxes/"+args[0], body, &resp); err != nil {
+			resp, err := c.SDK.Sandboxes.Boxes.Update(ctx, args[0], params)
+			if err != nil {
 				ExitErrorf("updating sandbox: %v", err)
 			}
 
@@ -313,7 +288,7 @@ func newSandboxDeleteCmd() *cobra.Command {
 			c := MustGetClient()
 			ctx := context.Background()
 
-			if err := c.RawDelete(ctx, "/v2/sandboxes/boxes/"+args[0], nil); err != nil {
+			if err := c.SDK.Sandboxes.Boxes.Delete(ctx, args[0]); err != nil {
 				ExitErrorf("deleting sandbox: %v", err)
 			}
 
@@ -412,7 +387,7 @@ func newSandboxStartCmd() *cobra.Command {
 			c := MustGetClient()
 			ctx := context.Background()
 
-			if err := c.RawPost(ctx, "/v2/sandboxes/boxes/"+args[0]+"/start", nil, nil); err != nil {
+			if _, err := c.SDK.Sandboxes.Boxes.Start(ctx, args[0]); err != nil {
 				ExitErrorf("starting sandbox: %v", err)
 			}
 
@@ -440,7 +415,7 @@ func newSandboxStopCmd() *cobra.Command {
 			c := MustGetClient()
 			ctx := context.Background()
 
-			if err := c.RawPost(ctx, "/v2/sandboxes/boxes/"+args[0]+"/stop", nil, nil); err != nil {
+			if err := c.SDK.Sandboxes.Boxes.Stop(ctx, args[0]); err != nil {
 				ExitErrorf("stopping sandbox: %v", err)
 			}
 

--- a/internal/cmd/sandbox_snapshot.go
+++ b/internal/cmd/sandbox_snapshot.go
@@ -11,29 +11,9 @@ import (
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	"github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
-
-// Snapshot API types (v2/sandboxes/snapshots).
-
-type snapshotResponse struct {
-	ID              string  `json:"id"`
-	Name            string  `json:"name"`
-	DockerImage     *string `json:"docker_image,omitempty"`
-	ImageDigest     *string `json:"image_digest,omitempty"`
-	SourceSandboxID *string `json:"source_sandbox_id,omitempty"`
-	Status          string  `json:"status"`
-	StatusMessage   *string `json:"status_message,omitempty"`
-	FsSizeBytes     int64   `json:"fs_capacity_bytes"`
-	SizeBytes       *int64  `json:"fs_used_bytes,omitempty"`
-	CreatedAt       string  `json:"created_at"`
-	UpdatedAt       string  `json:"updated_at"`
-}
-
-type snapshotListResponse struct {
-	Snapshots []snapshotResponse `json:"snapshots"`
-	Offset    int                `json:"offset"`
-}
 
 func newSandboxSnapshotCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -69,8 +49,8 @@ func newSnapshotListCmd() *cobra.Command {
 			c := MustGetClient()
 			ctx := context.Background()
 
-			var resp snapshotListResponse
-			if err := c.RawGet(ctx, "/v2/sandboxes/snapshots", &resp); err != nil {
+			resp, err := c.SDK.Sandboxes.Snapshots.List(ctx, langsmith.SandboxSnapshotListParams{})
+			if err != nil {
 				ExitErrorf("listing snapshots: %v", err)
 			}
 
@@ -81,12 +61,12 @@ func newSnapshotListCmd() *cobra.Command {
 				var rows [][]string
 				for _, s := range resp.Snapshots {
 					image := "-"
-					if s.DockerImage != nil {
-						image = *s.DockerImage
+					if s.DockerImage != "" {
+						image = s.DockerImage
 					}
 					size := "-"
-					if s.SizeBytes != nil {
-						size = formatBytes(*s.SizeBytes)
+					if s.FsUsedBytes > 0 {
+						size = formatBytes(s.FsUsedBytes)
 					}
 					rows = append(rows, []string{
 						s.ID, s.Name, image, s.Status, size, formatTime(s.CreatedAt),
@@ -103,13 +83,11 @@ func newSnapshotListCmd() *cobra.Command {
 
 func newSnapshotBuildCmd() *cobra.Command {
 	var (
-		dockerImage      string
-		capacity         string
-		registryURL      string
-		registryUsername string
-		registryPassword string
-		wait             bool
-		timeoutSec       int
+		dockerImage string
+		capacity    string
+		registryID  string
+		wait        bool
+		timeoutSec  int
 	)
 
 	cmd := &cobra.Command{
@@ -135,35 +113,32 @@ Examples:
 			c := MustGetClient()
 			ctx := context.Background()
 
-			body := map[string]any{
-				"name":              name,
-				"docker_image":      dockerImage,
-				"fs_capacity_bytes": capBytes,
+			params := langsmith.SandboxSnapshotNewParams{
+				Name:            langsmith.F(name),
+				DockerImage:     langsmith.F(dockerImage),
+				FsCapacityBytes: langsmith.F(capBytes),
 			}
-			if registryURL != "" {
-				body["registry_url"] = registryURL
-				body["registry_username"] = registryUsername
-				body["registry_password"] = registryPassword
+			if registryID != "" {
+				params.RegistryID = langsmith.F(registryID)
 			}
 
-			var resp snapshotResponse
-			if err := c.RawPost(ctx, "/v2/sandboxes/snapshots", body, &resp); err != nil {
+			resp, err := c.SDK.Sandboxes.Snapshots.New(ctx, params)
+			if err != nil {
 				ExitErrorf("building snapshot: %v", err)
 			}
 
+			var result any = resp
 			if wait {
-				resp = waitForSnapshot(ctx, c, resp.ID, time.Duration(timeoutSec)*time.Second)
+				result = waitForSnapshot(ctx, c, resp.ID, time.Duration(timeoutSec)*time.Second)
 			}
 
-			output.OutputJSON(resp, "")
+			output.OutputJSON(result, "")
 		},
 	}
 
 	cmd.Flags().StringVar(&dockerImage, "docker-image", "", "Docker image to build from (required)")
 	cmd.Flags().StringVar(&capacity, "capacity", "4gb", "Filesystem capacity with unit (e.g. 4gb, 8gb)")
-	cmd.Flags().StringVar(&registryURL, "registry-url", "", "Registry URL for private images")
-	cmd.Flags().StringVar(&registryUsername, "registry-username", "", "Registry username")
-	cmd.Flags().StringVar(&registryPassword, "registry-password", "", "Registry password")
+	cmd.Flags().StringVar(&registryID, "registry-id", "", "Registry ID for private images")
 	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for the snapshot to become ready")
 	cmd.Flags().IntVar(&timeoutSec, "timeout", 300, "Timeout in seconds when using --wait")
 
@@ -198,23 +173,24 @@ Examples:
 			c := MustGetClient()
 			ctx := context.Background()
 
-			body := map[string]any{
-				"name": name,
+			params := langsmith.SandboxBoxNewSnapshotParams{
+				Name: langsmith.F(name),
 			}
 			if checkpoint != "" {
-				body["checkpoint"] = checkpoint
+				params.Checkpoint = langsmith.F(checkpoint)
 			}
 
-			var resp snapshotResponse
-			if err := c.RawPost(ctx, "/v2/sandboxes/boxes/"+boxName+"/snapshot", body, &resp); err != nil {
+			resp, err := c.SDK.Sandboxes.Boxes.NewSnapshot(ctx, boxName, params)
+			if err != nil {
 				ExitErrorf("capturing snapshot: %v", err)
 			}
 
+			var result any = resp
 			if wait {
-				resp = waitForSnapshot(ctx, c, resp.ID, time.Duration(timeoutSec)*time.Second)
+				result = waitForSnapshot(ctx, c, resp.ID, time.Duration(timeoutSec)*time.Second)
 			}
 
-			output.OutputJSON(resp, "")
+			output.OutputJSON(result, "")
 		},
 	}
 
@@ -235,8 +211,8 @@ func newSnapshotGetCmd() *cobra.Command {
 			c := MustGetClient()
 			ctx := context.Background()
 
-			var resp snapshotResponse
-			if err := c.RawGet(ctx, "/v2/sandboxes/snapshots/"+args[0], &resp); err != nil {
+			resp, err := c.SDK.Sandboxes.Snapshots.Get(ctx, args[0])
+			if err != nil {
 				ExitErrorf("getting snapshot: %v", err)
 			}
 
@@ -255,7 +231,7 @@ func newSnapshotDeleteCmd() *cobra.Command {
 			c := MustGetClient()
 			ctx := context.Background()
 
-			if err := c.RawDelete(ctx, "/v2/sandboxes/snapshots/"+args[0], nil); err != nil {
+			if err := c.SDK.Sandboxes.Snapshots.Delete(ctx, args[0]); err != nil {
 				ExitErrorf("deleting snapshot: %v", err)
 			}
 
@@ -287,11 +263,11 @@ func newSnapshotWaitCmd() *cobra.Command {
 }
 
 // waitForSnapshot polls until the snapshot is ready or fails.
-func waitForSnapshot(ctx context.Context, c *client.Client, id string, timeout time.Duration) snapshotResponse {
+func waitForSnapshot(ctx context.Context, c *client.Client, id string, timeout time.Duration) *langsmith.SandboxSnapshotGetResponse {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		var resp snapshotResponse
-		if err := c.RawGet(ctx, "/v2/sandboxes/snapshots/"+id, &resp); err != nil {
+		resp, err := c.SDK.Sandboxes.Snapshots.Get(ctx, id)
+		if err != nil {
 			ExitErrorf("getting snapshot: %v", err)
 		}
 		switch resp.Status {
@@ -299,15 +275,15 @@ func waitForSnapshot(ctx context.Context, c *client.Client, id string, timeout t
 			return resp
 		case "failed":
 			msg := "unknown error"
-			if resp.StatusMessage != nil {
-				msg = *resp.StatusMessage
+			if resp.StatusMessage != "" {
+				msg = resp.StatusMessage
 			}
 			ExitErrorf("snapshot build failed: %s", msg)
 		}
 		time.Sleep(2 * time.Second)
 	}
 	ExitErrorf("timed out after %s waiting for snapshot", timeout)
-	return snapshotResponse{} // unreachable
+	return nil
 }
 
 func formatBytes(b int64) string {
@@ -364,7 +340,7 @@ func parseByteSize(s string) (int64, error) {
 
 	bytes := int64(num * multiplier)
 
-	const minBytes = 1024 * 1024              // 1 MB
+	const minBytes = 1024 * 1024                      // 1 MB
 	const maxBytes = 1024 * 1024 * 1024 * 1024 * 1024 // 1 PB
 	if bytes < minBytes {
 		return 0, fmt.Errorf("invalid size %q: must be at least 1mb", s)

--- a/internal/cmd/sandbox_test.go
+++ b/internal/cmd/sandbox_test.go
@@ -205,6 +205,18 @@ func TestSnapshotBuildCmd_CapacityFlag(t *testing.T) {
 	}
 }
 
+func TestSnapshotBuildCmd_RegistryIDFlag(t *testing.T) {
+	cmd := newSnapshotBuildCmd()
+	if f := cmd.Flags().Lookup("registry-id"); f == nil {
+		t.Fatal("flag --registry-id not found")
+	}
+	for _, name := range []string{"registry-url", "registry-username", "registry-password"} {
+		if f := cmd.Flags().Lookup(name); f != nil {
+			t.Fatalf("obsolete flag --%s should not exist", name)
+		}
+	}
+}
+
 // ==================== loadJSONArg ====================
 
 func TestLoadJSONArg_InlineValid(t *testing.T) {


### PR DESCRIPTION
## Summary

Use the LangSmith Go SDK for sandbox control-plane commands instead of hand-rolled raw HTTP structs and calls.

This also updates snapshot builds to use `--registry-id` instead of the removed inline registry credential flags.

## Test Plan

- [x] `go test ./... -run '^$'`
- [x] `go test ./internal/cmd -run 'TestSnapshotBuildCmd|TestSandboxCmd|TestSnapshotCmd|TestSandboxCreateCmd|TestSandboxUpdateCmd|TestLoadJSONArg|TestParseByteSize|TestDataplane|TestSandboxTunnelCmd' -count=1 -timeout 30s`
