### PR TITLE
refactor(sandbox): add structured command rendering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/langchain-ai/langsmith-go v0.7.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.8.1
+	github.com/stretchr/testify v1.11.1
 	github.com/xlab/treeprint v1.2.0
 	golang.org/x/term v0.41.0
 )
@@ -16,12 +17,14 @@ require (
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
@@ -42,4 +45,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,10 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
 github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/langchain-ai/langsmith-go v0.7.0 h1:7RCeSIBiXiwIepMztodn9U7eOG1dQ0543haAj7Ksgi4=
 github.com/langchain-ai/langsmith-go v0.7.0/go.mod h1:tUtPtr3nujib98CAfCgEHTL1QMoiNZ5VDx5Qb1pwYZg=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
@@ -35,6 +39,8 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
@@ -95,6 +101,8 @@ google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -18,7 +18,7 @@ func isolateConfig(t *testing.T) {
 
 func TestRootCmd_HasAllSubcommands(t *testing.T) {
 	root := NewRootCmd("1.0.0", "1.0.0")
-	expected := []string{"project", "trace", "run", "thread", "dataset", "example", "evaluator", "experiment", "login", "profile", "workspace", "self-update", "api"}
+	expected := []string{"project", "trace", "run", "thread", "dataset", "example", "evaluator", "experiment", "sandbox", "login", "profile", "workspace", "self-update", "api"}
 	cmds := root.Commands()
 
 	names := make(map[string]bool, len(cmds))

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -2,6 +2,11 @@ package cmd
 
 import "github.com/spf13/cobra"
 
+type sandboxMessage struct {
+	Name    string `json:"name,omitempty"`
+	Message string `json:"message"`
+}
+
 func newSandboxCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sandbox",
@@ -10,11 +15,11 @@ func newSandboxCmd() *cobra.Command {
 
 Common workflows:
 
-  # Build a snapshot from a Docker image and wait for it to be ready
-  langsmith sandbox snapshot build my-snap --docker-image ubuntu:24.04 --wait
+  # Build a snapshot from a Docker image
+  langsmith sandbox snapshot build my-snap --docker-image ubuntu:24.04
 
-  # Create a sandbox from the snapshot and wait for it to boot
-  langsmith sandbox create my-vm --snapshot-id <id> --wait
+  # Create a sandbox from the snapshot
+  langsmith sandbox create my-vm --snapshot-id <id>
 
   # Run a command inside the sandbox
   langsmith sandbox exec my-vm -- uname -a
@@ -31,14 +36,13 @@ Common workflows:
 	}
 
 	// Lifecycle
-	cmd.AddCommand(newSandboxCreateCmd())
-	cmd.AddCommand(newSandboxListCmd())
-	cmd.AddCommand(newSandboxGetCmd())
-	cmd.AddCommand(newSandboxUpdateCmd())
-	cmd.AddCommand(newSandboxDeleteCmd())
-	cmd.AddCommand(newSandboxStartCmd())
-	cmd.AddCommand(newSandboxStopCmd())
-	cmd.AddCommand(newSandboxWaitCmd())
+	cmd.AddCommand(sandboxCreateCommand.Cobra())
+	cmd.AddCommand(sandboxListCommand.Cobra())
+	cmd.AddCommand(sandboxGetCommand.Cobra())
+	cmd.AddCommand(sandboxUpdateCommand.Cobra())
+	cmd.AddCommand(sandboxDeleteCommand.Cobra())
+	cmd.AddCommand(sandboxStartCommand.Cobra())
+	cmd.AddCommand(sandboxStopCommand.Cobra())
 
 	// Connectivity
 	cmd.AddCommand(newSandboxExecCmd())
@@ -47,7 +51,7 @@ Common workflows:
 	cmd.AddCommand(newSandboxSSHSetupCmd())
 
 	// Sub-resources
-	cmd.AddCommand(newSandboxSnapshotCmd())
+	cmd.AddCommand(sandboxSnapshotCommand.Cobra())
 
 	return cmd
 }

--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -7,16 +7,16 @@ import (
 	"time"
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
-	"github.com/langchain-ai/langsmith-cli/internal/output"
+	"github.com/langchain-ai/langsmith-cli/internal/cmdutil"
+	"github.com/langchain-ai/langsmith-cli/internal/command"
 	"github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 
 const defaultBoxPollInterval = 2 * time.Second
 
-func waitForBoxReady(ctx context.Context, c *client.Client, name string, timeout time.Duration) (*langsmith.SandboxBoxGetStatusResponse, error) {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+func waitForBoxReady(ctx context.Context, c *client.Client, name string) (*langsmith.SandboxBoxGetStatusResponse, error) {
+	for {
 		resp, err := c.SDK.Sandboxes.Boxes.GetStatus(ctx, name)
 		if err != nil {
 			return nil, err
@@ -27,26 +27,28 @@ func waitForBoxReady(ctx context.Context, c *client.Client, name string, timeout
 		case "failed":
 			return resp, fmt.Errorf("sandbox entered %s state", resp.Status)
 		}
-		time.Sleep(defaultBoxPollInterval)
+		timer := time.NewTimer(defaultBoxPollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
 	}
-	return nil, fmt.Errorf("timed out after %s waiting for sandbox", timeout)
 }
 
-func newSandboxCreateCmd() *cobra.Command {
-	var (
-		snapshotID  string
-		vcpus       int
-		memory      string
-		rootfs      string
-		proxyConfig string
-		wait        bool
-		timeoutSec  int
-	)
+type sandboxCreateInput struct {
+	SnapshotID  string
+	VCPUs       int
+	Memory      string
+	RootFS      string
+	ProxyConfig string
+}
 
-	cmd := &cobra.Command{
-		Use:   "create <name>",
-		Short: "Create a sandbox VM from a snapshot",
-		Long: `Create a sandbox VM from a snapshot.
+var sandboxCreateCommand = command.Command[*sandboxCreateInput]{
+	Use:   "create <name>",
+	Short: "Create a sandbox VM from a snapshot",
+	Long: `Create a sandbox VM from a snapshot.
 
 The --proxy-config flag accepts inline JSON or a file path prefixed with @.
 The proxy config controls which outbound HTTP requests the sandbox proxy
@@ -76,250 +78,271 @@ responses), "workspace_secret" (resolved from workspace secrets via {KEY}).
 Examples:
   langsmith sandbox create my-vm --snapshot-id <id>
   langsmith sandbox create my-vm --snapshot-id <id> --vcpus 4 --memory 1gb
-  langsmith sandbox create my-vm --snapshot-id <id> --rootfs-capacity 8gb --wait
+  langsmith sandbox create my-vm --snapshot-id <id> --rootfs-capacity 8gb
   langsmith sandbox create my-vm --snapshot-id <id> --proxy-config @proxy.json`,
-		Args: cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			name := args[0]
-			if snapshotID == "" {
-				ExitError("--snapshot-id is required")
-			}
+	Args: cobra.ExactArgs(1),
+	Input: func(cmd *cobra.Command) *sandboxCreateInput {
+		in := &sandboxCreateInput{
+			VCPUs:  2,
+			Memory: "512mb",
+		}
+		cmd.Flags().StringVar(&in.SnapshotID, "snapshot-id", in.SnapshotID, "Snapshot ID to boot from (required)")
+		cmd.Flags().IntVar(&in.VCPUs, "vcpus", in.VCPUs, "Number of vCPUs")
+		cmd.Flags().StringVar(&in.Memory, "memory", in.Memory, "Memory with unit (e.g. 512mb, 1gb)")
+		cmd.Flags().StringVar(&in.RootFS, "rootfs-capacity", in.RootFS, "Root filesystem capacity with unit (e.g. 4gb, 8gb)")
+		cmd.Flags().StringVar(&in.ProxyConfig, "proxy-config", in.ProxyConfig, "Proxy config as JSON or @file.json")
+		return in
+	},
+	Action: func(ctx context.Context, cmd *cobra.Command, in *sandboxCreateInput, args []string) (any, error) {
+		name := args[0]
+		if in.SnapshotID == "" {
+			return nil, fmt.Errorf("--snapshot-id is required")
+		}
 
-			c := MustGetClient()
-			ctx := context.Background()
+		c, err := cmdutil.GetClient(cmd)
+		if err != nil {
+			return nil, err
+		}
 
-			memBytes, err := parseByteSize(memory)
+		memBytes, err := parseByteSize(in.Memory)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --memory: %w", err)
+		}
+
+		params := langsmith.SandboxBoxNewParams{
+			Name:       langsmith.F(name),
+			SnapshotID: langsmith.F(in.SnapshotID),
+			Vcpus:      langsmith.F(int64(in.VCPUs)),
+			MemBytes:   langsmith.F(memBytes),
+		}
+		if in.RootFS != "" {
+			rootfsBytes, err := parseByteSize(in.RootFS)
 			if err != nil {
-				ExitErrorf("invalid --memory: %v", err)
+				return nil, fmt.Errorf("invalid --rootfs-capacity: %w", err)
 			}
-
-			params := langsmith.SandboxBoxNewParams{
-				Name:       langsmith.F(name),
-				SnapshotID: langsmith.F(snapshotID),
-				Vcpus:      langsmith.F(int64(vcpus)),
-				MemBytes:   langsmith.F(memBytes),
-			}
-			if rootfs != "" {
-				rootfsBytes, err := parseByteSize(rootfs)
-				if err != nil {
-					ExitErrorf("invalid --rootfs-capacity: %v", err)
-				}
-				params.FsCapacityBytes = langsmith.F(rootfsBytes)
-			}
-			if proxyConfig != "" {
-				pc, err := loadJSONArg(proxyConfig)
-				if err != nil {
-					ExitErrorf("invalid --proxy-config: %v", err)
-				}
-				params.ProxyConfig = langsmith.Raw[langsmith.SandboxBoxNewParamsProxyConfig](pc)
-			}
-			if wait {
-				params.WaitForReady = langsmith.F(true)
-				params.Timeout = langsmith.F(int64(timeoutSec))
-			}
-
-			resp, err := c.SDK.Sandboxes.Boxes.New(ctx, params)
+			params.FsCapacityBytes = langsmith.F(rootfsBytes)
+		}
+		if in.ProxyConfig != "" {
+			pc, err := loadJSONArg(in.ProxyConfig)
 			if err != nil {
-				ExitErrorf("creating sandbox: %v", err)
+				return nil, fmt.Errorf("invalid --proxy-config: %w", err)
 			}
+			params.ProxyConfig = langsmith.Raw[langsmith.SandboxBoxNewParamsProxyConfig](pc)
+		}
+		resp, err := c.SDK.Sandboxes.Boxes.New(ctx, params)
+		if err != nil {
+			return nil, fmt.Errorf("creating sandbox: %w", err)
+		}
 
-			output.OutputJSON(resp, "")
-		},
-	}
-
-	cmd.Flags().StringVar(&snapshotID, "snapshot-id", "", "Snapshot ID to boot from (required)")
-	cmd.Flags().IntVar(&vcpus, "vcpus", 2, "Number of vCPUs")
-	cmd.Flags().StringVar(&memory, "memory", "512mb", "Memory with unit (e.g. 512mb, 1gb)")
-	cmd.Flags().StringVar(&rootfs, "rootfs-capacity", "", "Root filesystem capacity with unit (e.g. 4gb, 8gb)")
-	cmd.Flags().StringVar(&proxyConfig, "proxy-config", "", "Proxy config as JSON or @file.json")
-	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for the sandbox to become ready")
-	cmd.Flags().IntVar(&timeoutSec, "timeout", 120, "Timeout in seconds when using --wait")
-
-	return cmd
+		return resp, nil
+	},
+	Render: command.Template(`Name:     {{.Name}}
+Status:   {{.Status}}
+VCPUs:    {{formatCount .Vcpus}}
+Memory:   {{formatBytesOrDash .MemBytes}}
+Rootfs:   {{formatBytesOrDash .FsCapacityBytes}}
+Snapshot: {{shortID .SnapshotID}}
+Created:  {{formatTime .CreatedAt}}
+`),
 }
 
-func newSandboxListCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List all sandboxes",
-		Run: func(cmd *cobra.Command, args []string) {
-			c := MustGetClient()
-			ctx := context.Background()
+var sandboxListCommand = command.Command[struct{}]{
+	Use:   "list",
+	Short: "List all sandboxes",
+	Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+		c, err := cmdutil.GetClient(cmd)
+		if err != nil {
+			return nil, err
+		}
 
-			resp, err := c.SDK.Sandboxes.Boxes.List(ctx, langsmith.SandboxBoxListParams{})
-			if err != nil {
-				ExitErrorf("listing sandboxes: %v", err)
-			}
-
-			fmt_ := GetFormat()
-
-			if fmt_ == "pretty" && len(resp.Sandboxes) > 0 {
-				columns := []string{"Name", "Status", "VCPUs", "Mem", "Rootfs", "Snapshot", "Created"}
-				var rows [][]string
-				for _, b := range resp.Sandboxes {
-					snap := "-"
-					if b.SnapshotID != "" {
-						snap = b.SnapshotID
-						if len(snap) > 8 {
-							snap = snap[:8] + "..."
-						}
-					}
-					diskStr := "-"
-					if b.FsCapacityBytes > 0 {
-						diskStr = formatBytes(b.FsCapacityBytes)
-					}
-					mem := "-"
-					if b.MemBytes > 0 {
-						mem = formatBytes(b.MemBytes)
-					}
-					vcpusStr := "-"
-					if b.Vcpus > 0 {
-						vcpusStr = fmt.Sprintf("%d", b.Vcpus)
-					}
-					rows = append(rows, []string{
-						b.Name, b.Status, vcpusStr, mem, diskStr, snap, formatTime(b.CreatedAt),
-					})
-				}
-				output.OutputTable(columns, rows, "Sandboxes")
-			} else {
-				output.OutputJSON(resp.Sandboxes, "")
-			}
+		resp, err := c.SDK.Sandboxes.Boxes.List(ctx, langsmith.SandboxBoxListParams{})
+		if err != nil {
+			return nil, fmt.Errorf("listing sandboxes: %w", err)
+		}
+		return resp.Sandboxes, nil
+	},
+	Render: command.Table{
+		Title: "Sandboxes",
+		Rows:  ".",
+		Columns: []command.Column{
+			{Header: "Name", Template: "{{.Name}}"},
+			{Header: "Status", Template: "{{.Status}}"},
+			{Header: "VCPUs", Template: "{{formatCount .Vcpus}}"},
+			{Header: "Mem", Template: "{{formatBytesOrDash .MemBytes}}"},
+			{Header: "Rootfs", Template: "{{formatBytesOrDash .FsCapacityBytes}}"},
+			{Header: "Snapshot", Template: "{{shortID .SnapshotID}}"},
+			{Header: "Created", Template: "{{formatTime .CreatedAt}}"},
 		},
-	}
-	return cmd
+	},
 }
 
-func newSandboxGetCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "get <name>",
-		Short: "Get a sandbox by name",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			c := MustGetClient()
-			ctx := context.Background()
+var sandboxGetCommand = command.Command[struct{}]{
+	Use:   "get <name>",
+	Short: "Get a sandbox by name",
+	Args:  cobra.ExactArgs(1),
+	Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+		c, err := cmdutil.GetClient(cmd)
+		if err != nil {
+			return nil, err
+		}
 
-			resp, err := c.SDK.Sandboxes.Boxes.Get(ctx, args[0])
-			if err != nil {
-				ExitErrorf("getting sandbox: %v", err)
-			}
+		resp, err := c.SDK.Sandboxes.Boxes.Get(ctx, args[0])
+		if err != nil {
+			return nil, fmt.Errorf("getting sandbox: %w", err)
+		}
 
-			output.OutputJSON(resp, "")
-		},
-	}
-	return cmd
+		return resp, nil
+	},
+	Render: command.Template(`Name:     {{.Name}}
+Status:   {{.Status}}
+VCPUs:    {{formatCount .Vcpus}}
+Memory:   {{formatBytesOrDash .MemBytes}}
+Rootfs:   {{formatBytesOrDash .FsCapacityBytes}}
+Snapshot: {{shortID .SnapshotID}}
+Created:  {{formatTime .CreatedAt}}
+`),
 }
 
-func newSandboxUpdateCmd() *cobra.Command {
-	var (
-		vcpus       int
-		memory      string
-		rootfs      string
-		proxyConfig string
-	)
+type sandboxUpdateInput struct {
+	VCPUs       int
+	Memory      string
+	RootFS      string
+	ProxyConfig string
+}
 
-	cmd := &cobra.Command{
-		Use:   "update <name>",
-		Short: "Update sandbox resources (takes effect on next start)",
-		Long: `Update sandbox resources or proxy configuration.
+var sandboxUpdateCommand = command.Command[*sandboxUpdateInput]{
+	Use:   "update <name>",
+	Short: "Update sandbox resources (takes effect on next start)",
+	Long: `Update sandbox resources or proxy configuration.
 
 Resource changes (--vcpus, --memory, --rootfs-capacity) take effect on next start.
 Proxy config changes take effect immediately.
 
 The --proxy-config flag accepts inline JSON or @file.json. See "create --help"
 for the proxy config JSON format.`,
-		Args: cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			c := MustGetClient()
-			ctx := context.Background()
+	Args: cobra.ExactArgs(1),
+	Input: func(cmd *cobra.Command) *sandboxUpdateInput {
+		in := &sandboxUpdateInput{}
+		cmd.Flags().IntVar(&in.VCPUs, "vcpus", in.VCPUs, "Number of vCPUs")
+		cmd.Flags().StringVar(&in.Memory, "memory", in.Memory, "Memory with unit (e.g. 512mb, 1gb)")
+		cmd.Flags().StringVar(&in.RootFS, "rootfs-capacity", in.RootFS, "Root filesystem capacity with unit (e.g. 4gb, 8gb)")
+		cmd.Flags().StringVar(&in.ProxyConfig, "proxy-config", in.ProxyConfig, "Proxy config as JSON or @file.json")
+		return in
+	},
+	Action: func(ctx context.Context, cmd *cobra.Command, in *sandboxUpdateInput, args []string) (any, error) {
+		c, err := cmdutil.GetClient(cmd)
+		if err != nil {
+			return nil, err
+		}
 
-			params := langsmith.SandboxBoxUpdateParams{}
-			if cmd.Flags().Changed("vcpus") {
-				params.Vcpus = langsmith.F(int64(vcpus))
-			}
-			if cmd.Flags().Changed("memory") {
-				memBytes, err := parseByteSize(memory)
-				if err != nil {
-					ExitErrorf("invalid --memory: %v", err)
-				}
-				params.MemBytes = langsmith.F(memBytes)
-			}
-			if cmd.Flags().Changed("rootfs-capacity") {
-				rootfsBytes, err := parseByteSize(rootfs)
-				if err != nil {
-					ExitErrorf("invalid --rootfs-capacity: %v", err)
-				}
-				params.FsCapacityBytes = langsmith.F(rootfsBytes)
-			}
-			if cmd.Flags().Changed("proxy-config") {
-				pc, err := loadJSONArg(proxyConfig)
-				if err != nil {
-					ExitErrorf("invalid --proxy-config: %v", err)
-				}
-				params.ProxyConfig = langsmith.Raw[langsmith.SandboxBoxUpdateParamsProxyConfig](pc)
-			}
-
-			if !cmd.Flags().Changed("vcpus") && !cmd.Flags().Changed("memory") && !cmd.Flags().Changed("rootfs-capacity") && !cmd.Flags().Changed("proxy-config") {
-				ExitError("nothing to update (use --vcpus, --memory, --rootfs-capacity, or --proxy-config)")
-			}
-
-			resp, err := c.SDK.Sandboxes.Boxes.Update(ctx, args[0], params)
+		params := langsmith.SandboxBoxUpdateParams{}
+		if cmd.Flags().Changed("vcpus") {
+			params.Vcpus = langsmith.F(int64(in.VCPUs))
+		}
+		if cmd.Flags().Changed("memory") {
+			memBytes, err := parseByteSize(in.Memory)
 			if err != nil {
-				ExitErrorf("updating sandbox: %v", err)
+				return nil, fmt.Errorf("invalid --memory: %w", err)
 			}
+			params.MemBytes = langsmith.F(memBytes)
+		}
+		if cmd.Flags().Changed("rootfs-capacity") {
+			rootfsBytes, err := parseByteSize(in.RootFS)
+			if err != nil {
+				return nil, fmt.Errorf("invalid --rootfs-capacity: %w", err)
+			}
+			params.FsCapacityBytes = langsmith.F(rootfsBytes)
+		}
+		if cmd.Flags().Changed("proxy-config") {
+			pc, err := loadJSONArg(in.ProxyConfig)
+			if err != nil {
+				return nil, fmt.Errorf("invalid --proxy-config: %w", err)
+			}
+			params.ProxyConfig = langsmith.Raw[langsmith.SandboxBoxUpdateParamsProxyConfig](pc)
+		}
 
-			output.OutputJSON(resp, "")
-		},
-	}
+		if !cmd.Flags().Changed("vcpus") && !cmd.Flags().Changed("memory") && !cmd.Flags().Changed("rootfs-capacity") && !cmd.Flags().Changed("proxy-config") {
+			return nil, fmt.Errorf("nothing to update (use --vcpus, --memory, --rootfs-capacity, or --proxy-config)")
+		}
 
-	cmd.Flags().IntVar(&vcpus, "vcpus", 0, "Number of vCPUs")
-	cmd.Flags().StringVar(&memory, "memory", "", "Memory with unit (e.g. 512mb, 1gb)")
-	cmd.Flags().StringVar(&rootfs, "rootfs-capacity", "", "Root filesystem capacity with unit (e.g. 4gb, 8gb)")
-	cmd.Flags().StringVar(&proxyConfig, "proxy-config", "", "Proxy config as JSON or @file.json")
+		resp, err := c.SDK.Sandboxes.Boxes.Update(ctx, args[0], params)
+		if err != nil {
+			return nil, fmt.Errorf("updating sandbox: %w", err)
+		}
 
-	return cmd
+		return resp, nil
+	},
+	Render: command.Template(`Name:     {{.Name}}
+Status:   {{.Status}}
+VCPUs:    {{formatCount .Vcpus}}
+Memory:   {{formatBytesOrDash .MemBytes}}
+Rootfs:   {{formatBytesOrDash .FsCapacityBytes}}
+Snapshot: {{shortID .SnapshotID}}
+Created:  {{formatTime .CreatedAt}}
+`),
 }
 
-func newSandboxDeleteCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete a sandbox",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			c := MustGetClient()
-			ctx := context.Background()
+var sandboxDeleteCommand = command.Command[struct{}]{
+	Use:   "delete <name>",
+	Short: "Delete a sandbox",
+	Args:  cobra.ExactArgs(1),
+	Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+		c, err := cmdutil.GetClient(cmd)
+		if err != nil {
+			return nil, err
+		}
 
-			if err := c.SDK.Sandboxes.Boxes.Delete(ctx, args[0]); err != nil {
-				ExitErrorf("deleting sandbox: %v", err)
-			}
+		if err := c.SDK.Sandboxes.Boxes.Delete(ctx, args[0]); err != nil {
+			return nil, fmt.Errorf("deleting sandbox: %w", err)
+		}
 
-			fmt.Println("Sandbox deleted.")
-		},
-	}
-	return cmd
+		return sandboxMessage{Name: args[0], Message: "Sandbox deleted."}, nil
+	},
+	Render: command.Template(`{{.Message}}
+`),
 }
 
-func newSandboxWaitCmd() *cobra.Command {
-	var timeoutSec int
+var sandboxStartCommand = command.Command[struct{}]{
+	Use:   "start <name>",
+	Short: "Start a stopped sandbox",
+	Args:  cobra.ExactArgs(1),
+	Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+		c, err := cmdutil.GetClient(cmd)
+		if err != nil {
+			return nil, err
+		}
 
-	cmd := &cobra.Command{
-		Use:   "wait <name>",
-		Short: "Wait for a sandbox to become ready",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			c := MustGetClient()
-			ctx := context.Background()
+		if _, err := c.SDK.Sandboxes.Boxes.Start(ctx, args[0]); err != nil {
+			return nil, fmt.Errorf("starting sandbox: %w", err)
+		}
 
-			_, err := waitForBoxReady(ctx, c, args[0], time.Duration(timeoutSec)*time.Second)
-			if err != nil {
-				ExitErrorf("%v", err)
-			}
-			fmt.Printf("Sandbox %s is ready\n", args[0])
-		},
-	}
+		if _, err := waitForBoxReady(ctx, c, args[0]); err != nil {
+			return nil, err
+		}
+		return sandboxMessage{Name: args[0], Message: fmt.Sprintf("Sandbox %s started", args[0])}, nil
+	},
+	Render: command.Template(`{{.Message}}
+`),
+}
 
-	cmd.Flags().IntVar(&timeoutSec, "timeout", 120, "Timeout in seconds")
+var sandboxStopCommand = command.Command[struct{}]{
+	Use:   "stop <name>",
+	Short: "Stop a running sandbox (preserves data)",
+	Args:  cobra.ExactArgs(1),
+	Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+		c, err := cmdutil.GetClient(cmd)
+		if err != nil {
+			return nil, err
+		}
 
-	return cmd
+		if err := c.SDK.Sandboxes.Boxes.Stop(ctx, args[0]); err != nil {
+			return nil, fmt.Errorf("stopping sandbox: %w", err)
+		}
+
+		return sandboxMessage{Name: args[0], Message: "Sandbox stopped."}, nil
+	},
+	Render: command.Template(`{{.Message}}
+`),
 }
 
 func newSandboxExecCmd() *cobra.Command {
@@ -368,58 +391,6 @@ Examples:
 				os.Exit(result.ExitCode)
 			}
 			return nil
