### PR TITLE
fix(auth): include OAuth resource in login flow

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -308,7 +308,10 @@ func promptLine(cmd *cobra.Command, prompt string) (string, error) {
 }
 
 func requestDeviceCode(ctx context.Context, apiURL string) (*deviceCodeResponse, error) {
-	values := url.Values{"client_id": {oauthClientID}}
+	values := url.Values{
+		"client_id": {oauthClientID},
+		"resource":  {oauthResource(apiURL)},
+	}
 	var resp deviceCodeResponse
 	if err := postOAuthForm(ctx, apiURL, "/oauth/device/code", values, &resp); err != nil {
 		return nil, fmt.Errorf("requesting device code: %w", err)
@@ -323,6 +326,7 @@ func refreshProfileToken(ctx context.Context, apiURL, refreshToken string) (*oau
 	values := url.Values{
 		"grant_type":    {"refresh_token"},
 		"client_id":     {oauthClientID},
+		"resource":      {oauthResource(apiURL)},
 		"refresh_token": {refreshToken},
 	}
 	var resp oauthTokenResponse
@@ -379,6 +383,7 @@ func requestDeviceToken(ctx context.Context, apiURL, deviceCode string) (*oauthT
 		"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
 		"client_id":   {oauthClientID},
 		"device_code": {deviceCode},
+		"resource":    {oauthResource(apiURL)},
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, oauthURL(apiURL, "/oauth/token"), strings.NewReader(values.Encode()))
@@ -462,6 +467,12 @@ func applyTokenResponse(profile *lsconfig.Profile, token *oauthTokenResponse, no
 
 func oauthURL(apiURL, path string) string {
 	return strings.TrimRight(client.NormalizeURL(apiURL), "/") + path
+}
+
+// oauthResource is the API origin expected by the OAuth server; it must not
+// include the /api/v1 suffix accepted by LANGSMITH_ENDPOINT.
+func oauthResource(apiURL string) string {
+	return strings.TrimRight(client.NormalizeURL(apiURL), "/")
 }
 
 func openBrowserDefault(rawURL string) error {

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -55,6 +55,7 @@ func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
 			if got := r.FormValue("client_id"); got != oauthClientID {
 				t.Fatalf("expected client_id %q, got %q", oauthClientID, got)
 			}
+			assertOAuthResource(t, r)
 			_ = json.NewEncoder(w).Encode(deviceCodeResponse{
 				DeviceCode:      "device-code",
 				UserCode:        "ABCD-EFGH",
@@ -69,6 +70,7 @@ func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
 			if got := r.FormValue("grant_type"); got != "urn:ietf:params:oauth:grant-type:device_code" {
 				t.Fatalf("unexpected grant_type %q", got)
 			}
+			assertOAuthResource(t, r)
 			_ = json.NewEncoder(w).Encode(oauthTokenResponse{
 				AccessToken:  accessToken,
 				ExpiresIn:    300,
@@ -84,7 +86,7 @@ func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"--format=json", "login", "--api-url", ts.URL, "--no-browser", "--workspace-id", workspaceID})
+	root.SetArgs([]string{"--format=json", "login", "--api-url", ts.URL + "/api/v1", "--no-browser", "--workspace-id", workspaceID})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())
@@ -106,6 +108,9 @@ func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
 	}
 	if result["workspace_id"] != workspaceID {
 		t.Fatalf("expected workspace_id %q in result, got %q", workspaceID, result["workspace_id"])
+	}
+	if result["api_url"] != ts.URL {
+		t.Fatalf("expected normalized api_url %q, got %q", ts.URL, result["api_url"])
 	}
 
 	cfg, err := lsconfig.LoadFrom(configPath)
@@ -165,6 +170,10 @@ func TestLoginPromptsWorkspaceSelection(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/oauth/device/code":
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			assertOAuthResource(t, r)
 			_ = json.NewEncoder(w).Encode(deviceCodeResponse{
 				DeviceCode:      "device-code",
 				UserCode:        "ABCD-EFGH",
@@ -173,6 +182,10 @@ func TestLoginPromptsWorkspaceSelection(t *testing.T) {
 				Interval:        0,
 			})
 		case "/oauth/token":
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			assertOAuthResource(t, r)
 			_ = json.NewEncoder(w).Encode(oauthTokenResponse{
 				AccessToken:  accessToken,
 				ExpiresIn:    300,
@@ -257,6 +270,10 @@ func TestLoginWarnsWhenNonInteractiveWithoutWorkspace(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/oauth/device/code":
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			assertOAuthResource(t, r)
 			_ = json.NewEncoder(w).Encode(deviceCodeResponse{
 				DeviceCode:      "device-code",
 				UserCode:        "ABCD-EFGH",
@@ -265,6 +282,10 @@ func TestLoginWarnsWhenNonInteractiveWithoutWorkspace(t *testing.T) {
 				Interval:        0,
 			})
 		case "/oauth/token":
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			assertOAuthResource(t, r)
 			_ = json.NewEncoder(w).Encode(oauthTokenResponse{
 				AccessToken:  "test-access-token",
 				ExpiresIn:    300,
@@ -332,6 +353,7 @@ func TestRefreshProfileToken(t *testing.T) {
 		if got := r.FormValue("refresh_token"); got != "old-refresh-token" {
 			t.Fatalf("unexpected refresh token %q", got)
 		}
+		assertOAuthResource(t, r)
 		_ = json.NewEncoder(w).Encode(oauthTokenResponse{
 			AccessToken:  "new-access-token",
 			ExpiresIn:    300,
@@ -340,7 +362,7 @@ func TestRefreshProfileToken(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	token, err := refreshProfileToken(t.Context(), ts.URL, "old-refresh-token")
+	token, err := refreshProfileToken(t.Context(), ts.URL+"/api/v1", "old-refresh-token")
 	if err != nil {
 		t.Fatalf("refreshProfileToken returned error: %v", err)
 	}
@@ -386,4 +408,15 @@ func tsActivateURL(r *http.Request) string {
 		scheme = "https"
 	}
 	return scheme + "://" + r.Host + "/activate"
+}
+
+func assertOAuthResource(t *testing.T, r *http.Request) {
+	t.Helper()
+	expected := "http://" + r.Host
+	if r.TLS != nil {
+		expected = "https://" + r.Host
+	}
+	if got := r.FormValue("resource"); got != expected {
+		t.Fatalf("expected resource %q, got %q", expected, got)
+	}
 }

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -180,6 +180,7 @@ func refreshProfileToken(ctx context.Context, apiURL, refreshToken string) (*oau
 	values := url.Values{
 		"grant_type":    {"refresh_token"},
 		"client_id":     {oauthClientID},
+		"resource":      {oauthResource(apiURL)},
 		"refresh_token": {refreshToken},
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, oauthURL(apiURL, "/oauth/token"), strings.NewReader(values.Encode()))
@@ -234,4 +235,10 @@ func decodeOAuthError(body []byte, statusCode int) *oauthErrorResponse {
 
 func oauthURL(apiURL, path string) string {
 	return strings.TrimRight(client.NormalizeURL(apiURL), "/") + path
+}
+
+// oauthResource is the API origin expected by the OAuth server; it must not
+// include the /api/v1 suffix accepted by LANGSMITH_ENDPOINT.
+func oauthResource(apiURL string) string {
+	return strings.TrimRight(client.NormalizeURL(apiURL), "/")
 }

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -200,6 +200,7 @@ func TestResolveClientOptionsRefreshesProfileWithoutAccessToken(t *testing.T) {
 		if got := r.FormValue("refresh_token"); got != "old-refresh-token" {
 			t.Fatalf("unexpected refresh token %q", got)
 		}
+		assertOAuthResource(t, r)
 		_ = json.NewEncoder(w).Encode(oauthTokenResponse{
 			AccessToken:  "new-access-token",
 			ExpiresIn:    300,
@@ -216,7 +217,7 @@ func TestResolveClientOptionsRefreshesProfileWithoutAccessToken(t *testing.T) {
   "current_profile": "dev",
   "profiles": {
     "dev": {
-      "api_url": "`+ts.URL+`",
+      "api_url": "`+ts.URL+`/api/v1",
       "oauth": {
         "refresh_token": "old-refresh-token"
       }
@@ -234,6 +235,17 @@ func TestResolveClientOptionsRefreshesProfileWithoutAccessToken(t *testing.T) {
 	}
 	if opts.OAuthAccessToken != "new-access-token" {
 		t.Fatalf("expected refreshed OAuth token, got %q", opts.OAuthAccessToken)
+	}
+}
+
+func assertOAuthResource(t *testing.T, r *http.Request) {
+	t.Helper()
+	expected := "http://" + r.Host
+	if r.TLS != nil {
+		expected = "https://" + r.Host
+	}
+	if got := r.FormValue("resource"); got != expected {
+		t.Fatalf("expected resource %q, got %q", expected, got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- include the normalized API origin as the OAuth resource during device-code, device-token, and refresh-token requests
- cover resource handling in login and cmdutil refresh tests
- document why the resource excludes the /api/v1 suffix

## Verification
- go test ./...
- live dev login against https://dev.api.smith.langchain.com completed after device-code authorization
- reran workspace/project checks with LangSmith env overrides unset so the saved OAuth profile was used