### PR TITLE
docs: clarify login is SaaS-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ Download the latest binary for your platform from [GitHub Releases](https://gith
 
 ## Authentication
 
+For hosted LangSmith (SaaS), you can authenticate with OAuth:
+
+```bash
+langsmith login
+```
+
+OAuth login currently supports hosted LangSmith only. For self-hosted LangSmith,
+use an API key with `LANGSMITH_API_KEY` or `--api-key`.
+
 Set your API key as an environment variable:
 
 ```bash

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -70,6 +70,9 @@ func newLoginCmd() *cobra.Command {
 		Short: "Authenticate with LangSmith using OAuth",
 		Long: `Authenticate with LangSmith using OAuth.
 
+OAuth login currently supports hosted LangSmith (SaaS) only. For self-hosted
+LangSmith, use LANGSMITH_API_KEY or --api-key instead.
+
 The command stores OAuth tokens in ~/.langsmith/config.json under the selected
 profile. Select a profile with --profile or LANGSMITH_PROFILE.`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -33,7 +33,8 @@ access to traces, runs, datasets, evaluators, experiments, and threads.
 All commands output JSON by default for easy parsing.
 
 Authentication:
-  Run 'langsmith login', set LANGSMITH_API_KEY, or pass --api-key.
+  Run 'langsmith login' for hosted LangSmith (SaaS) OAuth.
+  For self-hosted instances, set LANGSMITH_API_KEY or pass --api-key.
   Optionally set LANGSMITH_ENDPOINT for self-hosted instances.
   Use --profile or LANGSMITH_PROFILE to select a saved profile.
   Set a default workspace with 'langsmith profile set-workspace <workspace-id>'.


### PR DESCRIPTION
Clarifies that `langsmith login` OAuth is currently for hosted LangSmith (SaaS) only, and points self-hosted users to API key authentication instead. This appears in the README, root help text, and `login` command help.

## Release Note

Clarifies that `langsmith login` OAuth currently supports hosted LangSmith only.

## Test Plan

- [x] `/Users/mukil/.local/share/mise/installs/go/1.25.7/bin/go test ./internal/cmd -run 'TestRootCmd|TestLogin'`