-		},
-	}
-	return cmd
-}
-
-func newSandboxStartCmd() *cobra.Command {
-	var (
-		wait       bool
-		timeoutSec int
-	)
-
-	cmd := &cobra.Command{
-		Use:   "start <name>",
-		Short: "Start a stopped sandbox",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			c := MustGetClient()
-			ctx := context.Background()
-
-			if _, err := c.SDK.Sandboxes.Boxes.Start(ctx, args[0]); err != nil {
-				ExitErrorf("starting sandbox: %v", err)
-			}
-
-			if wait {
-				if _, err := waitForBoxReady(ctx, c, args[0], time.Duration(timeoutSec)*time.Second); err != nil {
-					ExitErrorf("%v", err)
-				}
-			}
-			fmt.Printf("Sandbox %s started\n", args[0])
-		},
-	}
-
-	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for the sandbox to become ready")
-	cmd.Flags().IntVar(&timeoutSec, "timeout", 120, "Timeout in seconds when using --wait")
-
-	return cmd
-}
-
-func newSandboxStopCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "stop <name>",
-		Short: "Stop a running sandbox (preserves data)",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			c := MustGetClient()
-			ctx := context.Background()
-
-			if err := c.SDK.Sandboxes.Boxes.Stop(ctx, args[0]); err != nil {
-				ExitErrorf("stopping sandbox: %v", err)
-			}
-
-			fmt.Println("Sandbox stopped.")
 		},
 	}
 	return cmd

