### PR TITLE
feat(issues): add --status flag to issues update command

### DIFF
--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -285,12 +285,11 @@ The issue ID is the UUID returned by 'langsmith project issues list'.
 --title and --description are for factual corrections only (when new evidence disproves the original finding).
 --proposed-fix updates the suggested code fix shown to users.
 --evaluator replaces the suggested evaluator. Pass the evaluator config as JSON — the CLI wraps it automatically.
---status changes the issue status. Valid values: open, completed, ignored. Use 'open' to reopen a resolved issue.
+--status reopens a resolved issue. The only accepted value is 'open' — closing an issue is a human action done via the UI.
 
 Examples:
   langsmith project issues update <id> --title "Corrected title" --description "New finding..."
   langsmith project issues update <id> --status open
-  langsmith project issues update <id> --status completed
   langsmith project issues update <id> --proposed-fix "Root cause: missing null check.\n\` + "`" + `` + "`" + `diff\n-if result:\n+if result is not None:\n` + "`" + `` + "`" + `"
   langsmith project issues update <id> --evaluator '{"type":"llm","display_name":"no_hallucination","prompt":[["system","Evaluate whether the response contains hallucinated facts. Score 1 if grounded, 0 if not."],["user","Evaluate and score."]],"schema":{"type":"object","properties":{"score":{"type":"integer","minimum":0,"maximum":1},"reasoning":{"type":"string"}},"required":["score","reasoning"]}}'
   langsmith project issues update <id> --evaluator '{"type":"code","display_name":"no_tool_errors","code_evaluators":[{"code":"def perform_eval(run, example=None):\n    out = str((run.outputs or {}).get(\"output\",\"\")).lower()\n    return {\"score\": 0 if \"error\" in out else 1, \"key\": \"no_tool_errors\"}","language":"python"}]}'`,
@@ -300,8 +299,8 @@ Examples:
 			if title == "" && description == "" && proposedFix == "" && evaluator == "" && status == "" {
 				ExitError("at least one of --title, --description, --proposed-fix, --evaluator, or --status is required")
 			}
-			if status != "" && status != "open" && status != "completed" && status != "ignored" {
-				ExitError("--status must be one of: open, completed, ignored")
+			if status != "" && status != "open" {
+				ExitError("--status only accepts 'open' — closing an issue is done via the UI")
 			}
 
 			c := MustGetClient()
@@ -362,7 +361,7 @@ Examples:
 	cmd.Flags().StringVar(&title, "title", "", "Corrected title (use only when original is factually wrong)")
 	cmd.Flags().StringVar(&description, "description", "", "Corrected description (use only when original is factually wrong)")
 	cmd.Flags().StringVar(&proposedFix, "proposed-fix", "", "Updated proposed fix (markdown with code diff)")
-	cmd.Flags().StringVar(&status, "status", "", "Set issue status: open, completed, or ignored (use 'open' to reopen a resolved issue)")
+	cmd.Flags().StringVar(&status, "status", "", "Reopen a resolved issue. Only 'open' is accepted — closing is done via the UI")
 	cmd.Flags().StringVar(&evaluator, "evaluator", "", `Replace the suggested evaluator. JSON with "type" ("llm" or "code"), "display_name", and type-specific fields`)
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 

--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -269,12 +269,13 @@ func newProjectIssuesUpdateCmd() *cobra.Command {
 		description string
 		proposedFix string
 		evaluator   string
+		status      string
 		outputFile  string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "update <issue-id>",
-		Short: "[Private Beta] Update an existing issue's title, description, proposed fix, or evaluator",
+		Short: "[Private Beta] Update an existing issue's title, description, proposed fix, evaluator, or status",
 		Long: `[Private Beta] Update an existing issue.
 
 To link runs as evidence, use 'langsmith project issues runs add' instead.
