### PR TITLE
ci: enforce gofmt formatting in lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+linters:
+  enable:
+    - gofmt

--- a/internal/cmd/api/info_test.go
+++ b/internal/cmd/api/info_test.go
@@ -21,7 +21,7 @@ func newDetailedSpecServer(t *testing.T) *httptest.Server {
 					"parameters": []any{
 						map[string]any{
 							"name": "limit", "in": "query", "required": false,
-							"schema": map[string]any{"type": "integer"},
+							"schema":      map[string]any{"type": "integer"},
 							"description": "Max results",
 						},
 					},

--- a/internal/cmd/dataset.go
+++ b/internal/cmd/dataset.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/evaluator.go
+++ b/internal/cmd/evaluator.go
@@ -8,8 +8,8 @@ import (
 	"regexp"
 	"strings"
 
-	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 
@@ -40,7 +40,6 @@ Examples:
 	cmd.AddCommand(newEvaluatorDeleteCmd())
 	return cmd
 }
-
 
 func newEvaluatorGetCmd() *cobra.Command {
 	var (

--- a/internal/cmd/example.go
+++ b/internal/cmd/example.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/experiment.go
+++ b/internal/cmd/experiment.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 
 	"github.com/google/uuid"
-	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 
@@ -165,8 +165,8 @@ func newExperimentGetCmd() *cobra.Command {
 
 			// Build output
 			data := map[string]any{
-				"id":            p.ID,
-				"name":          p.Name,
+				"id":             p.ID,
+				"name":           p.Name,
 				"feedback_stats": p.FeedbackStats,
 				"run_stats": map[string]any{
 					"latency":     p.LatencyP50,
@@ -195,4 +195,3 @@ func newExperimentGetCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 	return cmd
 }
-

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"time"
 
-	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/extract"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
 
 	"github.com/google/uuid"
 )
@@ -144,8 +144,8 @@ func resolveDataset(ctx context.Context, c *client.Client, nameOrID string) (*la
 	}
 	// Fall back to name lookup
 	resp, err := c.SDK.Datasets.List(ctx, langsmith.DatasetListParams{
-		Name: langsmith.F(nameOrID),
-		Limit:       langsmith.F(int64(1)),
+		Name:  langsmith.F(nameOrID),
+		Limit: langsmith.F(int64(1)),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("searching dataset by name: %w", err)

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
 )
 
 // ---------- formatTimedelta ----------

--- a/internal/cmd/insights.go
+++ b/internal/cmd/insights.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/prompt.go
+++ b/internal/cmd/prompt.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"strings"
 
-	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"os"
 
-	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/langchain-ai/langsmith-cli/internal/extract"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -7,9 +7,9 @@ import (
 	"sort"
 	"time"
 
-	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/langchain-ai/langsmith-cli/internal/extract"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
## Summary
- add a repo-level golangci-lint config enabling the gofmt linter
- apply gofmt to currently non-formatted Go files so the new rule is immediately green

## Validation
- gofmt -l .
- GOCACHE=/tmp/go-build-cache go test ./... -run '^$'