--- a/internal/cmd/sandbox_snapshot.go
+++ b/internal/cmd/sandbox_snapshot.go
@@ -7,19 +7,17 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
-	"github.com/langchain-ai/langsmith-cli/internal/client"
-	"github.com/langchain-ai/langsmith-cli/internal/output"
+	"github.com/langchain-ai/langsmith-cli/internal/cmdutil"
+	"github.com/langchain-ai/langsmith-cli/internal/command"
 	"github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 
-func newSandboxSnapshotCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "snapshot",
-		Short: "Manage sandbox snapshots (ext4 rootfs images)",
-		Long: `Manage sandbox snapshots — ext4 rootfs images built from Docker images
+var sandboxSnapshotCommand = command.Parent{
+	Use:   "snapshot",
+	Short: "Manage sandbox snapshots (ext4 rootfs images)",
+	Long: `Manage sandbox snapshots — ext4 rootfs images built from Docker images
 or captured from running sandboxes. Snapshots are used to create new sandboxes.
 
 Examples:
@@ -27,284 +25,218 @@ Examples:
   langsmith sandbox snapshot build my-snap --docker-image ubuntu:24.04
   langsmith sandbox snapshot capture my-snap --box my-vm
   langsmith sandbox snapshot get <id>
-  langsmith sandbox snapshot delete <id>
-  langsmith sandbox snapshot wait <id>`,
-	}
-
-	cmd.AddCommand(newSnapshotListCmd())
-	cmd.AddCommand(newSnapshotBuildCmd())
-	cmd.AddCommand(newSnapshotCaptureCmd())
-	cmd.AddCommand(newSnapshotGetCmd())
-	cmd.AddCommand(newSnapshotDeleteCmd())
-	cmd.AddCommand(newSnapshotWaitCmd())
-
-	return cmd
+  langsmith sandbox snapshot delete <id>`,
+	Children: []func() *cobra.Command{
+		snapshotListCommand.Cobra,
+		snapshotBuildCommand.Cobra,
+		snapshotCaptureCommand.Cobra,
+		snapshotGetCommand.Cobra,
+		snapshotDeleteCommand.Cobra,
+	},
 }
 
