### PR TITLE
test(hub): force JSON in integration harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,21 +347,6 @@ chmod +x ~/.local/bin/langsmith
 
 Ensure `~/.local/bin` is in your `PATH` before `~/go/bin`. This way commands like `langsmith sandbox list` and SSH ProxyCommand entries work without manually sourcing `.env` each time.
 
-### Integration tests
-
-Unit tests run with `go test ./...` (or `make test`) and use `httptest` mock servers; they require no API access.
-
-The `hub` command surface also has integration tests that hit the real LangSmith API. They are gated behind a build tag and skipped by default.
-
-```bash
-export LANGSMITH_API_KEY="lsv2_pt_..."
-make test-integration
-```
-
-The tests create temporary repos prefixed with `cli-int-` and clean them up via `t.Cleanup`. Failed runs may leave repos behind; `langsmith hub list --query cli-int` shows any leftovers and `langsmith hub delete <handle> --yes` removes them.
-
-In CI, the integration job runs only when the `LANGSMITH_API_KEY_TEST` secret is configured on the repository. Forks see the job skipped silently.
-
 ### Requirements
 
 - Go 1.23+

--- a/internal/cmd/hub_integration_test.go
+++ b/internal/cmd/hub_integration_test.go
@@ -32,7 +32,7 @@ func randomHandle(prefix string) string {
 // output. Fails the test on a non-nil execute error or non-JSON stdout.
 func runHub(t *testing.T, args ...string) map[string]any {
 	t.Helper()
-	full := append([]string{"hub"}, args...)
+	full := append([]string{"--format", "json", "hub"}, args...)
 	out := captureStdout(t, func() {
 		cmd := NewRootCmd("dev", "dev")
 		cmd.SetArgs(full)
@@ -50,7 +50,7 @@ func runHub(t *testing.T, args ...string) map[string]any {
 // runHubExpectError invokes the command and asserts it returned a non-nil error.
 func runHubExpectError(t *testing.T, args ...string) error {
 	t.Helper()
-	full := append([]string{"hub"}, args...)
+	full := append([]string{"--format", "json", "hub"}, args...)
 	var execErr error
 	captureStdout(t, func() {
 		cmd := NewRootCmd("dev", "dev")
@@ -75,7 +75,7 @@ func isNotFoundErr(err error) bool {
 // errors. Runs even on test failure so test repos do not pile up.
 func scheduleDelete(t *testing.T, handle string) {
 	t.Cleanup(func() {
-		full := []string{"hub", "delete", handle, "--yes"}
+		full := []string{"--format", "json", "hub", "delete", handle, "--yes"}
 		captureStdout(t, func() {
 			cmd := NewRootCmd("dev", "dev")
 			cmd.SetArgs(full)


### PR DESCRIPTION
## Summary
- force integration helper commands to run with `--format json` so parsing is deterministic
- remove the README integration test run section that was requested to be dropped

## Why
- `hub list` now defaults to pretty output, which made `TestHubIntegration_UserJourney` fail when it attempted to parse stdout as JSON
- this keeps integration tests aligned with their JSON assertions

## Validation
- `go test ./... -count=1`
- `go test -tags=integration -v -run Integration ./internal/cmd/ -count=1` (with LANGSMITH_API_KEY)
