### PR TITLE
Add gh-style API fields

### DIFF
--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -14,6 +14,10 @@ func NewCmd() *cobra.Command {
 		body    string
 		headers []string
 		include bool
+		input   string
+		method  string
+		fields  []string
+		raw     []string
 	)
 
 	cmd := &cobra.Command{
@@ -28,24 +32,33 @@ Browse endpoints:
   langsmith api info GET sessions               Show endpoint details
 
 Make requests:
-  langsmith api GET sessions?limit=5
-  langsmith api POST runs/query --body '{"session_id":"abc"}'
-  langsmith api DELETE sessions/abc-123
-  langsmith api POST datasets --body @body.json
-  echo '{"name":"x"}' | langsmith api POST sessions --body @-
-  langsmith api GET sessions --include`,
+  langsmith api sessions?limit=5
+  langsmith api runs/query -F session_id=abc -F limit=10
+  langsmith api sessions/abc-123 -X DELETE
+  langsmith api datasets --input body.json
+  echo '{"name":"x"}' | langsmith api sessions --input -
+  langsmith api sessions --include`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) < 2 {
+			if len(args) < 1 {
 				return cmd.Help()
 			}
 
-			method := strings.ToUpper(args[0])
-			if !isHTTPMethod(method) {
-				return fmt.Errorf("unknown subcommand or HTTP method: %q\nRun 'langsmith api --help' for usage", args[0])
+			params, err := parseFields(raw, fields)
+			if err != nil {
+				return err
 			}
 
-			path := args[1]
+			methodPassed := cmd.Flags().Changed("method")
+			method := strings.ToUpper(method)
+			if !methodPassed && (len(params) > 0 || input != "" || body != "") {
+				method = "POST"
+			}
+			if !isHTTPMethod(method) {
+				return fmt.Errorf("invalid HTTP method: %q\nRun 'langsmith api --help' for usage", method)
+			}
+
+			path := args[0]
 
 			c, err := cmdutil.GetClient(cmd)
 			if err != nil {
@@ -53,7 +66,7 @@ Make requests:
 			}
 
 			w := cmd.OutOrStdout()
-			statusCode, err := runRequest(c, method, path, body, headers, include, w)
+			statusCode, err := runRequest(c, method, path, body, input, params, headers, include, w)
 			if err != nil {
 				return err
 			}
@@ -66,8 +79,12 @@ Make requests:
 
 	// Flags for request mode
 	cmd.Flags().StringVar(&body, "body", "", `Request body (JSON string, @file, or @- for stdin)`)
+	cmd.Flags().StringVar(&input, "input", "", `File to use as body for the HTTP request (use "-" to read from stdin)`)
+	cmd.Flags().StringArrayVarP(&fields, "field", "F", nil, `Add a typed JSON field in key=value format (use "@<path>" or "@-" to read value from file or stdin)`)
+	cmd.Flags().StringArrayVarP(&raw, "raw-field", "f", nil, "Add a string JSON field in key=value format")
 	cmd.Flags().StringArrayVarP(&headers, "header", "H", nil, "Additional headers (Key:Value, repeatable)")
 	cmd.Flags().BoolVarP(&include, "include", "i", false, "Include HTTP response headers in output")
+	cmd.Flags().StringVarP(&method, "method", "X", "GET", "HTTP method")
 
 	cmd.AddCommand(newLsCmd())
 	cmd.AddCommand(newInfoCmd())

--- a/internal/cmd/api/api_test.go
+++ b/internal/cmd/api/api_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -32,7 +33,7 @@ func TestNewCmd_UseField(t *testing.T) {
 
 func TestNewCmd_RequestFlags(t *testing.T) {
 	cmd := NewCmd()
-	for _, name := range []string{"body", "header", "include"} {
+	for _, name := range []string{"body", "field", "header", "include", "input", "method", "raw-field"} {
 		f := cmd.Flags().Lookup(name)
 		if f == nil {
 			t.Errorf("flag --%s not found on api command", name)
@@ -40,7 +41,63 @@ func TestNewCmd_RequestFlags(t *testing.T) {
 	}
 }
 
-func TestNewCmd_GETRequest(t *testing.T) {
+func TestNewCmd_AutoPOSTWithFields(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var data map[string]any
+		if err := json.Unmarshal(body, &data); err != nil {
+			t.Fatalf("invalid json body: %v", err)
+		}
+		if data["name"] != "x" {
+			t.Errorf("expected name=x, got %v", data["name"])
+		}
+		if data["limit"] != float64(10) {
+			t.Errorf("expected limit=10, got %v", data["limit"])
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"created":true}`))
+	}))
+	defer ts.Close()
+
+	root := newTestRoot()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"api", "--api-key", "test-key", "--api-url", ts.URL, "sessions", "-f", "name=x", "-F", "limit=10"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewCmd_GETWithFieldsUsesQuery(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Query().Get("name") != "x" {
+			t.Errorf("expected query name=x, got %q", r.URL.RawQuery)
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	root := newTestRoot()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"api", "--api-key", "test-key", "--api-url", ts.URL, "sessions", "-X", "GET", "-f", "name=x"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewCmd_DefaultGETRequest(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/openapi.json" {
 			_ = json.NewEncoder(w).Encode(map[string]any{"openapi": "3.1.0", "paths": map[string]any{}})
@@ -61,7 +118,7 @@ func TestNewCmd_GETRequest(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"api", "--api-key", "test-key", "--api-url", ts.URL, "GET", "sessions"})
+	root.SetArgs([]string{"api", "--api-key", "test-key", "--api-url", ts.URL, "sessions"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -89,7 +146,7 @@ func TestNewCmd_POSTWithBody(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"api", "--api-key", "test-key", "--api-url", ts.URL, "POST", "sessions", "--body", `{"name":"x"}`})
+	root.SetArgs([]string{"api", "--api-key", "test-key", "--api-url", ts.URL, "sessions", "-X", "POST", "--body", `{"name":"x"}`})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -118,13 +175,13 @@ func TestNewCmd_InvalidMethod(t *testing.T) {
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
-	root.SetArgs([]string{"api", "--api-key", "key", "BOGUS", "sessions"})
+	root.SetArgs([]string{"api", "--api-key", "key", "sessions", "-X", "BOGUS"})
 
 	err := root.Execute()
 	if err == nil {
 		t.Fatal("expected error for invalid method")
 	}
-	if !strings.Contains(err.Error(), "unknown subcommand or HTTP method") {
+	if !strings.Contains(err.Error(), "invalid HTTP method") {
 		t.Errorf("expected helpful error, got %q", err.Error())
 	}
 }

--- a/internal/cmd/api/fields.go
+++ b/internal/cmd/api/fields.go
@@ -1,0 +1,189 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+func parseFields(rawFields, typedFields []string) (map[string]any, error) {
+	params := make(map[string]any)
+	for _, field := range rawFields {
+		if err := parseField(params, field, false); err != nil {
+			return nil, err
+		}
+	}
+	for _, field := range typedFields {
+		if err := parseField(params, field, true); err != nil {
+			return nil, err
+		}
+	}
+	return params, nil
+}
+
+func parseField(params map[string]any, field string, typed bool) error {
+	var valueIndex int
+	var keys []string
+	keyStartAt := 0
+parseLoop:
+	for i, r := range field {
+		switch r {
+		case '[':
+			if keyStartAt == 0 {
+				keys = append(keys, field[0:i])
+			}
+			keyStartAt = i + 1
+		case ']':
+			keys = append(keys, field[keyStartAt:i])
+		case '=':
+			if keyStartAt == 0 {
+				keys = append(keys, field[0:i])
+			}
+			valueIndex = i + 1
+			break parseLoop
+		}
+	}
+	if len(keys) == 0 || keys[0] == "" {
+		if valueIndex == 0 && !strings.ContainsAny(field, "[]") {
+			return fmt.Errorf("field %q requires a value separated by '='", field)
+		}
+		return fmt.Errorf("invalid field key: %q", field)
+	}
+
+	key := field
+	var value any
+	if valueIndex == 0 {
+		if keys[len(keys)-1] != "" {
+			return fmt.Errorf("field %q requires a value separated by '='", key)
+		}
+	} else {
+		key = field[:valueIndex-1]
+		value = field[valueIndex:]
+	}
+
+	if typed && value != nil {
+		typedValue, err := parseTypedFieldValue(value.(string))
+		if err != nil {
+			return fmt.Errorf("error parsing %q value: %w", key, err)
+		}
+		value = typedValue
+	}
+
+	return setFieldValue(params, keys, value)
+}
+
+func parseTypedFieldValue(value string) (any, error) {
+	if strings.HasPrefix(value, "@") {
+		data, err := readFieldFile(value[1:])
+		if err != nil {
+			return nil, err
+		}
+		return string(data), nil
+	}
+	if value == "true" {
+		return true, nil
+	}
+	if value == "false" {
+		return false, nil
+	}
+	if value == "null" {
+		return nil, nil
+	}
+	if n, err := strconv.Atoi(value); err == nil {
+		return n, nil
+	}
+	return value, nil
+}
+
+func readFieldFile(path string) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(os.Stdin)
+	}
+	return os.ReadFile(path)
+}
+
+func setFieldValue(params map[string]any, keys []string, value any) error {
+	current := params
+	isArray := false
+	var subkey string
+	for _, key := range keys {
+		if key == "" {
+			isArray = true
+			continue
+		}
+		if subkey != "" {
+			var err error
+			if isArray {
+				current, err = addFieldSlice(current, subkey, key)
+				isArray = false
+			} else {
+				current, err = addFieldMap(current, subkey)
+			}
+			if err != nil {
+				return err
+			}
+		}
+		subkey = key
+	}
+
+	if isArray {
+		if value == nil {
+			current[subkey] = []any{}
+			return nil
+		}
+		if existing, ok := current[subkey]; ok {
+			slice, ok := existing.([]any)
+			if !ok {
+				return fmt.Errorf("expected array type under %q, got %T", subkey, existing)
+			}
+			current[subkey] = append(slice, value)
+			return nil
+		}
+		current[subkey] = []any{value}
+		return nil
+	}
+	if _, exists := current[subkey]; exists {
+		return fmt.Errorf("unexpected override existing field under %q", subkey)
+	}
+	current[subkey] = value
+	return nil
+}
+
+func addFieldMap(m map[string]any, key string) (map[string]any, error) {
+	if existing, ok := m[key]; ok {
+		next, ok := existing.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("expected object under %q, got %T", key, existing)
+		}
+		return next, nil
+	}
+	next := make(map[string]any)
+	m[key] = next
+	return next, nil
+}
+
+func addFieldSlice(m map[string]any, prevKey, newKey string) (map[string]any, error) {
+	if existing, ok := m[prevKey]; ok {
+		slice, ok := existing.([]any)
+		if !ok {
+			return nil, fmt.Errorf("expected array type under %q, got %T", prevKey, existing)
+		}
+		if len(slice) > 0 {
+			last := slice[len(slice)-1]
+			if lastMap, ok := last.(map[string]any); ok {
+				if _, exists := lastMap[newKey]; !exists || reflect.TypeOf(lastMap[newKey]).Kind() == reflect.Slice {
+					return lastMap, nil
+				}
+			}
+		}
+		next := make(map[string]any)
+		m[prevKey] = append(slice, next)
+		return next, nil
+	}
+	next := make(map[string]any)
+	m[prevKey] = []any{next}
+	return next, nil
+}

--- a/internal/cmd/api/fields_test.go
+++ b/internal/cmd/api/fields_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseFields_RawFieldsAreStrings(t *testing.T) {
+	got, err := parseFields([]string{"limit=10", "draft=false", "empty="}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]any{"limit": "10", "draft": "false", "empty": ""}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestParseFields_TypedFields(t *testing.T) {
+	got, err := parseFields(nil, []string{"limit=10", "draft=false", "enabled=true", "name=test", "nil=null"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]any{"limit": 10, "draft": false, "enabled": true, "name": "test", "nil": nil}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestParseFields_NestedFields(t *testing.T) {
+	got, err := parseFields(
+		[]string{"metadata[source]=cli"},
+		[]string{"config[limit]=5", "config[enabled]=true"},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]any{
+		"metadata": map[string]any{"source": "cli"},
+		"config":   map[string]any{"limit": 5, "enabled": true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestParseFields_ArrayFields(t *testing.T) {
+	got, err := parseFields(
+		[]string{"tags[]=alpha", "tags[]=beta"},
+		[]string{"examples[][id]=1", "examples[][name]=first", "examples[][id]=2"},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]any{
+		"tags": []any{"alpha", "beta"},
+		"examples": []any{
+			map[string]any{"id": 1, "name": "first"},
+			map[string]any{"id": 2},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestParseFields_TypedValueFromFile(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "field-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("hello from file"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := parseFields(nil, []string{"body=@" + f.Name()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["body"] != "hello from file" {
+		t.Fatalf("got %#v", got["body"])
+	}
+}
+
+func TestParseFields_Errors(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields []string
+		want   string
+	}{
+		{"missing equals", []string{"name"}, "requires a value"},
+		{"empty key", []string{"=value"}, "invalid field key"},
+		{"override", []string{"name=x", "name=y"}, "unexpected override"},
+		{"object conflict", []string{"config=x", "config[name]=y"}, "expected object"},
+		{"array conflict", []string{"items=x", "items[]=y"}, "expected array"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseFields(tt.fields, nil)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("got %q, want containing %q", err.Error(), tt.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/api/request.go
+++ b/internal/cmd/api/request.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -15,9 +16,12 @@ import (
 
 // runRequest executes an HTTP request and writes the response to w.
 // Returns the HTTP status code and any transport-level error.
-func runRequest(c *client.Client, method, path, body string, headers []string, include bool, w io.Writer) (int, error) {
+func runRequest(c *client.Client, method, path, body, input string, params map[string]any, headers []string, include bool, w io.Writer) (int, error) {
 	apiURL := c.APIURL()
 	fullURL := resolveEndpoint(apiURL, path)
+	if len(params) > 0 && strings.EqualFold(method, "GET") {
+		fullURL = addQueryParams(fullURL, params)
+	}
 
 	// RawDo prepends apiURL, so compute the relative path.
 	// For full URLs with a different host, pass the full URL as the path
@@ -31,8 +35,7 @@ func runRequest(c *client.Client, method, path, body string, headers []string, i
 		reqClient = client.NewWithOptions(client.Options{})
 	}
 
-	// Resolve body
-	bodyReader, err := resolveBody(body)
+	bodyReader, err := resolveRequestBody(method, body, input, params)
 	if err != nil {
 		return 0, err
 	}
@@ -75,6 +78,82 @@ func runRequest(c *client.Client, method, path, body string, headers []string, i
 	}
 
 	return statusCode, nil
+}
+
+func resolveRequestBody(method, body, input string, params map[string]any) (io.Reader, error) {
+	if input != "" && body != "" {
+		return nil, fmt.Errorf("only one of --input or --body may be used")
+	}
+	if input != "" && len(params) > 0 && !strings.EqualFold(method, "GET") {
+		return nil, fmt.Errorf("--input cannot be combined with field parameters unless using GET")
+	}
+	if strings.EqualFold(method, "GET") {
+		if input != "" {
+			return resolveInput(input)
+		}
+		if body != "" {
+			return resolveBody(body)
+		}
+		return nil, nil
+	}
+	if input != "" {
+		return resolveInput(input)
+	}
+	if body != "" {
+		return resolveBody(body)
+	}
+	if len(params) == 0 {
+		return nil, nil
+	}
+	data, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling fields: %w", err)
+	}
+	return bytes.NewReader(data), nil
+}
+
+func resolveInput(input string) (io.Reader, error) {
+	if input == "-" {
+		return os.Stdin, nil
+	}
+	data, err := os.ReadFile(input)
+	if err != nil {
+		return nil, fmt.Errorf("reading input file %q: %w", input, err)
+	}
+	return bytes.NewReader(data), nil
+}
+
+func addQueryParams(rawURL string, params map[string]any) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := u.Query()
+	for key, value := range params {
+		addQueryValue(q, key, value)
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func addQueryValue(q url.Values, key string, value any) {
+	switch v := value.(type) {
+	case map[string]any:
+		data, err := json.Marshal(v)
+		if err != nil {
+			q.Add(key, fmt.Sprint(v))
+			return
+		}
+		q.Add(key, string(data))
+	case []any:
+		for _, item := range v {
+			addQueryValue(q, key, item)
+		}
+	case nil:
+		q.Add(key, "")
+	default:
+		q.Add(key, fmt.Sprint(v))
+	}
 }
 
 // resolveBody resolves a --body value to an io.Reader.

--- a/internal/cmd/api/request_test.go
+++ b/internal/cmd/api/request_test.go
@@ -31,7 +31,7 @@ func TestRunRequest_GET(t *testing.T) {
 
 	var out bytes.Buffer
 	c := client.New("test-key", ts.URL)
-	code, err := runRequest(c, "GET", "sessions", "", nil, false, &out)
+	code, err := runRequest(c, "GET", "sessions", "", "", nil, nil, false, &out)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -61,12 +61,74 @@ func TestRunRequest_POSTWithBody(t *testing.T) {
 
 	var out bytes.Buffer
 	c := client.New("key", ts.URL)
-	code, err := runRequest(c, "POST", "sessions", `{"name":"test"}`, nil, false, &out)
+	code, err := runRequest(c, "POST", "sessions", `{"name":"test"}`, "", nil, nil, false, &out)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if code != 201 {
 		t.Errorf("expected 201, got %d", code)
+	}
+}
+
+func TestRunRequest_POSTWithFields(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var data map[string]any
+		if err := json.Unmarshal(body, &data); err != nil {
+			t.Fatalf("invalid json body: %v", err)
+		}
+		if data["name"] != "test" {
+			t.Errorf("expected name=test, got %v", data["name"])
+		}
+		if data["limit"] != float64(10) {
+			t.Errorf("expected limit=10, got %v", data["limit"])
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	var out bytes.Buffer
+	c := client.New("key", ts.URL)
+	params := map[string]any{"name": "test", "limit": 10}
+	code, err := runRequest(c, "POST", "sessions", "", "", params, nil, false, &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Errorf("expected 200, got %d", code)
+	}
+}
+
+func TestRunRequest_GETWithFieldsAddsQuery(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Query().Get("limit") != "10" {
+			t.Errorf("expected limit=10, got %q", r.URL.RawQuery)
+		}
+		if r.URL.Query().Get("name") != "test" {
+			t.Errorf("expected name=test, got %q", r.URL.RawQuery)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if len(body) != 0 {
+			t.Errorf("expected empty body, got %q", body)
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	var out bytes.Buffer
+	c := client.New("key", ts.URL)
+	params := map[string]any{"name": "test", "limit": 10}
+	_, err := runRequest(c, "GET", "sessions?existing=1", "", "", params, nil, false, &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -82,7 +144,7 @@ func TestRunRequest_ExtraHeaders(t *testing.T) {
 
 	var out bytes.Buffer
 	c := client.New("key", ts.URL)
-	_, err := runRequest(c, "GET", "sessions", "", []string{"X-Custom:val"}, false, &out)
+	_, err := runRequest(c, "GET", "sessions", "", "", nil, []string{"X-Custom:val"}, false, &out)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -98,7 +160,7 @@ func TestRunRequest_Include(t *testing.T) {
 
 	var out bytes.Buffer
 	c := client.New("key", ts.URL)
-	_, err := runRequest(c, "GET", "sessions", "", nil, true, &out)
+	_, err := runRequest(c, "GET", "sessions", "", "", nil, nil, true, &out)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -119,7 +181,7 @@ func TestRunRequest_4xxPrintsBody(t *testing.T) {
 
 	var out bytes.Buffer
 	c := client.New("key", ts.URL)
-	code, err := runRequest(c, "GET", "sessions", "", nil, false, &out)
+	code, err := runRequest(c, "GET", "sessions", "", "", nil, nil, false, &out)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -145,7 +207,7 @@ func TestRunRequest_BodyFromFile(t *testing.T) {
 
 	var out bytes.Buffer
 	c := client.New("key", ts.URL)
-	code, err := runRequest(c, "POST", "sessions", "@"+f.Name(), nil, false, &out)
+	code, err := runRequest(c, "POST", "sessions", "@"+f.Name(), "", nil, nil, false, &out)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -172,7 +234,7 @@ func TestRunRequest_FullURLDifferentHost(t *testing.T) {
 
 	var out bytes.Buffer
 	c := client.New("key", "https://different.host")
-	code, err := runRequest(c, "GET", ts.URL+"/custom/endpoint", "", nil, false, &out)
+	code, err := runRequest(c, "GET", ts.URL+"/custom/endpoint", "", "", nil, nil, false, &out)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -194,7 +256,7 @@ func TestRunRequest_MultiValueHeaders(t *testing.T) {
 
 	var out bytes.Buffer
 	c := client.New("key", ts.URL)
-	_, err := runRequest(c, "GET", "sessions", "", []string{"X-Multi:one", "X-Multi:two"}, false, &out)
+	_, err := runRequest(c, "GET", "sessions", "", "", nil, []string{"X-Multi:one", "X-Multi:two"}, false, &out)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -222,7 +284,7 @@ func TestRunRequest_PrefixConfusionAttack(t *testing.T) {
 	c := client.New("secret-key", apiURL)
 
 	var out bytes.Buffer
-	code, err := runRequest(c, "GET", ts.URL+"/steal", "", nil, false, &out)
+	code, err := runRequest(c, "GET", ts.URL+"/steal", "", "", nil, nil, false, &out)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -280,5 +342,39 @@ func TestResolveBody_FileNotFound(t *testing.T) {
 	_, err := resolveBody("@/nonexistent/path.json")
 	if err == nil {
 		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestResolveRequestBody_InputFile(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "input-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"from":"input"}`); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := resolveRequestBody("POST", "", f.Name(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, _ := io.ReadAll(r)
+	if string(data) != `{"from":"input"}` {
+		t.Fatalf("unexpected body: %s", data)
+	}
+}
+
+func TestResolveRequestBody_Errors(t *testing.T) {
+	_, err := resolveRequestBody("POST", "{}", "body.json", nil)
+	if err == nil || !strings.Contains(err.Error(), "only one of --input or --body") {
+		t.Fatalf("expected input/body conflict, got %v", err)
+	}
+
+	_, err = resolveRequestBody("POST", "", "body.json", map[string]any{"name": "x"})
+	if err == nil || !strings.Contains(err.Error(), "--input cannot be combined") {
+		t.Fatalf("expected input/fields conflict, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Add gh-style request flags to `langsmith api`: `-X/--method`, `-f/--raw-field`, `-F/--field`, and `--input`.
- Default requests to GET, auto-switch to POST when body/field/input flags are used, and keep `-X GET` fields in the query string.
- Add JSON field parsing for typed values, nested objects, arrays, and `@file` / `@-` values.

## Test Plan

- [x] `go test ./...`