-func newSnapshotListCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List all snapshots",
-		Run: func(cmd *cobra.Command, args []string) {
-			c := MustGetClient()
-			ctx := context.Background()
+var snapshotListCommand = command.Command[struct{}]{
+	Use:   "list",
+	Short: "List all snapshots",
+	Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+		c, err := cmdutil.GetClient(cmd)
+		if err != nil {
+			return nil, err
+		}
 
-			resp, err := c.SDK.Sandboxes.Snapshots.List(ctx, langsmith.SandboxSnapshotListParams{})
-			if err != nil {
-				ExitErrorf("listing snapshots: %v", err)
-			}
-
-			fmt_ := GetFormat()
-
-			if fmt_ == "pretty" && len(resp.Snapshots) > 0 {
-				columns := []string{"ID", "Name", "Image", "Status", "Size", "Created"}
-				var rows [][]string
-				for _, s := range resp.Snapshots {
-					image := "-"
-					if s.DockerImage != "" {
-						image = s.DockerImage
-					}
-					size := "-"
-					if s.FsUsedBytes > 0 {
-						size = formatBytes(s.FsUsedBytes)
-					}
-					rows = append(rows, []string{
-						s.ID, s.Name, image, s.Status, size, formatTime(s.CreatedAt),
-					})
-				}
-				output.OutputTable(columns, rows, "Snapshots")
-			} else {
-				output.OutputJSON(resp.Snapshots, "")
-			}
+		resp, err := c.SDK.Sandboxes.Snapshots.List(ctx, langsmith.SandboxSnapshotListParams{})
+		if err != nil {
+			return nil, fmt.Errorf("listing snapshots: %w", err)
+		}
+		return resp.Snapshots, nil
+	},
+	Render: command.Table{
+		Title: "Snapshots",
+		Rows:  ".",
+		Columns: []command.Column{
+			{Header: "ID", Template: "{{.ID}}"},
+			{Header: "Name", Template: "{{.Name}}"},
+			{Header: "Image", Template: "{{dash .DockerImage}}"},
+			{Header: "Status", Template: "{{.Status}}"},
+			{Header: "Size", Template: "{{formatBytesOrDash .FsUsedBytes}}"},
+			{Header: "Created", Template: "{{formatTime .CreatedAt}}"},
 		},
-	}
-	return cmd
+	},
 }
 
