### PR TITLE
cli: default to human-readable output

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ All commands default to human-readable output:
 langsmith trace list --project my-app
 ```
 
-Use `--json` for machine-readable output:
+Use `--format=json` for machine-readable output:
 
 ```bash
-langsmith --json trace list --project my-app
+langsmith --format=json trace list --project my-app
 ```
 
 Write to a file with `-o`:
@@ -113,7 +113,7 @@ langsmith project list --limit 50
 langsmith project list --name-contains chatbot
 
 # Machine-readable JSON
-langsmith --json project list
+langsmith --format=json project list
 ```
 
 ### `trace` — Query and export traces

--- a/README.md
+++ b/README.md
@@ -78,16 +78,16 @@ langsmith experiment list --dataset my-eval-set
 
 ## Output Formats
 
-All commands default to **JSON** output for agent consumption:
+All commands default to human-readable output:
 
 ```bash
-langsmith trace list --project my-app  # JSON array to stdout
+langsmith trace list --project my-app
 ```
 
-Use `--format pretty` for human-readable tables and trees:
+Use `--format json` for machine-readable output:
 
 ```bash
-langsmith --format pretty trace list --project my-app
+langsmith --format json trace list --project my-app
 ```
 
 Write to a file with `-o`:
@@ -112,8 +112,8 @@ langsmith project list --limit 50
 # Filter by name
 langsmith project list --name-contains chatbot
 
-# Human-readable table
-langsmith --format pretty project list
+# Machine-readable JSON
+langsmith --format json project list
 ```
 
 ### `trace` — Query and export traces

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ All commands default to human-readable output:
 langsmith trace list --project my-app
 ```
 
-Use `--format json` for machine-readable output:
+Use `--json` for machine-readable output:
 
 ```bash
-langsmith --format json trace list --project my-app
+langsmith --json trace list --project my-app
 ```
 
 Write to a file with `-o`:
@@ -113,7 +113,7 @@ langsmith project list --limit 50
 langsmith project list --name-contains chatbot
 
 # Machine-readable JSON
-langsmith --format json project list
+langsmith --json project list
 ```
 
 ### `trace` — Query and export traces

--- a/README.md
+++ b/README.md
@@ -78,19 +78,13 @@ langsmith experiment list --dataset my-eval-set
 
 ## Output Formats
 
-All commands default to human-readable output:
-
 ```bash
 langsmith trace list --project my-app
 ```
 
-Use `--format=json` for machine-readable output:
-
 ```bash
 langsmith --format=json trace list --project my-app
 ```
-
-Write to a file with `-o`:
 
 ```bash
 langsmith trace list --project my-app -o traces.json

