### PR TITLE
fix(issues): rename output field name → title to match --title flag

### DIFF
--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -113,7 +113,7 @@ Examples:
 			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
-				columns := []string{"NAME", "SEVERITY", "STATUS", "TAGS", "CREATED"}
+				columns := []string{"TITLE", "SEVERITY", "STATUS", "TAGS", "CREATED"}
 				var rows [][]string
 				for _, issue := range issues {
 					sevLabel := severityLabels[issue.Severity]
@@ -387,7 +387,7 @@ func issueToMap(issue forgeIssue) map[string]any {
 	return map[string]any{
 		"id":            issue.ID,
 		"session_id":    issue.SessionID,
-		"name":          issue.Name,
+		"title":         issue.Name,
 		"description":   issue.Description,
 		"severity":      issue.Severity,
 		"status":        issue.Status,


### PR DESCRIPTION
The JSON output from `issues list` used `"name"` but the CLI flag is `--title`. Agents doing `.title` in jq got null on every issue, making it impossible to deduplicate against existing issues.

Renames `name` → `title` in `issueToMap` and the pretty-format column header to be consistent with the flag.

## Release Note
none

## Test Plan
- [ ] `langsmith project issues list --format json` output contains `title` field, not `name`
- [ ] `langsmith project issues list --format pretty` shows `TITLE` column header

[no screenshot]