-func newSnapshotBuildCmd() *cobra.Command {
-	var (
-		dockerImage string
-		capacity    string
-		registryID  string
-		wait        bool
-		timeoutSec  int
-	)
-
-	cmd := &cobra.Command{
-		Use:   "build <name>",
-		Short: "Build a snapshot from a Docker image",
-		Long: `Build a snapshot from a Docker image.
-
-Examples:
-  langsmith sandbox snapshot build my-snap --docker-image ubuntu:24.04
-  langsmith sandbox snapshot build my-snap --docker-image ubuntu:24.04 --capacity 8gb --wait`,
-		Args: cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			name := args[0]
-			if dockerImage == "" {
-				ExitError("--docker-image is required")
-			}
-
-			capBytes, err := parseByteSize(capacity)
-			if err != nil {
-				ExitErrorf("invalid --capacity: %v", err)
-			}
-
-			c := MustGetClient()
-			ctx := context.Background()
-
-			params := langsmith.SandboxSnapshotNewParams{
-				Name:            langsmith.F(name),
-				DockerImage:     langsmith.F(dockerImage),
-				FsCapacityBytes: langsmith.F(capBytes),
-			}
-			if registryID != "" {
-				params.RegistryID = langsmith.F(registryID)
-			}
-
-			resp, err := c.SDK.Sandboxes.Snapshots.New(ctx, params)
-			if err != nil {
-				ExitErrorf("building snapshot: %v", err)
-			}
-
-			var result any = resp
-			if wait {
-				result = waitForSnapshot(ctx, c, resp.ID, time.Duration(timeoutSec)*time.Second)
-			}
-
-			output.OutputJSON(result, "")
-		},
-	}
-
-	cmd.Flags().StringVar(&dockerImage, "docker-image", "", "Docker image to build from (required)")
-	cmd.Flags().StringVar(&capacity, "capacity", "4gb", "Filesystem capacity with unit (e.g. 4gb, 8gb)")
-	cmd.Flags().StringVar(&registryID, "registry-id", "", "Registry ID for private images")
-	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for the snapshot to become ready")
-	cmd.Flags().IntVar(&timeoutSec, "timeout", 300, "Timeout in seconds when using --wait")
-
-	return cmd
+type snapshotBuildInput struct {
+	DockerImage string
+	Capacity    string
+	RegistryID  string
 }
 