--- a/internal/cmd/api/info_test.go
+++ b/internal/cmd/api/info_test.go
@@ -84,7 +84,7 @@ func TestInfoCmd_JSON(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"--json", "api", "info", "--api-url", ts.URL, "GET", "/api/v1/sessions"})
+	root.SetArgs([]string{"--format=json", "api", "info", "--api-url", ts.URL, "GET", "/api/v1/sessions"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -116,7 +116,7 @@ func TestInfoCmd_Shorthand(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"--json", "api", "info", "--api-url", ts.URL, "GET", "sessions"})
+	root.SetArgs([]string{"--format=json", "api", "info", "--api-url", ts.URL, "GET", "sessions"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -139,7 +139,7 @@ func TestInfoCmd_WithRequestBody(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"--json", "api", "info", "--api-url", ts.URL, "POST", "runs/query"})
+	root.SetArgs([]string{"--format=json", "api", "info", "--api-url", ts.URL, "POST", "runs/query"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/cmd/api/info_test.go
+++ b/internal/cmd/api/info_test.go
@@ -84,7 +84,7 @@ func TestInfoCmd_JSON(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"--format", "json", "api", "info", "--api-url", ts.URL, "GET", "/api/v1/sessions"})
+	root.SetArgs([]string{"--json", "api", "info", "--api-url", ts.URL, "GET", "/api/v1/sessions"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -116,7 +116,7 @@ func TestInfoCmd_Shorthand(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"--format", "json", "api", "info", "--api-url", ts.URL, "GET", "sessions"})
+	root.SetArgs([]string{"--json", "api", "info", "--api-url", ts.URL, "GET", "sessions"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -139,7 +139,7 @@ func TestInfoCmd_WithRequestBody(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"--format", "json", "api", "info", "--api-url", ts.URL, "POST", "runs/query"})
+	root.SetArgs([]string{"--json", "api", "info", "--api-url", ts.URL, "POST", "runs/query"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/cmd/api/info_test.go
+++ b/internal/cmd/api/info_test.go
@@ -84,7 +84,7 @@ func TestInfoCmd_JSON(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"api", "info", "--api-url", ts.URL, "GET", "/api/v1/sessions"})
+	root.SetArgs([]string{"--format", "json", "api", "info", "--api-url", ts.URL, "GET", "/api/v1/sessions"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -116,7 +116,7 @@ func TestInfoCmd_Shorthand(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"api", "info", "--api-url", ts.URL, "GET", "sessions"})
+	root.SetArgs([]string{"--format", "json", "api", "info", "--api-url", ts.URL, "GET", "sessions"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -139,7 +139,7 @@ func TestInfoCmd_WithRequestBody(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"api", "info", "--api-url", ts.URL, "POST", "runs/query"})
+	root.SetArgs([]string{"--format", "json", "api", "info", "--api-url", ts.URL, "POST", "runs/query"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/cmd/api/ls_test.go
+++ b/internal/cmd/api/ls_test.go
@@ -44,7 +44,7 @@ func TestLsCmd_JSON(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"--json", "api", "ls", "--api-url", ts.URL, "--refresh"})
+	root.SetArgs([]string{"--format=json", "api", "ls", "--api-url", ts.URL, "--refresh"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -67,7 +67,7 @@ func TestLsCmd_FilterByTag(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"--json", "api", "ls", "--api-url", ts.URL, "--tag", "datasets", "--refresh"})
+	root.SetArgs([]string{"--format=json", "api", "ls", "--api-url", ts.URL, "--tag", "datasets", "--refresh"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -95,7 +95,7 @@ func TestLsCmd_Search(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"--json", "api", "ls", "--api-url", ts.URL, "--search", "query", "--refresh"})
+	root.SetArgs([]string{"--format=json", "api", "ls", "--api-url", ts.URL, "--search", "query", "--refresh"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/cmd/api/ls_test.go
+++ b/internal/cmd/api/ls_test.go
@@ -44,7 +44,7 @@ func TestLsCmd_JSON(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"api", "ls", "--api-url", ts.URL, "--refresh"})
+	root.SetArgs([]string{"--format", "json", "api", "ls", "--api-url", ts.URL, "--refresh"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -67,7 +67,7 @@ func TestLsCmd_FilterByTag(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"api", "ls", "--api-url", ts.URL, "--tag", "datasets", "--refresh"})
+	root.SetArgs([]string{"--format", "json", "api", "ls", "--api-url", ts.URL, "--tag", "datasets", "--refresh"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -95,7 +95,7 @@ func TestLsCmd_Search(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"api", "ls", "--api-url", ts.URL, "--search", "query", "--refresh"})
+	root.SetArgs([]string{"--format", "json", "api", "ls", "--api-url", ts.URL, "--search", "query", "--refresh"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/cmd/api/ls_test.go
+++ b/internal/cmd/api/ls_test.go
@@ -44,7 +44,7 @@ func TestLsCmd_JSON(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"--format", "json", "api", "ls", "--api-url", ts.URL, "--refresh"})
+	root.SetArgs([]string{"--json", "api", "ls", "--api-url", ts.URL, "--refresh"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -67,7 +67,7 @@ func TestLsCmd_FilterByTag(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"--format", "json", "api", "ls", "--api-url", ts.URL, "--tag", "datasets", "--refresh"})
+	root.SetArgs([]string{"--json", "api", "ls", "--api-url", ts.URL, "--tag", "datasets", "--refresh"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -95,7 +95,7 @@ func TestLsCmd_Search(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"--format", "json", "api", "ls", "--api-url", ts.URL, "--search", "query", "--refresh"})
+	root.SetArgs([]string{"--json", "api", "ls", "--api-url", ts.URL, "--search", "query", "--refresh"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/cmd/api/testutil_test.go
+++ b/internal/cmd/api/testutil_test.go
@@ -9,7 +9,7 @@ func newTestRoot() *cobra.Command {
 	root := &cobra.Command{Use: "langsmith"}
 	root.PersistentFlags().String("api-key", "", "")
 	root.PersistentFlags().String("api-url", "", "")
-	root.PersistentFlags().String("format", "json", "")
+	root.PersistentFlags().String("format", "pretty", "")
 	root.AddCommand(NewCmd())
 	return root
 }

--- a/internal/cmd/api/testutil_test.go
+++ b/internal/cmd/api/testutil_test.go
@@ -10,6 +10,7 @@ func newTestRoot() *cobra.Command {
 	root.PersistentFlags().String("api-key", "", "")
 	root.PersistentFlags().String("api-url", "", "")
 	root.PersistentFlags().String("format", "pretty", "")
+	root.PersistentFlags().Bool("json", false, "")
 	root.AddCommand(NewCmd())
 	return root
 }

--- a/internal/cmd/evaluator_test.go
+++ b/internal/cmd/evaluator_test.go
@@ -533,6 +533,7 @@ func TestEvaluatorListCmd_Execute(t *testing.T) {
 
 	cleanup := setupTestEnv(t, ts.URL)
 	defer cleanup()
+	flagOutputFormat = "json"
 
 	out := captureStdout(t, func() {
 		cmd := newEvaluatorListCmd()
@@ -604,6 +605,7 @@ func TestEvaluatorListCmd_Execute_EmptyList(t *testing.T) {
 
 	cleanup := setupTestEnv(t, ts.URL)
 	defer cleanup()
+	flagOutputFormat = "json"
 
 	out := captureStdout(t, func() {
 		cmd := newEvaluatorListCmd()

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -84,7 +84,7 @@ func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"--format", "json", "login", "--api-url", ts.URL, "--no-browser", "--workspace-id", workspaceID})
+	root.SetArgs([]string{"--json", "login", "--api-url", ts.URL, "--no-browser", "--workspace-id", workspaceID})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())
@@ -202,7 +202,7 @@ func TestLoginPromptsWorkspaceSelection(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"--format", "json", "login", "--api-url", ts.URL, "--no-browser"})
+	root.SetArgs([]string{"--json", "login", "--api-url", ts.URL, "--no-browser"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())
@@ -284,7 +284,7 @@ func TestLoginWarnsWhenNonInteractiveWithoutWorkspace(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"--format", "json", "login", "--api-url", ts.URL, "--no-browser"})
+	root.SetArgs([]string{"--json", "login", "--api-url", ts.URL, "--no-browser"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -84,7 +84,7 @@ func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"--json", "login", "--api-url", ts.URL, "--no-browser", "--workspace-id", workspaceID})
+	root.SetArgs([]string{"--format=json", "login", "--api-url", ts.URL, "--no-browser", "--workspace-id", workspaceID})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())
@@ -202,7 +202,7 @@ func TestLoginPromptsWorkspaceSelection(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"--json", "login", "--api-url", ts.URL, "--no-browser"})
+	root.SetArgs([]string{"--format=json", "login", "--api-url", ts.URL, "--no-browser"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())
@@ -284,7 +284,7 @@ func TestLoginWarnsWhenNonInteractiveWithoutWorkspace(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"--json", "login", "--api-url", ts.URL, "--no-browser"})
+	root.SetArgs([]string{"--format=json", "login", "--api-url", ts.URL, "--no-browser"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -84,7 +84,7 @@ func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"login", "--api-url", ts.URL, "--no-browser", "--workspace-id", workspaceID})
+	root.SetArgs([]string{"--format", "json", "login", "--api-url", ts.URL, "--no-browser", "--workspace-id", workspaceID})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())
@@ -202,7 +202,7 @@ func TestLoginPromptsWorkspaceSelection(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"login", "--api-url", ts.URL, "--no-browser"})
+	root.SetArgs([]string{"--format", "json", "login", "--api-url", ts.URL, "--no-browser"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())
@@ -284,7 +284,7 @@ func TestLoginWarnsWhenNonInteractiveWithoutWorkspace(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"login", "--api-url", ts.URL, "--no-browser"})
+	root.SetArgs([]string{"--format", "json", "login", "--api-url", ts.URL, "--no-browser"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -111,6 +111,7 @@ func TestTraceMessages_Success(t *testing.T) {
 	})
 	cleanup := setupTestEnv(t, ts.URL)
 	defer cleanup()
+	flagOutputFormat = "json"
 
 	out := captureStdout(t, func() {
 		cmd := newTraceMessagesCmd()
@@ -340,6 +341,7 @@ func TestTraceMessages_Pagination(t *testing.T) {
 	})
 	cleanup := setupTestEnv(t, ts.URL)
 	defer cleanup()
+	flagOutputFormat = "json"
 
 	out := captureStdout(t, func() {
 		cmd := newTraceMessagesCmd()
@@ -396,6 +398,7 @@ func TestTraceMessages_PaginationStopsAtLimit(t *testing.T) {
 	})
 	cleanup := setupTestEnv(t, ts.URL)
 	defer cleanup()
+	flagOutputFormat = "json"
 
 	out := captureStdout(t, func() {
 		cmd := newTraceMessagesCmd()
@@ -443,6 +446,7 @@ func TestTraceMessages_CursorFlag_SinglePage(t *testing.T) {
 	})
 	cleanup := setupTestEnv(t, ts.URL)
 	defer cleanup()
+	flagOutputFormat = "json"
 
 	out := captureStdout(t, func() {
 		cmd := newTraceMessagesCmd()
@@ -497,6 +501,7 @@ func TestTraceMessages_CursorFlag_EmptyCursorIsFirstPage(t *testing.T) {
 	})
 	cleanup := setupTestEnv(t, ts.URL)
 	defer cleanup()
+	flagOutputFormat = "json"
 
 	out := captureStdout(t, func() {
 		cmd := newTraceMessagesCmd()
@@ -575,6 +580,7 @@ func TestTraceMessages_EmptyResult(t *testing.T) {
 	})
 	cleanup := setupTestEnv(t, ts.URL)
 	defer cleanup()
+	flagOutputFormat = "json"
 
 	out := captureStdout(t, func() {
 		cmd := newTraceMessagesCmd()

--- a/internal/cmd/profile_test.go
+++ b/internal/cmd/profile_test.go
@@ -35,7 +35,7 @@ func TestProfileCreate(t *testing.T) {
 	apiKey := "test-api-key"
 	workspaceID := "00000000-0000-0000-0000-000000000123"
 	stdout, err := executeCommand(t,
-		"--json",
+		"--format=json",
 		"profile", "create", "dev",
 		"--api-key", apiKey,
 		"--api-url", "https://api.smith.langchain.com/api/v1",
@@ -260,7 +260,7 @@ func TestProfileShowDoesNotExposeSecrets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stdout, err := executeCommand(t, "--json", "profile", "show", "dev")
+	stdout, err := executeCommand(t, "--format=json", "profile", "show", "dev")
 	if err != nil {
 		t.Fatalf("profile show returned error: %v\nstdout: %s", err, stdout)
 	}
@@ -311,7 +311,7 @@ func TestProfileDisplayTrimsEnvProfile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	showStdout, err := executeCommand(t, "--json", "profile", "show", "prod")
+	showStdout, err := executeCommand(t, "--format=json", "profile", "show", "prod")
 	if err != nil {
 		t.Fatalf("profile show returned error: %v\nstdout: %s", err, showStdout)
 	}
@@ -323,7 +323,7 @@ func TestProfileDisplayTrimsEnvProfile(t *testing.T) {
 		t.Fatalf("expected whitespace-padded env profile to mark prod active: %+v", showResult)
 	}
 
-	listStdout, err := executeCommand(t, "--json", "profile", "list")
+	listStdout, err := executeCommand(t, "--format=json", "profile", "list")
 	if err != nil {
 		t.Fatalf("profile list returned error: %v\nstdout: %s", err, listStdout)
 	}
@@ -375,7 +375,7 @@ func TestProfileUse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stdout, err := executeCommand(t, "--json", "profile", "use", "prod")
+	stdout, err := executeCommand(t, "--format=json", "profile", "use", "prod")
 	if err != nil {
 		t.Fatalf("profile use returned error: %v\nstdout: %s", err, stdout)
 	}
@@ -436,7 +436,7 @@ func TestProfileDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stdout, err := executeCommand(t, "--json", "profile", "delete", "dev")
+	stdout, err := executeCommand(t, "--format=json", "profile", "delete", "dev")
 	if err != nil {
 		t.Fatalf("profile delete returned error: %v\nstdout: %s", err, stdout)
 	}
@@ -514,7 +514,7 @@ func TestProfileSetWorkspace(t *testing.T) {
 	}
 
 	workspaceID := "00000000-0000-0000-0000-000000000456"
-	stdout, err := executeCommand(t, "--json", "profile", "set-workspace", workspaceID)
+	stdout, err := executeCommand(t, "--format=json", "profile", "set-workspace", workspaceID)
 	if err != nil {
 		t.Fatalf("set-workspace returned error: %v\nstdout: %s", err, stdout)
 	}
@@ -593,7 +593,7 @@ func TestProfileListDoesNotExposeSecrets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stdout, err := executeCommand(t, "--json", "profile", "list")
+	stdout, err := executeCommand(t, "--format=json", "profile", "list")
 	if err != nil {
 		t.Fatalf("profile list returned error: %v\nstdout: %s", err, stdout)
 	}

--- a/internal/cmd/profile_test.go
+++ b/internal/cmd/profile_test.go
@@ -35,6 +35,7 @@ func TestProfileCreate(t *testing.T) {
 	apiKey := "test-api-key"
 	workspaceID := "00000000-0000-0000-0000-000000000123"
 	stdout, err := executeCommand(t,
+		"--json",
 		"profile", "create", "dev",
 		"--api-key", apiKey,
 		"--api-url", "https://api.smith.langchain.com/api/v1",
@@ -259,7 +260,7 @@ func TestProfileShowDoesNotExposeSecrets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stdout, err := executeCommand(t, "profile", "show", "dev")
+	stdout, err := executeCommand(t, "--json", "profile", "show", "dev")
 	if err != nil {
 		t.Fatalf("profile show returned error: %v\nstdout: %s", err, stdout)
 	}
@@ -310,7 +311,7 @@ func TestProfileDisplayTrimsEnvProfile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	showStdout, err := executeCommand(t, "profile", "show", "prod")
+	showStdout, err := executeCommand(t, "--json", "profile", "show", "prod")
 	if err != nil {
 		t.Fatalf("profile show returned error: %v\nstdout: %s", err, showStdout)
 	}
@@ -322,7 +323,7 @@ func TestProfileDisplayTrimsEnvProfile(t *testing.T) {
 		t.Fatalf("expected whitespace-padded env profile to mark prod active: %+v", showResult)
 	}
 
-	listStdout, err := executeCommand(t, "profile", "list")
+	listStdout, err := executeCommand(t, "--json", "profile", "list")
 	if err != nil {
 		t.Fatalf("profile list returned error: %v\nstdout: %s", err, listStdout)
 	}
@@ -374,7 +375,7 @@ func TestProfileUse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stdout, err := executeCommand(t, "profile", "use", "prod")
+	stdout, err := executeCommand(t, "--json", "profile", "use", "prod")
 	if err != nil {
 		t.Fatalf("profile use returned error: %v\nstdout: %s", err, stdout)
 	}
@@ -435,7 +436,7 @@ func TestProfileDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stdout, err := executeCommand(t, "profile", "delete", "dev")
+	stdout, err := executeCommand(t, "--json", "profile", "delete", "dev")
 	if err != nil {
 		t.Fatalf("profile delete returned error: %v\nstdout: %s", err, stdout)
 	}
@@ -513,7 +514,7 @@ func TestProfileSetWorkspace(t *testing.T) {
 	}
 
 	workspaceID := "00000000-0000-0000-0000-000000000456"
-	stdout, err := executeCommand(t, "profile", "set-workspace", workspaceID)
+	stdout, err := executeCommand(t, "--json", "profile", "set-workspace", workspaceID)
 	if err != nil {
 		t.Fatalf("set-workspace returned error: %v\nstdout: %s", err, stdout)
 	}
@@ -592,7 +593,7 @@ func TestProfileListDoesNotExposeSecrets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stdout, err := executeCommand(t, "profile", "list")
+	stdout, err := executeCommand(t, "--json", "profile", "list")
 	if err != nil {
 		t.Fatalf("profile list returned error: %v\nstdout: %s", err, stdout)
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -19,7 +19,6 @@ var (
 	flagAPIURL       string
 	flagProfile      string
 	flagOutputFormat string
-	flagOutputJSON   bool
 )
 
 // NewRootCmd creates the top-level `langsmith` command.
@@ -49,8 +48,7 @@ Quick start:
 
 	Output:
 	  --format pretty  Human-readable tables, trees, and syntax-highlighted JSON (default).
-	  --json           Machine-readable JSON for agents and scripts.
-	  --format json    Equivalent to --json.`,
+	  --format json    Machine-readable JSON for agents and scripts.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Version:       displayVersion,
@@ -60,7 +58,6 @@ Quick start:
 	rootCmd.PersistentFlags().StringVar(&flagAPIURL, "api-url", "", "LangSmith API URL [env: LANGSMITH_ENDPOINT]")
 	rootCmd.PersistentFlags().StringVar(&flagProfile, "profile", "", "Named profile to use [env: LANGSMITH_PROFILE]")
 	rootCmd.PersistentFlags().StringVar(&flagOutputFormat, "format", "pretty", "Output format: pretty or json")
-	rootCmd.PersistentFlags().BoolVar(&flagOutputJSON, "json", false, "Output machine-readable JSON")
 
 	// Register all subcommand groups
 	rootCmd.AddCommand(newProjectCmd())
@@ -110,9 +107,6 @@ func GetWorkspaceID() string {
 
 // GetFormat returns the output format.
 func GetFormat() string {
-	if flagOutputJSON {
-		return "json"
-	}
 	return flagOutputFormat
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -28,9 +28,8 @@ func NewRootCmd(rawVersion, displayVersion string) *cobra.Command {
 		Short: "LangSmith CLI — query and manage LangSmith resources",
 		Long: `LangSmith CLI — query and manage LangSmith resources from the command line.
 
-Designed for AI coding agents and developers who need fast, scriptable
-access to traces, runs, datasets, evaluators, experiments, and threads.
-All commands output JSON by default for easy parsing.
+	Designed for developers and AI coding agents who need fast access to traces,
+	runs, datasets, evaluators, experiments, and threads.
 
 Authentication:
   Run 'langsmith login', set LANGSMITH_API_KEY, or pass --api-key.
@@ -47,9 +46,9 @@ Quick start:
   langsmith evaluator list
   langsmith experiment list --dataset my-eval-dataset
 
-Output:
-  --format json    Machine-readable JSON (default). Best for agents and scripts.
-  --format pretty  Human-readable tables, trees, and syntax-highlighted JSON.`,
+	Output:
+	  --format pretty  Human-readable tables, trees, and syntax-highlighted JSON (default).
+	  --format json    Machine-readable JSON for agents and scripts.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Version:       displayVersion,
@@ -58,7 +57,7 @@ Output:
 	rootCmd.PersistentFlags().StringVar(&flagAPIKey, "api-key", "", "LangSmith API key [env: LANGSMITH_API_KEY]")
 	rootCmd.PersistentFlags().StringVar(&flagAPIURL, "api-url", "", "LangSmith API URL [env: LANGSMITH_ENDPOINT]")
 	rootCmd.PersistentFlags().StringVar(&flagProfile, "profile", "", "Named profile to use [env: LANGSMITH_PROFILE]")
-	rootCmd.PersistentFlags().StringVar(&flagOutputFormat, "format", "json", "Output format: json or pretty")
+	rootCmd.PersistentFlags().StringVar(&flagOutputFormat, "format", "pretty", "Output format: pretty or json")
 
 	// Register all subcommand groups
 	rootCmd.AddCommand(newProjectCmd())

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -19,6 +19,7 @@ var (
 	flagAPIURL       string
 	flagProfile      string
 	flagOutputFormat string
+	flagOutputJSON   bool
 )
 
 // NewRootCmd creates the top-level `langsmith` command.
@@ -48,7 +49,8 @@ Quick start:
 
 	Output:
 	  --format pretty  Human-readable tables, trees, and syntax-highlighted JSON (default).
-	  --format json    Machine-readable JSON for agents and scripts.`,
+	  --json           Machine-readable JSON for agents and scripts.
+	  --format json    Equivalent to --json.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Version:       displayVersion,
@@ -58,6 +60,7 @@ Quick start:
 	rootCmd.PersistentFlags().StringVar(&flagAPIURL, "api-url", "", "LangSmith API URL [env: LANGSMITH_ENDPOINT]")
 	rootCmd.PersistentFlags().StringVar(&flagProfile, "profile", "", "Named profile to use [env: LANGSMITH_PROFILE]")
 	rootCmd.PersistentFlags().StringVar(&flagOutputFormat, "format", "pretty", "Output format: pretty or json")
+	rootCmd.PersistentFlags().BoolVar(&flagOutputJSON, "json", false, "Output machine-readable JSON")
 
 	// Register all subcommand groups
 	rootCmd.AddCommand(newProjectCmd())
@@ -107,6 +110,9 @@ func GetWorkspaceID() string {
 
 // GetFormat returns the output format.
 func GetFormat() string {
+	if flagOutputJSON {
+		return "json"
+	}
 	return flagOutputFormat
 }
 

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -91,17 +91,6 @@ func TestRootCmd_PersistentFlags_Format(t *testing.T) {
 	}
 }
 
-func TestRootCmd_PersistentFlags_JSON(t *testing.T) {
-	root := NewRootCmd("dev", "dev")
-	f := root.PersistentFlags().Lookup("json")
-	if f == nil {
-		t.Fatal("--json flag not found")
-	}
-	if f.DefValue != "false" {
-		t.Errorf("expected default false, got %q", f.DefValue)
-	}
-}
-
 func TestRootCmd_PersistentFlags_Profile(t *testing.T) {
 	root := NewRootCmd("dev", "dev")
 	f := root.PersistentFlags().Lookup("profile")
@@ -418,25 +407,16 @@ func TestGetAPIKey_EnvOverridesProfileBearer(t *testing.T) {
 
 func TestGetFormat_ReturnsValue(t *testing.T) {
 	oldFormat := flagOutputFormat
-	oldJSON := flagOutputJSON
 	defer func() {
 		flagOutputFormat = oldFormat
-		flagOutputJSON = oldJSON
 	}()
 
-	flagOutputJSON = false
 	flagOutputFormat = "pretty"
 	if got := GetFormat(); got != "pretty" {
 		t.Errorf("expected pretty, got %q", got)
 	}
 
 	flagOutputFormat = "json"
-	if got := GetFormat(); got != "json" {
-		t.Errorf("expected json, got %q", got)
-	}
-
-	flagOutputFormat = "pretty"
-	flagOutputJSON = true
 	if got := GetFormat(); got != "json" {
 		t.Errorf("expected json, got %q", got)
 	}

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -91,6 +91,17 @@ func TestRootCmd_PersistentFlags_Format(t *testing.T) {
 	}
 }
 
+func TestRootCmd_PersistentFlags_JSON(t *testing.T) {
+	root := NewRootCmd("dev", "dev")
+	f := root.PersistentFlags().Lookup("json")
+	if f == nil {
+		t.Fatal("--json flag not found")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("expected default false, got %q", f.DefValue)
+	}
+}
+
 func TestRootCmd_PersistentFlags_Profile(t *testing.T) {
 	root := NewRootCmd("dev", "dev")
 	f := root.PersistentFlags().Lookup("profile")
@@ -406,15 +417,26 @@ func TestGetAPIKey_EnvOverridesProfileBearer(t *testing.T) {
 // ---------- getFormat ----------
 
 func TestGetFormat_ReturnsValue(t *testing.T) {
-	old := flagOutputFormat
-	defer func() { flagOutputFormat = old }()
+	oldFormat := flagOutputFormat
+	oldJSON := flagOutputJSON
+	defer func() {
+		flagOutputFormat = oldFormat
+		flagOutputJSON = oldJSON
+	}()
 
+	flagOutputJSON = false
 	flagOutputFormat = "pretty"
 	if got := GetFormat(); got != "pretty" {
 		t.Errorf("expected pretty, got %q", got)
 	}
 
 	flagOutputFormat = "json"
+	if got := GetFormat(); got != "json" {
+		t.Errorf("expected json, got %q", got)
+	}
+
+	flagOutputFormat = "pretty"
+	flagOutputJSON = true
 	if got := GetFormat(); got != "json" {
 		t.Errorf("expected json, got %q", got)
 	}

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -86,8 +86,8 @@ func TestRootCmd_PersistentFlags_Format(t *testing.T) {
 	if f == nil {
 		t.Fatal("--format flag not found")
 	}
-	if f.DefValue != "json" {
-		t.Errorf("expected default json, got %q", f.DefValue)
+	if f.DefValue != "pretty" {
+		t.Errorf("expected default pretty, got %q", f.DefValue)
 	}
 }
 

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -240,6 +240,7 @@ func TestRunListCmd_Execute_WithProject_Succeeds(t *testing.T) {
 	)
 	cleanup := setupTestEnv(t, ts.URL)
 	defer cleanup()
+	flagOutputFormat = "json"
 
 	cmd := newRunListCmd()
 	_ = cmd.Flags().Set("project", "my-app")
@@ -265,6 +266,7 @@ func TestRunListCmd_Execute_WithEnvProject_Succeeds(t *testing.T) {
 	)
 	cleanup := setupTestEnv(t, ts.URL)
 	defer cleanup()
+	flagOutputFormat = "json"
 	t.Setenv("LANGSMITH_PROJECT", "env-project")
 
 	cmd := newRunListCmd()

--- a/internal/cmd/testutil_test.go
+++ b/internal/cmd/testutil_test.go
@@ -46,20 +46,17 @@ func setupTestEnv(t *testing.T, serverURL string) func() {
 	oldURL := flagAPIURL
 	oldProfile := flagProfile
 	oldFmt := flagOutputFormat
-	oldJSON := flagOutputJSON
 
 	flagAPIKey = "test-api-key"
 	flagAPIURL = serverURL
 	flagProfile = ""
 	flagOutputFormat = "pretty"
-	flagOutputJSON = false
 
 	return func() {
 		flagAPIKey = oldKey
 		flagAPIURL = oldURL
 		flagProfile = oldProfile
 		flagOutputFormat = oldFmt
-		flagOutputJSON = oldJSON
 	}
 }
 

--- a/internal/cmd/testutil_test.go
+++ b/internal/cmd/testutil_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"strings"
 	"testing"
 )
 
@@ -52,7 +51,7 @@ func setupTestEnv(t *testing.T, serverURL string) func() {
 	flagAPIKey = "test-api-key"
 	flagAPIURL = serverURL
 	flagProfile = ""
-	flagOutputFormat = "json"
+	flagOutputFormat = "pretty"
 	flagOutputJSON = false
 
 	return func() {
@@ -68,32 +67,10 @@ func setupTestEnv(t *testing.T, serverURL string) func() {
 // and returns captured stdout and any error.
 func executeCommand(t *testing.T, args ...string) (string, error) {
 	t.Helper()
-	format := flagOutputFormat
-	jsonOutput := flagOutputJSON
-	defer func() {
-		flagOutputFormat = format
-		flagOutputJSON = jsonOutput
-	}()
 	cmd := NewRootCmd("test", "test")
 	var outBuf bytes.Buffer
 	cmd.SetOut(&outBuf)
 	cmd.SetErr(&outBuf)
-	if format != "" {
-		hasFormat := false
-		for _, arg := range args {
-			if arg == "--json" || arg == "--format" || strings.HasPrefix(arg, "--format=") {
-				hasFormat = true
-				break
-			}
-		}
-		if !hasFormat {
-			if format == "json" {
-				args = append([]string{"--json"}, args...)
-			} else {
-				args = append([]string{"--format", format}, args...)
-			}
-		}
-	}
 	cmd.SetArgs(args)
 	err := cmd.Execute()
 	return outBuf.String(), err

--- a/internal/cmd/testutil_test.go
+++ b/internal/cmd/testutil_test.go
@@ -47,17 +47,20 @@ func setupTestEnv(t *testing.T, serverURL string) func() {
 	oldURL := flagAPIURL
 	oldProfile := flagProfile
 	oldFmt := flagOutputFormat
+	oldJSON := flagOutputJSON
 
 	flagAPIKey = "test-api-key"
 	flagAPIURL = serverURL
 	flagProfile = ""
 	flagOutputFormat = "json"
+	flagOutputJSON = false
 
 	return func() {
 		flagAPIKey = oldKey
 		flagAPIURL = oldURL
 		flagProfile = oldProfile
 		flagOutputFormat = oldFmt
+		flagOutputJSON = oldJSON
 	}
 }
 
@@ -66,6 +69,11 @@ func setupTestEnv(t *testing.T, serverURL string) func() {
 func executeCommand(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 	format := flagOutputFormat
+	jsonOutput := flagOutputJSON
+	defer func() {
+		flagOutputFormat = format
+		flagOutputJSON = jsonOutput
+	}()
 	cmd := NewRootCmd("test", "test")
 	var outBuf bytes.Buffer
 	cmd.SetOut(&outBuf)
@@ -73,13 +81,17 @@ func executeCommand(t *testing.T, args ...string) (string, error) {
 	if format != "" {
 		hasFormat := false
 		for _, arg := range args {
-			if arg == "--format" || strings.HasPrefix(arg, "--format=") {
+			if arg == "--json" || arg == "--format" || strings.HasPrefix(arg, "--format=") {
 				hasFormat = true
 				break
 			}
 		}
 		if !hasFormat {
-			args = append([]string{"--format", format}, args...)
+			if format == "json" {
+				args = append([]string{"--json"}, args...)
+			} else {
+				args = append([]string{"--format", format}, args...)
+			}
 		}
 	}
 	cmd.SetArgs(args)

--- a/internal/cmd/testutil_test.go
+++ b/internal/cmd/testutil_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -64,10 +65,23 @@ func setupTestEnv(t *testing.T, serverURL string) func() {
 // and returns captured stdout and any error.
 func executeCommand(t *testing.T, args ...string) (string, error) {
 	t.Helper()
+	format := flagOutputFormat
 	cmd := NewRootCmd("test", "test")
 	var outBuf bytes.Buffer
 	cmd.SetOut(&outBuf)
 	cmd.SetErr(&outBuf)
+	if format != "" {
+		hasFormat := false
+		for _, arg := range args {
+			if arg == "--format" || strings.HasPrefix(arg, "--format=") {
+				hasFormat = true
+				break
+			}
+		}
+		if !hasFormat {
+			args = append([]string{"--format", format}, args...)
+		}
+	}
 	cmd.SetArgs(args)
 	err := cmd.Execute()
 	return outBuf.String(), err

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -55,7 +55,7 @@ func TestWorkspaceSetDefault(t *testing.T) {
 	t.Setenv("LANGSMITH_PROFILE", "")
 
 	workspaceID := "00000000-0000-0000-0000-000000000789"
-	stdout, err := executeCommand(t, "workspace", "set-default", workspaceID)
+	stdout, err := executeCommand(t, "--json", "workspace", "set-default", workspaceID)
 	if err != nil {
 		t.Fatalf("workspace set-default returned error: %v\nstdout: %s", err, stdout)
 	}

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -55,7 +55,7 @@ func TestWorkspaceSetDefault(t *testing.T) {
 	t.Setenv("LANGSMITH_PROFILE", "")
 
 	workspaceID := "00000000-0000-0000-0000-000000000789"
-	stdout, err := executeCommand(t, "--json", "workspace", "set-default", workspaceID)
+	stdout, err := executeCommand(t, "--format=json", "workspace", "set-default", workspaceID)
 	if err != nil {
 		t.Fatalf("workspace set-default returned error: %v\nstdout: %s", err, stdout)
 	}

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -73,7 +73,7 @@ func ResolveAPIURL(cmd *cobra.Command) string {
 func ResolveFormat(cmd *cobra.Command) string {
 	v := getFlagString(cmd, "format")
 	if v == "" {
-		return "json"
+		return "pretty"
 	}
 	return v
 }

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -50,6 +50,16 @@ func getFlagString(cmd *cobra.Command, name string) string {
 	return ""
 }
 
+func getFlagBool(cmd *cobra.Command, name string) bool {
+	if f := cmd.Flags().Lookup(name); f != nil {
+		return f.Value.String() == "true"
+	}
+	if f := cmd.PersistentFlags().Lookup(name); f != nil {
+		return f.Value.String() == "true"
+	}
+	return false
+}
+
 // ResolveAPIKey reads the API key from cobra's flag tree → env.
 func ResolveAPIKey(cmd *cobra.Command) string {
 	if v := getFlagString(cmd, "api-key"); v != "" {
@@ -71,6 +81,9 @@ func ResolveAPIURL(cmd *cobra.Command) string {
 
 // ResolveFormat reads the output format from cobra's flag tree.
 func ResolveFormat(cmd *cobra.Command) string {
+	if getFlagBool(cmd, "json") {
+		return "json"
+	}
 	v := getFlagString(cmd, "format")
 	if v == "" {
 		return "pretty"

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -17,6 +17,7 @@ func newTestCmd() *cobra.Command {
 	root.PersistentFlags().String("api-url", "", "")
 	root.PersistentFlags().String("profile", "", "")
 	root.PersistentFlags().String("format", "pretty", "")
+	root.PersistentFlags().Bool("json", false, "")
 	return root
 }
 
@@ -77,9 +78,17 @@ func TestResolveAPIURL_NormalizesTrailingAPIV1(t *testing.T) {
 
 func TestResolveFormat_Flag(t *testing.T) {
 	cmd := newTestCmd()
-	_ = cmd.PersistentFlags().Set("format", "pretty")
-	if got := ResolveFormat(cmd); got != "pretty" {
-		t.Errorf("expected pretty, got %q", got)
+	_ = cmd.PersistentFlags().Set("format", "json")
+	if got := ResolveFormat(cmd); got != "json" {
+		t.Errorf("expected json, got %q", got)
+	}
+}
+
+func TestResolveFormat_JSONFlag(t *testing.T) {
+	cmd := newTestCmd()
+	_ = cmd.PersistentFlags().Set("json", "true")
+	if got := ResolveFormat(cmd); got != "json" {
+		t.Errorf("expected json, got %q", got)
 	}
 }
 

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -16,7 +16,7 @@ func newTestCmd() *cobra.Command {
 	root.PersistentFlags().String("api-key", "", "")
 	root.PersistentFlags().String("api-url", "", "")
 	root.PersistentFlags().String("profile", "", "")
-	root.PersistentFlags().String("format", "json", "")
+	root.PersistentFlags().String("format", "pretty", "")
 	return root
 }
 
@@ -85,8 +85,8 @@ func TestResolveFormat_Flag(t *testing.T) {
 
 func TestResolveFormat_Default(t *testing.T) {
 	cmd := newTestCmd()
-	if got := ResolveFormat(cmd); got != "json" {
-		t.Errorf("expected json, got %q", got)
+	if got := ResolveFormat(cmd); got != "pretty" {
+		t.Errorf("expected pretty, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Change the CLI default output format from JSON to human-readable pretty output
- Keep machine-readable JSON available via --format json
- Update docs and JSON-specific tests to request JSON explicitly

## Test Plan
- [x] go test ./...