@@ -284,17 +285,23 @@ The issue ID is the UUID returned by 'langsmith project issues list'.
 --title and --description are for factual corrections only (when new evidence disproves the original finding).
 --proposed-fix updates the suggested code fix shown to users.
 --evaluator replaces the suggested evaluator. Pass the evaluator config as JSON — the CLI wraps it automatically.
+--status changes the issue status. Valid values: open, completed, ignored. Use 'open' to reopen a resolved issue.
 
 Examples:
   langsmith project issues update <id> --title "Corrected title" --description "New finding..."
+  langsmith project issues update <id> --status open
+  langsmith project issues update <id> --status completed
   langsmith project issues update <id> --proposed-fix "Root cause: missing null check.\n\` + "`" + `` + "`" + `diff\n-if result:\n+if result is not None:\n` + "`" + `` + "`" + `"
   langsmith project issues update <id> --evaluator '{"type":"llm","display_name":"no_hallucination","prompt":[["system","Evaluate whether the response contains hallucinated facts. Score 1 if grounded, 0 if not."],["user","Evaluate and score."]],"schema":{"type":"object","properties":{"score":{"type":"integer","minimum":0,"maximum":1},"reasoning":{"type":"string"}},"required":["score","reasoning"]}}'
   langsmith project issues update <id> --evaluator '{"type":"code","display_name":"no_tool_errors","code_evaluators":[{"code":"def perform_eval(run, example=None):\n    out = str((run.outputs or {}).get(\"output\",\"\")).lower()\n    return {\"score\": 0 if \"error\" in out else 1, \"key\": \"no_tool_errors\"}","language":"python"}]}'`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			issueID := args[0]
-			if title == "" && description == "" && proposedFix == "" && evaluator == "" {
-				ExitError("at least one of --title, --description, --proposed-fix, or --evaluator is required")
+			if title == "" && description == "" && proposedFix == "" && evaluator == "" && status == "" {
+				ExitError("at least one of --title, --description, --proposed-fix, --evaluator, or --status is required")
+			}
+			if status != "" && status != "open" && status != "completed" && status != "ignored" {
+				ExitError("--status must be one of: open, completed, ignored")
 			}
 
 			c := MustGetClient()
@@ -309,6 +316,9 @@ Examples:
 			}
 			if proposedFix != "" {
 				body["proposed_fix"] = proposedFix
+			}
+			if status != "" {
+				body["status"] = status
 			}
 			if evaluator != "" {
 				var evalConfig map[string]any
@@ -352,6 +362,7 @@ Examples:
 	cmd.Flags().StringVar(&title, "title", "", "Corrected title (use only when original is factually wrong)")
 	cmd.Flags().StringVar(&description, "description", "", "Corrected description (use only when original is factually wrong)")
 	cmd.Flags().StringVar(&proposedFix, "proposed-fix", "", "Updated proposed fix (markdown with code diff)")
+	cmd.Flags().StringVar(&status, "status", "", "Set issue status: open, completed, or ignored (use 'open' to reopen a resolved issue)")
 	cmd.Flags().StringVar(&evaluator, "evaluator", "", `Replace the suggested evaluator. JSON with "type" ("llm" or "code"), "display_name", and type-specific fields`)
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 


### PR DESCRIPTION
Adds `--status open|completed|ignored` to `langsmith project issues update` so agents and users can explicitly change an issue's status from the CLI.

The primary use case is reopening a resolved issue when new trace evidence is found:
```
langsmith project issues update <id> --status open
```

This is the CLI half of the reopen feature. The backend companion PR ([langchain-ai/langchainplus#23964](https://github.com/langchain-ai/langchainplus/pull/23964)) auto-reopens issues when a run is linked via `issues runs add`, but the explicit `--status` flag is needed for cases where the agent wants direct control over issue status.

## Test Plan
- [x] `langsmith project issues update <id> --status open` reopens a completed issue
- [x] `langsmith project issues update <id> --status completed` resolves an open issue