### PR TITLE
test: remove stale json flag

### DIFF
--- a/internal/cmd/api/testutil_test.go
+++ b/internal/cmd/api/testutil_test.go
@@ -10,7 +10,6 @@ func newTestRoot() *cobra.Command {
 	root.PersistentFlags().String("api-key", "", "")
 	root.PersistentFlags().String("api-url", "", "")
 	root.PersistentFlags().String("format", "pretty", "")
-	root.PersistentFlags().Bool("json", false, "")
 	root.AddCommand(NewCmd())
 	return root
 }

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -50,16 +50,6 @@ func getFlagString(cmd *cobra.Command, name string) string {
 	return ""
 }
 
-func getFlagBool(cmd *cobra.Command, name string) bool {
-	if f := cmd.Flags().Lookup(name); f != nil {
-		return f.Value.String() == "true"
-	}
-	if f := cmd.PersistentFlags().Lookup(name); f != nil {
-		return f.Value.String() == "true"
-	}
-	return false
-}
-
 // ResolveAPIKey reads the API key from cobra's flag tree → env.
 func ResolveAPIKey(cmd *cobra.Command) string {
 	if v := getFlagString(cmd, "api-key"); v != "" {
@@ -81,9 +71,6 @@ func ResolveAPIURL(cmd *cobra.Command) string {
 
 // ResolveFormat reads the output format from cobra's flag tree.
 func ResolveFormat(cmd *cobra.Command) string {
-	if getFlagBool(cmd, "json") {
-		return "json"
-	}
 	v := getFlagString(cmd, "format")
 	if v == "" {
 		return "pretty"

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -17,7 +17,6 @@ func newTestCmd() *cobra.Command {
 	root.PersistentFlags().String("api-url", "", "")
 	root.PersistentFlags().String("profile", "", "")
 	root.PersistentFlags().String("format", "pretty", "")
-	root.PersistentFlags().Bool("json", false, "")
 	return root
 }
 
@@ -79,14 +78,6 @@ func TestResolveAPIURL_NormalizesTrailingAPIV1(t *testing.T) {
 func TestResolveFormat_Flag(t *testing.T) {
 	cmd := newTestCmd()
 	_ = cmd.PersistentFlags().Set("format", "json")
-	if got := ResolveFormat(cmd); got != "json" {
-		t.Errorf("expected json, got %q", got)
-	}
-}
-
-func TestResolveFormat_JSONFlag(t *testing.T) {
-	cmd := newTestCmd()
-	_ = cmd.PersistentFlags().Set("json", "true")
 	if got := ResolveFormat(cmd); got != "json" {
 		t.Errorf("expected json, got %q", got)
 	}


### PR DESCRIPTION
Removes stale `--json` handling from API/cmdutil test plumbing now that JSON output is selected with `--format=json`.

## Test Plan
- [x] `go test ./internal/cmd/api ./internal/cmdutil`