-func newSnapshotCaptureCmd() *cobra.Command {
-	var (
-		boxName    string
-		checkpoint string
-		wait       bool
-		timeoutSec int
-	)
+var snapshotBuildCommand = command.Command[*snapshotBuildInput]{
+	Use:   "build <name>",
+	Short: "Build a snapshot from a Docker image",
+	Long: `Build a snapshot from a Docker image.
 
-	cmd := &cobra.Command{
-		Use:   "capture <name>",
-		Short: "Capture a snapshot from a running sandbox",
-		Long: `Capture a snapshot from a sandbox VM. If --checkpoint is specified, uses
+	Examples:
+	  langsmith sandbox snapshot build my-snap --docker-image ubuntu:24.04
+	  langsmith sandbox snapshot build my-snap --docker-image ubuntu:24.04 --capacity 8gb`,
+	Args: cobra.ExactArgs(1),
+	Input: func(cmd *cobra.Command) *snapshotBuildInput {
+		in := &snapshotBuildInput{
+			Capacity: "4gb",
+		}
+		cmd.Flags().StringVar(&in.DockerImage, "docker-image", in.DockerImage, "Docker image to build from (required)")
+		cmd.Flags().StringVar(&in.Capacity, "capacity", in.Capacity, "Filesystem capacity with unit (e.g. 4gb, 8gb)")
+		cmd.Flags().StringVar(&in.RegistryID, "registry-id", in.RegistryID, "Registry ID for private images")
+		return in
+	},
+	Action: func(ctx context.Context, cmd *cobra.Command, in *snapshotBuildInput, args []string) (any, error) {
+		name := args[0]
+		if in.DockerImage == "" {
+			return nil, fmt.Errorf("--docker-image is required")
+		}
+
+		capBytes, err := parseByteSize(in.Capacity)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --capacity: %w", err)
+		}
+
+		c, err := cmdutil.GetClient(cmd)
+		if err != nil {
+			return nil, err
+		}
+
+		params := langsmith.SandboxSnapshotNewParams{
+			Name:            langsmith.F(name),
+			DockerImage:     langsmith.F(in.DockerImage),
+			FsCapacityBytes: langsmith.F(capBytes),
+		}
+		if in.RegistryID != "" {
+			params.RegistryID = langsmith.F(in.RegistryID)
+		}
+
+		resp, err := c.SDK.Sandboxes.Snapshots.New(ctx, params)
+		if err != nil {
+			return nil, fmt.Errorf("building snapshot: %w", err)
+		}
+
+		return resp, nil
+	},
+	Render: command.Template(`ID:      {{.ID}}
+Name:    {{.Name}}
+Image:   {{dash .DockerImage}}
+Status:  {{.Status}}
+Size:    {{formatBytesOrDash .FsUsedBytes}}
+Created: {{formatTime .CreatedAt}}
+`),
+}
+
+type snapshotCaptureInput struct {
+	BoxName    string
+	Checkpoint string
+}
+
+var snapshotCaptureCommand = command.Command[*snapshotCaptureInput]{
+	Use:   "capture <name>",
+	Short: "Capture a snapshot from a running sandbox",
+	Long: `Capture a snapshot from a sandbox VM. If --checkpoint is specified, uses
 that existing checkpoint (no VM interaction needed). Otherwise creates a
 fresh checkpoint from the running VM's current state.
 
-Examples:
-  langsmith sandbox snapshot capture my-snap --box my-vm
-  langsmith sandbox snapshot capture my-snap --box my-vm --checkpoint 2026-03-29T00:09:28Z`,
-		Args: cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			name := args[0]
-			if boxName == "" {
-				ExitError("--box is required")
-			}
+	Examples:
+	  langsmith sandbox snapshot capture my-snap --box my-vm
+	  langsmith sandbox snapshot capture my-snap --box my-vm --checkpoint 2026-03-29T00:09:28Z`,
+	Args: cobra.ExactArgs(1),
+	Input: func(cmd *cobra.Command) *snapshotCaptureInput {
+		in := &snapshotCaptureInput{}
+		cmd.Flags().StringVar(&in.BoxName, "box", in.BoxName, "Sandbox name to capture from (required)")
+		cmd.Flags().StringVar(&in.Checkpoint, "checkpoint", in.Checkpoint, "Checkpoint timestamp to use (omit for fresh checkpoint)")
+		return in
+	},
+	Action: func(ctx context.Context, cmd *cobra.Command, in *snapshotCaptureInput, args []string) (any, error) {
+		name := args[0]
+		if in.BoxName == "" {
+			return nil, fmt.Errorf("--box is required")
+		}
 
-			c := MustGetClient()
-			ctx := context.Background()
-
-			params := langsmith.SandboxBoxNewSnapshotParams{
-				Name: langsmith.F(name),
-			}
-			if checkpoint != "" {
-				params.Checkpoint = langsmith.F(checkpoint)
-			}
-
-			resp, err := c.SDK.Sandboxes.Boxes.NewSnapshot(ctx, boxName, params)
-			if err != nil {
-				ExitErrorf("capturing snapshot: %v", err)
-			}
-
-			var result any = resp
-			if wait {
-				result = waitForSnapshot(ctx, c, resp.ID, time.Duration(timeoutSec)*time.Second)
-			}
-
-			output.OutputJSON(result, "")
-		},
-	}
-
-	cmd.Flags().StringVar(&boxName, "box", "", "Sandbox name to capture from (required)")
-	cmd.Flags().StringVar(&checkpoint, "checkpoint", "", "Checkpoint timestamp to use (omit for fresh checkpoint)")
-	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for the snapshot to become ready")
-	cmd.Flags().IntVar(&timeoutSec, "timeout", 300, "Timeout in seconds when using --wait")
-
-	return cmd
-}
-
-func newSnapshotGetCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "get <snapshot-id>",
-		Short: "Get a snapshot by ID",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			c := MustGetClient()
-			ctx := context.Background()
-
-			resp, err := c.SDK.Sandboxes.Snapshots.Get(ctx, args[0])
-			if err != nil {
-				ExitErrorf("getting snapshot: %v", err)
-			}
-
-			output.OutputJSON(resp, "")
-		},
-	}
-	return cmd
-}
-
-func newSnapshotDeleteCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "delete <snapshot-id>",
-		Short: "Delete a snapshot",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			c := MustGetClient()
-			ctx := context.Background()
-
-			if err := c.SDK.Sandboxes.Snapshots.Delete(ctx, args[0]); err != nil {
-				ExitErrorf("deleting snapshot: %v", err)
-			}
-
-			fmt.Println("Snapshot deleted.")
-		},
-	}
-	return cmd
-}
-
-func newSnapshotWaitCmd() *cobra.Command {
-	var timeoutSec int
-
-	cmd := &cobra.Command{
-		Use:   "wait <snapshot-id>",
-		Short: "Wait for a snapshot to become ready",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			c := MustGetClient()
-			ctx := context.Background()
-
-			resp := waitForSnapshot(ctx, c, args[0], time.Duration(timeoutSec)*time.Second)
-			output.OutputJSON(resp, "")
-		},
-	}
-
-	cmd.Flags().IntVar(&timeoutSec, "timeout", 300, "Timeout in seconds")
-
-	return cmd
-}
-
-// waitForSnapshot polls until the snapshot is ready or fails.
-func waitForSnapshot(ctx context.Context, c *client.Client, id string, timeout time.Duration) *langsmith.SandboxSnapshotGetResponse {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		resp, err := c.SDK.Sandboxes.Snapshots.Get(ctx, id)
+		c, err := cmdutil.GetClient(cmd)
 		if err != nil {
-			ExitErrorf("getting snapshot: %v", err)
+			return nil, err
 		}
-		switch resp.Status {
-		case "ready":
-			return resp
-		case "failed":
-			msg := "unknown error"
-			if resp.StatusMessage != "" {
-				msg = resp.StatusMessage
-			}
-			ExitErrorf("snapshot build failed: %s", msg)
+
+		params := langsmith.SandboxBoxNewSnapshotParams{
+			Name: langsmith.F(name),
 		}
-		time.Sleep(2 * time.Second)
-	}
-	ExitErrorf("timed out after %s waiting for snapshot", timeout)
-	return nil
+		if in.Checkpoint != "" {
+			params.Checkpoint = langsmith.F(in.Checkpoint)
+		}
+
+		resp, err := c.SDK.Sandboxes.Boxes.NewSnapshot(ctx, in.BoxName, params)
+		if err != nil {
+			return nil, fmt.Errorf("capturing snapshot: %w", err)
+		}
+
+		return resp, nil
+	},
+	Render: command.Template(`ID:      {{.ID}}
+Name:    {{.Name}}
+Image:   {{dash .DockerImage}}
+Status:  {{.Status}}
+Size:    {{formatBytesOrDash .FsUsedBytes}}
+Created: {{formatTime .CreatedAt}}
+`),
 }
 
-func formatBytes(b int64) string {
-	const gb = 1024 * 1024 * 1024
-	const mb = 1024 * 1024
-	if b >= gb {
-		return fmt.Sprintf("%.1f GB", float64(b)/float64(gb))
-	}
-	return fmt.Sprintf("%.0f MB", float64(b)/float64(mb))
+var snapshotGetCommand = command.Command[struct{}]{
+	Use:   "get <snapshot-id>",
+	Short: "Get a snapshot by ID",
+	Args:  cobra.ExactArgs(1),
+	Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+		c, err := cmdutil.GetClient(cmd)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := c.SDK.Sandboxes.Snapshots.Get(ctx, args[0])
+		if err != nil {
+			return nil, fmt.Errorf("getting snapshot: %w", err)
+		}
+
+		return resp, nil
+	},
+	Render: command.Template(`ID:      {{.ID}}
+Name:    {{.Name}}
+Image:   {{dash .DockerImage}}
+Status:  {{.Status}}
+Size:    {{formatBytesOrDash .FsUsedBytes}}
+Created: {{formatTime .CreatedAt}}
+`),
 }
 
-// parseByteSize parses a human-readable size string into bytes.
-// Accepts: "512mb", "2GB", "1g", "4GiB", "1024M", "1tb", etc.
-// A bare number without a unit is rejected.
+var snapshotDeleteCommand = command.Command[struct{}]{
+	Use:   "delete <snapshot-id>",
+	Short: "Delete a snapshot",
+	Args:  cobra.ExactArgs(1),
+	Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+		c, err := cmdutil.GetClient(cmd)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := c.SDK.Sandboxes.Snapshots.Delete(ctx, args[0]); err != nil {
+			return nil, fmt.Errorf("deleting snapshot: %w", err)
+		}
+
+		return sandboxMessage{Name: args[0], Message: "Snapshot deleted."}, nil
+	},
+	Render: command.Template(`{{.Message}}
+`),
+}
+
 func parseByteSize(s string) (int64, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return 0, fmt.Errorf("empty size")
 	}
 
-	// Find where digits end and unit begins.
 	i := 0
 	for i < len(s) && (s[i] >= '0' && s[i] <= '9' || s[i] == '.') {
 		i++
@@ -340,8 +272,8 @@ func parseByteSize(s string) (int64, error) {
 
 	bytes := int64(num * multiplier)
 
-	const minBytes = 1024 * 1024                      // 1 MB
-	const maxBytes = 1024 * 1024 * 1024 * 1024 * 1024 // 1 PB
+	const minBytes = 1024 * 1024
+	const maxBytes = 1024 * 1024 * 1024 * 1024 * 1024
 	if bytes < minBytes {
 		return 0, fmt.Errorf("invalid size %q: must be at least 1mb", s)
 	}
@@ -352,9 +284,6 @@ func parseByteSize(s string) (int64, error) {
 	return bytes, nil
 }
 
-// loadJSONArg parses a JSON value from a CLI argument.
-// If the string starts with "@", it reads the rest as a file path.
-// Otherwise it parses it as inline JSON.
 func loadJSONArg(s string) (json.RawMessage, error) {
 	var data []byte
 	if strings.HasPrefix(s, "@") {
@@ -371,12 +300,4 @@ func loadJSONArg(s string) (json.RawMessage, error) {
 		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 	return raw, nil
-}
-
-func formatTime(ts string) string {
-	t, err := time.Parse(time.RFC3339Nano, ts)
-	if err != nil {
-		return ts
-	}
-	return t.Local().Format("2006-01-02 15:04")
 }

--- a/internal/cmd/sandbox_test.go
+++ b/internal/cmd/sandbox_test.go
@@ -81,7 +81,7 @@ func TestSandboxCmd_FlatSubcommands(t *testing.T) {
 	cmd := newSandboxCmd()
 	expected := map[string]bool{
 		"create": false, "list": false, "get": false, "update": false,
-		"delete": false, "start": false, "stop": false, "wait": false,
+		"delete": false, "start": false, "stop": false,
 		"exec": false, "console": false, "tunnel": false, "ssh-setup": false,
 		"snapshot": false,
 	}
@@ -98,10 +98,10 @@ func TestSandboxCmd_FlatSubcommands(t *testing.T) {
 }
 
 func TestSnapshotCmd_Subcommands(t *testing.T) {
-	cmd := newSandboxSnapshotCmd()
+	cmd := sandboxSnapshotCommand.Cobra()
 	expected := map[string]bool{
 		"build": false, "capture": false, "list": false,
-		"get": false, "delete": false, "wait": false,
+		"get": false, "delete": false,
 	}
 	for _, sub := range cmd.Commands() {
 		if _, ok := expected[sub.Name()]; ok {
@@ -116,7 +116,7 @@ func TestSnapshotCmd_Subcommands(t *testing.T) {
 }
 
 func TestSandboxCreateCmd_PositionalName(t *testing.T) {
-	cmd := newSandboxCreateCmd()
+	cmd := sandboxCreateCommand.Cobra()
 	if cmd.Args == nil {
 		t.Fatal("expected Args validator")
 	}
@@ -155,7 +155,7 @@ func TestSandboxTunnelCmd_HiddenNameFlag(t *testing.T) {
 }
 
 func TestSnapshotBuildCmd_PositionalName(t *testing.T) {
-	cmd := newSnapshotBuildCmd()
+	cmd := snapshotBuildCommand.Cobra()
 	if err := cmd.Args(cmd, []string{}); err == nil {
 		t.Error("expected error with 0 args")
 	}
@@ -165,7 +165,7 @@ func TestSnapshotBuildCmd_PositionalName(t *testing.T) {
 }
 
 func TestSnapshotCaptureCmd_PositionalName(t *testing.T) {
-	cmd := newSnapshotCaptureCmd()
+	cmd := snapshotCaptureCommand.Cobra()
 	if err := cmd.Args(cmd, []string{}); err == nil {
 		t.Error("expected error with 0 args")
 	}
@@ -175,7 +175,7 @@ func TestSnapshotCaptureCmd_PositionalName(t *testing.T) {
 }
 
 func TestSandboxCreateCmd_SizeFlags(t *testing.T) {
-	cmd := newSandboxCreateCmd()
+	cmd := sandboxCreateCommand.Cobra()
 	for _, name := range []string{"memory", "rootfs-capacity"} {
 		f := cmd.Flags().Lookup(name)
 		if f == nil {
@@ -185,7 +185,7 @@ func TestSandboxCreateCmd_SizeFlags(t *testing.T) {
 }
 
 func TestSandboxUpdateCmd_SizeFlags(t *testing.T) {
-	cmd := newSandboxUpdateCmd()
+	cmd := sandboxUpdateCommand.Cobra()
 	for _, name := range []string{"memory", "rootfs-capacity"} {
 		f := cmd.Flags().Lookup(name)
 		if f == nil {
@@ -195,7 +195,7 @@ func TestSandboxUpdateCmd_SizeFlags(t *testing.T) {
 }
 
 func TestSnapshotBuildCmd_CapacityFlag(t *testing.T) {
-	cmd := newSnapshotBuildCmd()
+	cmd := snapshotBuildCommand.Cobra()
 	f := cmd.Flags().Lookup("capacity")
 	if f == nil {
 		t.Fatal("flag --capacity not found")
@@ -206,7 +206,7 @@ func TestSnapshotBuildCmd_CapacityFlag(t *testing.T) {
 }
 
 func TestSnapshotBuildCmd_RegistryIDFlag(t *testing.T) {
-	cmd := newSnapshotBuildCmd()
+	cmd := snapshotBuildCommand.Cobra()
 	if f := cmd.Flags().Lookup("registry-id"); f == nil {
 		t.Fatal("flag --registry-id not found")
 	}
@@ -296,7 +296,7 @@ func TestLoadJSONArg_FileAbsolutePath(t *testing.T) {
 // ==================== proxy-config flag ====================
 
 func TestSandboxCreateCmd_ProxyConfigFlag(t *testing.T) {
-	cmd := newSandboxCreateCmd()
+	cmd := sandboxCreateCommand.Cobra()
 	f := cmd.Flags().Lookup("proxy-config")
 	if f == nil {
 		t.Fatal("flag --proxy-config not found on create command")
@@ -304,7 +304,7 @@ func TestSandboxCreateCmd_ProxyConfigFlag(t *testing.T) {
 }
 
 func TestSandboxUpdateCmd_ProxyConfigFlag(t *testing.T) {
-	cmd := newSandboxUpdateCmd()
+	cmd := sandboxUpdateCommand.Cobra()
 	f := cmd.Flags().Lookup("proxy-config")
 	if f == nil {
 		t.Fatal("flag --proxy-config not found on update command")

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -1,0 +1,261 @@
+package command
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/langchain-ai/langsmith-cli/internal/cmdutil"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+type Spec interface {
+	RenderText(io.Writer, any) error
+}
+
+type Command[I any] struct {
+	Use    string
+	Short  string
+	Long   string
+	Args   cobra.PositionalArgs
+	Input  func(*cobra.Command) I
+	Action func(context.Context, *cobra.Command, I, []string) (any, error)
+	Render Spec
+}
+
+func (c Command[I]) Cobra() *cobra.Command {
+	var input I
+	cmd := &cobra.Command{
+		Use:   c.Use,
+		Short: c.Short,
+		Long:  c.Long,
+		Args:  c.Args,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := c.Action(cmd.Context(), cmd, input, args)
+			if err != nil {
+				return err
+			}
+			return Render(cmd, result, c.Render)
+		},
+	}
+	if c.Input != nil {
+		input = c.Input(cmd)
+	}
+	return cmd
+}
+
+type Parent struct {
+	Use      string
+	Short    string
+	Long     string
+	Children []func() *cobra.Command
+}
+
+func (p Parent) Cobra() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   p.Use,
+		Short: p.Short,
+		Long:  p.Long,
+	}
+	for _, child := range p.Children {
+		cmd.AddCommand(child())
+	}
+	return cmd
+}
+
+func Render(cmd *cobra.Command, model any, spec Spec) error {
+	w := cmd.OutOrStdout()
+	if cmdutil.ResolveFormat(cmd) != "pretty" || spec == nil {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(model)
+	}
+	return spec.RenderText(w, model)
+}
+
+func templateFuncs() template.FuncMap {
+	return template.FuncMap{
+		"dash":              dash,
+		"formatBytes":       formatBytes,
+		"formatBytesOrDash": formatBytesOrDash,
+		"formatCount":       formatCount,
+		"formatTime":        formatTime,
+		"shortID":           shortID,
+	}
+}
+
+func dash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func formatBytes(b int64) string {
+	const gb = 1024 * 1024 * 1024
+	const mb = 1024 * 1024
+	if b >= gb {
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(gb))
+	}
+	return fmt.Sprintf("%.0f MB", float64(b)/float64(mb))
+}
+
+func formatBytesOrDash(b int64) string {
+	if b <= 0 {
+		return "-"
+	}
+	return formatBytes(b)
+}
+
+func formatCount(n int64) string {
+	if n <= 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%d", n)
+}
+
+func formatTime(ts string) string {
+	t, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		return ts
+	}
+	return t.Local().Format("2006-01-02 15:04")
+}
+
+func shortID(id string) string {
+	if id == "" {
+		return "-"
+	}
+	if len(id) > 8 {
+		return id[:8] + "..."
+	}
+	return id
+}
+
+type Template string
+
+func (s Template) RenderText(w io.Writer, model any) error {
+	tmpl, err := template.New("text").Funcs(templateFuncs()).Parse(string(s))
+	if err != nil {
+		return err
+	}
+	return tmpl.Execute(w, model)
+}
+
+type Table struct {
+	Title   string
+	Rows    string
+	Columns []Column
+}
+
+type Column struct {
+	Header   string
+	Template string
+}
+
+func (t Table) RenderText(w io.Writer, model any) error {
+	rows, err := resolveRows(model, t.Rows)
+	if err != nil {
+		return err
+	}
+
+	columnTemplates := make([]*template.Template, 0, len(t.Columns))
+	headers := make([]string, 0, len(t.Columns))
+	for _, col := range t.Columns {
+		headers = append(headers, col.Header)
+		tmpl, err := template.New(col.Header).Funcs(templateFuncs()).Parse(col.Template)
+		if err != nil {
+			return fmt.Errorf("parsing column %q: %w", col.Header, err)
+		}
+		columnTemplates = append(columnTemplates, tmpl)
+	}
+
+	if t.Title != "" {
+		fmt.Fprintln(w, t.Title)
+		fmt.Fprintln(w, strings.Repeat("-", len(t.Title)))
+	}
+
+	table := tablewriter.NewWriter(w)
+	table.SetHeader(headers)
+	table.SetBorder(false)
+	table.SetColumnSeparator("  ")
+	table.SetHeaderLine(true)
+	table.SetAutoWrapText(false)
+
+	for _, rowModel := range rows {
+		row := make([]string, 0, len(columnTemplates))
+		for i, tmpl := range columnTemplates {
+			var buf bytes.Buffer
+			if err := tmpl.Execute(&buf, rowModel); err != nil {
+				return fmt.Errorf("rendering column %q: %w", t.Columns[i].Header, err)
+			}
+			row = append(row, buf.String())
+		}
+		table.Append(row)
+	}
+
+	table.Render()
+	return nil
+}
+
+func resolveRows(model any, path string) ([]any, error) {
+	if path == "" {
+		path = "."
+	}
+
+	value := reflect.ValueOf(model)
+	if path != "." {
+		parts := strings.Split(strings.TrimPrefix(path, "."), ".")
+		for _, part := range parts {
+			if part == "" {
+				continue
+			}
+			value = dereference(value)
+			if !value.IsValid() {
+				return nil, fmt.Errorf("rows path %q resolved to nil", path)
+			}
+			switch value.Kind() {
+			case reflect.Struct:
+				value = value.FieldByName(part)
+			case reflect.Map:
+				value = value.MapIndex(reflect.ValueOf(part))
+			default:
+				return nil, fmt.Errorf("rows path %q cannot select %q from %s", path, part, value.Kind())
+			}
+			if !value.IsValid() {
+				return nil, fmt.Errorf("rows path %q could not resolve %q", path, part)
+			}
+		}
+	}
+
+	value = dereference(value)
+	if !value.IsValid() {
+		return nil, nil
+	}
+	if value.Kind() != reflect.Slice && value.Kind() != reflect.Array {
+		return nil, fmt.Errorf("rows path %q resolved to %s, want slice or array", path, value.Kind())
+	}
+
+	rows := make([]any, 0, value.Len())
+	for i := 0; i < value.Len(); i++ {
+		rows = append(rows, value.Index(i).Interface())
+	}
+	return rows, nil
+}
+
+func dereference(value reflect.Value) reflect.Value {
+	for value.IsValid() && (value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface) {
+		if value.IsNil() {
+			return reflect.Value{}
+		}
+		value = value.Elem()
+	}
+	return value
+}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1,0 +1,88 @@
+package command
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func testCmd(format string, out *bytes.Buffer) *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.PersistentFlags().String("format", format, "")
+	cmd.SetOut(out)
+	return cmd
+}
+
+func TestRenderJSONIgnoresTextSpec(t *testing.T) {
+	var out bytes.Buffer
+	cmd := testCmd("json", &out)
+
+	err := Render(cmd, map[string]any{"name": "sandbox"}, Template(`ignored`))
+
+	require.NoError(t, err)
+	require.JSONEq(t, `{"name":"sandbox"}`, out.String())
+}
+
+func TestTemplateRenderText(t *testing.T) {
+	var out bytes.Buffer
+	cmd := testCmd("pretty", &out)
+
+	err := Render(cmd, struct{ Name string }{Name: "sandbox"}, Template(`Name: {{.Name}}`))
+
+	require.NoError(t, err)
+	require.Equal(t, "Name: sandbox", out.String())
+}
+
+func TestTableRenderText(t *testing.T) {
+	var out bytes.Buffer
+	cmd := testCmd("pretty", &out)
+	model := struct {
+		Rows []struct {
+			Name       string
+			SnapshotID string
+		}
+	}{
+		Rows: []struct {
+			Name       string
+			SnapshotID string
+		}{
+			{Name: "a", SnapshotID: "1234567890abcdef"},
+		},
+	}
+
+	err := Render(cmd, model, Table{
+		Title: "Rows",
+		Rows:  ".Rows",
+		Columns: []Column{
+			{Header: "Name", Template: "{{.Name}}"},
+			{Header: "Snapshot", Template: "{{shortID .SnapshotID}}"},
+		},
+	})
+
+	require.NoError(t, err)
+	got := out.String()
+	require.Contains(t, got, "Rows")
+	require.Contains(t, got, "NAME")
+	require.Contains(t, got, "SNAPSHOT")
+	require.Contains(t, got, "a")
+	require.Contains(t, got, "12345678...")
+	require.False(t, strings.Contains(got, "{{"))
+}
+
+func TestTableRenderTextMissingRowsPath(t *testing.T) {
+	var out bytes.Buffer
+	cmd := testCmd("pretty", &out)
+
+	err := Render(cmd, struct{}{}, Table{
+		Rows: ".Missing",
+		Columns: []Column{
+			{Header: "Name", Template: "{{.Name}}"},
+		},
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `rows path ".Missing"`)
+}


### PR DESCRIPTION
## Summary
- Add a generic internal command framework for action/input/render separation
- Move sandbox lifecycle and snapshot commands onto the framework
- Remove obsolete sandbox wait/timeout CLI surfaces

## Test Plan
- [x] go test ./...