### PR TITLE
feat(auth): add OAuth token command

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -17,6 +17,7 @@ var authCommand = structured.Parent{
 	Use:   "auth",
 	Short: "Manage authentication",
 	Children: []func() *cobra.Command{
+		newLoginCmd,
 		authTokenCommand.Cobra,
 	},
 }
@@ -36,7 +37,7 @@ var authTokenCommand = structured.Command[struct{}]{
 			return "", fmt.Errorf("profile not found: %s", profileName)
 		}
 		if !hasProfile || (profile.AccessToken() == "" && profile.OAuth.RefreshToken == "") {
-			return "", fmt.Errorf("no OAuth token found; run 'langsmith login'")
+			return "", fmt.Errorf("no OAuth token found; run 'langsmith auth login'")
 		}
 
 		apiURL := lsconfig.DefaultAPIURL
@@ -58,7 +59,7 @@ var authTokenCommand = structured.Command[struct{}]{
 			}
 			token, err := refreshProfileToken(ctx, apiURL, profile.OAuth.RefreshToken)
 			if err != nil {
-				return "", fmt.Errorf("refreshing OAuth token for profile %q: %w; run 'langsmith login --profile %s' to reauthenticate", profileName, err, profileName)
+				return "", fmt.Errorf("refreshing OAuth token for profile %q: %w; run 'langsmith auth login --profile %s' to reauthenticate", profileName, err, profileName)
 			}
 			applyTokenResponse(&profile, token, time.Now())
 			cfg.Profiles[profileName] = profile

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/langchain-ai/langsmith-cli/internal/client"
+	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func newAuthCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Manage authentication",
+	}
+	cmd.AddCommand(newAuthTokenCmd())
+	return cmd
+}
+
+func newAuthTokenCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "token",
+		Short: "Print the OAuth access token",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			token, err := resolveOAuthAccessToken(cmd.Context())
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), token)
+			return nil
+		},
+	}
+}
+
+func resolveOAuthAccessToken(ctx context.Context) (string, error) {
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return "", err
+	}
+
+	envProfile := strings.TrimSpace(os.Getenv("LANGSMITH_PROFILE"))
+	profileName, profile, hasProfile := cfg.ResolveProfile(flagProfile, envProfile)
+	if (flagProfile != "" || envProfile != "") && !hasProfile {
+		return "", fmt.Errorf("profile not found: %s", profileName)
+	}
+	if !hasProfile || (profile.AccessToken() == "" && profile.OAuth.RefreshToken == "") {
+		return "", fmt.Errorf("no OAuth token found; run 'langsmith login'")
+	}
+
+	apiURL := lsconfig.DefaultAPIURL
+	if profile.APIURL != "" {
+		apiURL = profile.APIURL
+	}
+	if envURL := strings.TrimSpace(os.Getenv("LANGSMITH_ENDPOINT")); envURL != "" {
+		apiURL = envURL
+	}
+	if flagAPIURL != "" {
+		apiURL = flagAPIURL
+	}
+	apiURL = client.NormalizeURL(apiURL)
+
+	if profile.OAuth.RefreshToken != "" &&
+		(profile.AccessToken() == "" || profile.TokenExpiresSoon(time.Now(), time.Minute)) {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		token, err := refreshProfileToken(ctx, apiURL, profile.OAuth.RefreshToken)
+		if err != nil {
+			return "", fmt.Errorf("refreshing OAuth token for profile %q: %w; run 'langsmith login --profile %s' to reauthenticate", profileName, err, profileName)
+		}
+		applyTokenResponse(&profile, token, time.Now())
+		cfg.Profiles[profileName] = profile
+		if err := cfg.Save(); err != nil {
+			return "", fmt.Errorf("saving refreshed OAuth token: %w", err)
+		}
+	}
+
+	return profile.AccessToken(), nil
+}

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -9,31 +9,26 @@ import (
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
 	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
+	"github.com/langchain-ai/langsmith-cli/internal/structured"
 	"github.com/spf13/cobra"
 )
 
-func newAuthCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "auth",
-		Short: "Manage authentication",
-	}
-	cmd.AddCommand(newAuthTokenCmd())
-	return cmd
+var authCommand = structured.Parent{
+	Use:   "auth",
+	Short: "Manage authentication",
+	Children: []func() *cobra.Command{
+		authTokenCommand.Cobra,
+	},
 }
 
-func newAuthTokenCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "token",
-		Short: "Print the OAuth access token",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			token, err := resolveOAuthAccessToken(cmd.Context())
-			if err != nil {
-				return err
-			}
-			fmt.Fprintln(cmd.OutOrStdout(), token)
-			return nil
-		},
-	}
+var authTokenCommand = structured.Command[struct{}]{
+	Use:   "token",
+	Short: "Print the OAuth access token",
+	Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+		return resolveOAuthAccessToken(ctx)
+	},
+	Render: structured.Template(`{{.}}
+`),
 }
 
 func resolveOAuthAccessToken(ctx context.Context) (string, error) {

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -25,54 +25,50 @@ var authTokenCommand = structured.Command[struct{}]{
 	Use:   "token",
 	Short: "Print the OAuth access token",
 	Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
-		return resolveOAuthAccessToken(ctx)
+		cfg, err := lsconfig.Load()
+		if err != nil {
+			return "", err
+		}
+
+		envProfile := strings.TrimSpace(os.Getenv("LANGSMITH_PROFILE"))
+		profileName, profile, hasProfile := cfg.ResolveProfile(flagProfile, envProfile)
+		if (flagProfile != "" || envProfile != "") && !hasProfile {
+			return "", fmt.Errorf("profile not found: %s", profileName)
+		}
+		if !hasProfile || (profile.AccessToken() == "" && profile.OAuth.RefreshToken == "") {
+			return "", fmt.Errorf("no OAuth token found; run 'langsmith login'")
+		}
+
+		apiURL := lsconfig.DefaultAPIURL
+		if profile.APIURL != "" {
+			apiURL = profile.APIURL
+		}
+		if envURL := strings.TrimSpace(os.Getenv("LANGSMITH_ENDPOINT")); envURL != "" {
+			apiURL = envURL
+		}
+		if flagAPIURL != "" {
+			apiURL = flagAPIURL
+		}
+		apiURL = client.NormalizeURL(apiURL)
+
+		if profile.OAuth.RefreshToken != "" &&
+			(profile.AccessToken() == "" || profile.TokenExpiresSoon(time.Now(), time.Minute)) {
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			token, err := refreshProfileToken(ctx, apiURL, profile.OAuth.RefreshToken)
+			if err != nil {
+				return "", fmt.Errorf("refreshing OAuth token for profile %q: %w; run 'langsmith login --profile %s' to reauthenticate", profileName, err, profileName)
+			}
+			applyTokenResponse(&profile, token, time.Now())
+			cfg.Profiles[profileName] = profile
+			if err := cfg.Save(); err != nil {
+				return "", fmt.Errorf("saving refreshed OAuth token: %w", err)
+			}
+		}
+
+		return profile.AccessToken(), nil
 	},
 	Render: structured.Template(`{{.}}
 `),
-}
-
-func resolveOAuthAccessToken(ctx context.Context) (string, error) {
-	cfg, err := lsconfig.Load()
-	if err != nil {
-		return "", err
-	}
-
-	envProfile := strings.TrimSpace(os.Getenv("LANGSMITH_PROFILE"))
-	profileName, profile, hasProfile := cfg.ResolveProfile(flagProfile, envProfile)
-	if (flagProfile != "" || envProfile != "") && !hasProfile {
-		return "", fmt.Errorf("profile not found: %s", profileName)
-	}
-	if !hasProfile || (profile.AccessToken() == "" && profile.OAuth.RefreshToken == "") {
-		return "", fmt.Errorf("no OAuth token found; run 'langsmith login'")
-	}
-
-	apiURL := lsconfig.DefaultAPIURL
-	if profile.APIURL != "" {
-		apiURL = profile.APIURL
-	}
-	if envURL := strings.TrimSpace(os.Getenv("LANGSMITH_ENDPOINT")); envURL != "" {
-		apiURL = envURL
-	}
-	if flagAPIURL != "" {
-		apiURL = flagAPIURL
-	}
-	apiURL = client.NormalizeURL(apiURL)
-
-	if profile.OAuth.RefreshToken != "" &&
-		(profile.AccessToken() == "" || profile.TokenExpiresSoon(time.Now(), time.Minute)) {
-		if ctx == nil {
-			ctx = context.Background()
-		}
-		token, err := refreshProfileToken(ctx, apiURL, profile.OAuth.RefreshToken)
-		if err != nil {
-			return "", fmt.Errorf("refreshing OAuth token for profile %q: %w; run 'langsmith login --profile %s' to reauthenticate", profileName, err, profileName)
-		}
-		applyTokenResponse(&profile, token, time.Now())
-		cfg.Profiles[profileName] = profile
-		if err := cfg.Save(); err != nil {
-			return "", fmt.Errorf("saving refreshed OAuth token: %w", err)
-		}
-	}
-
-	return profile.AccessToken(), nil
 }

--- a/internal/cmd/auth_test.go
+++ b/internal/cmd/auth_test.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAuthTokenPrintsSavedOAuthToken(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	if err := os.WriteFile(path, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "oauth": {
+        "access_token": "saved-access-token"
+      }
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, err := executeCommand(t, "auth", "token")
+	if err != nil {
+		t.Fatalf("auth token returned error: %v", err)
+	}
+	if stdout != "saved-access-token\n" {
+		t.Fatalf("expected saved token, got %q", stdout)
+	}
+}
+
+func TestAuthTokenRefreshesExpiredOAuthToken(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		if got := r.FormValue("grant_type"); got != "refresh_token" {
+			t.Fatalf("unexpected grant_type %q", got)
+		}
+		if got := r.FormValue("refresh_token"); got != "old-refresh-token" {
+			t.Fatalf("unexpected refresh token %q", got)
+		}
+		assertOAuthResource(t, r)
+		_ = json.NewEncoder(w).Encode(oauthTokenResponse{
+			AccessToken:  "new-access-token",
+			ExpiresIn:    300,
+			RefreshToken: "new-refresh-token",
+		})
+	}))
+	defer ts.Close()
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	if err := os.WriteFile(path, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_url": "`+ts.URL+`",
+      "oauth": {
+        "access_token": "expired-access-token",
+        "refresh_token": "old-refresh-token",
+        "expires_at": "2000-01-01T00:00:00Z"
+      }
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, err := executeCommand(t, "auth", "token")
+	if err != nil {
+		t.Fatalf("auth token returned error: %v", err)
+	}
+	if stdout != "new-access-token\n" {
+		t.Fatalf("expected refreshed token, got %q", stdout)
+	}
+
+	cfg, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(cfg), "new-refresh-token") {
+		t.Fatalf("expected refreshed token to be saved, got %s", string(cfg))
+	}
+}
+
+func TestAuthTokenRequiresOAuthToken(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+
+	isolateConfig(t)
+	t.Setenv("LANGSMITH_API_KEY", "from-env")
+
+	_, err := executeCommand(t, "auth", "token")
+	if err == nil || !strings.Contains(err.Error(), "no OAuth token") {
+		t.Fatalf("expected missing OAuth token error, got %v", err)
+	}
+}

--- a/internal/cmd/auth_test.go
+++ b/internal/cmd/auth_test.go
@@ -10,6 +10,19 @@ import (
 	"testing"
 )
 
+func TestAuthCmdHasSubcommands(t *testing.T) {
+	cmd := authCommand.Cobra()
+	names := make(map[string]bool, len(cmd.Commands()))
+	for _, child := range cmd.Commands() {
+		names[child.Name()] = true
+	}
+	for _, expected := range []string{"login", "token"} {
+		if !names[expected] {
+			t.Fatalf("auth command missing subcommand %q", expected)
+		}
+	}
+}
+
 func TestAuthTokenPrintsSavedOAuthToken(t *testing.T) {
 	oldKey := flagAPIKey
 	oldURL := flagAPIURL

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -214,7 +214,7 @@ func validateWorkspaceID(workspaceID string) error {
 func promptWorkspaceSelection(cmd *cobra.Command, apiURL, accessToken string) (string, error) {
 	in := cmd.InOrStdin()
 	if !inputIsTerminal(in) {
-		fmt.Fprintln(cmd.ErrOrStderr(), "No default workspace set because stdin is not interactive. Some commands require a workspace; pass --workspace-id to login or run 'langsmith workspace set-default <workspace-id>'.")
+		fmt.Fprintln(cmd.ErrOrStderr(), "No default workspace set because stdin is not interactive. Some commands require a workspace; pass --workspace-id to auth login or run 'langsmith workspace set-default <workspace-id>'.")
 		return "", nil
 	}
 	workspaces, err := listLoginWorkspaces(cmd.Context(), apiURL, accessToken)

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -86,7 +86,7 @@ func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"--format=json", "login", "--api-url", ts.URL + "/api/v1", "--no-browser", "--workspace-id", workspaceID})
+	root.SetArgs([]string{"--format=json", "auth", "login", "--api-url", ts.URL + "/api/v1", "--no-browser", "--workspace-id", workspaceID})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())
@@ -215,7 +215,7 @@ func TestLoginPromptsWorkspaceSelection(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"--format=json", "login", "--api-url", ts.URL, "--no-browser"})
+	root.SetArgs([]string{"--format=json", "auth", "login", "--api-url", ts.URL, "--no-browser"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())
@@ -305,7 +305,7 @@ func TestLoginWarnsWhenNonInteractiveWithoutWorkspace(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"--format=json", "login", "--api-url", ts.URL, "--no-browser"})
+	root.SetArgs([]string{"--format=json", "auth", "login", "--api-url", ts.URL, "--no-browser"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -32,7 +32,7 @@ func NewRootCmd(rawVersion, displayVersion string) *cobra.Command {
 	runs, datasets, evaluators, experiments, and threads.
 
 Authentication:
-  Run 'langsmith login', set LANGSMITH_API_KEY, or pass --api-key.
+  Run 'langsmith auth login', set LANGSMITH_API_KEY, or pass --api-key.
   Optionally set LANGSMITH_ENDPOINT for self-hosted instances.
   Use --profile or LANGSMITH_PROFILE to select a saved profile.
   Set a default workspace with 'langsmith profile set-workspace <workspace-id>'.
@@ -74,7 +74,6 @@ Quick start:
 	rootCmd.AddCommand(newHubCmd())
 	rootCmd.AddCommand(newPromptCmd())
 	rootCmd.AddCommand(authCommand.Cobra())
-	rootCmd.AddCommand(newLoginCmd())
 	rootCmd.AddCommand(newProfileCmd())
 	rootCmd.AddCommand(newWorkspaceCmd())
 	rootCmd.AddCommand(newUpdateCmd(rawVersion))
@@ -119,7 +118,7 @@ func MustGetClient() *client.Client {
 		ExitError(err.Error())
 	}
 	if opts.APIKey == "" && opts.OAuthAccessToken == "" {
-		ExitError("not authenticated; run 'langsmith login', set LANGSMITH_API_KEY, or pass --api-key")
+		ExitError("not authenticated; run 'langsmith auth login', set LANGSMITH_API_KEY, or pass --api-key")
 	}
 	return client.NewWithOptions(opts)
 }
@@ -176,7 +175,7 @@ func resolveClientOptions(refreshOAuth bool) (client.Options, error) {
 			(profile.AccessToken() == "" || profile.TokenExpiresSoon(time.Now(), time.Minute)) {
 			token, err := refreshProfileToken(context.Background(), opts.APIURL, profile.OAuth.RefreshToken)
 			if err != nil {
-				return opts, fmt.Errorf("refreshing OAuth token for profile %q: %w; run 'langsmith login --profile %s' to reauthenticate", profileName, err, profileName)
+				return opts, fmt.Errorf("refreshing OAuth token for profile %q: %w; run 'langsmith auth login --profile %s' to reauthenticate", profileName, err, profileName)
 			}
 			applyTokenResponse(&profile, token, time.Now())
 			cfg.Profiles[profileName] = profile

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -73,7 +73,7 @@ Quick start:
 	rootCmd.AddCommand(newFleetCmd())
 	rootCmd.AddCommand(newHubCmd())
 	rootCmd.AddCommand(newPromptCmd())
-	rootCmd.AddCommand(newAuthCmd())
+	rootCmd.AddCommand(authCommand.Cobra())
 	rootCmd.AddCommand(newLoginCmd())
 	rootCmd.AddCommand(newProfileCmd())
 	rootCmd.AddCommand(newWorkspaceCmd())

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -73,6 +73,7 @@ Quick start:
 	rootCmd.AddCommand(newFleetCmd())
 	rootCmd.AddCommand(newHubCmd())
 	rootCmd.AddCommand(newPromptCmd())
+	rootCmd.AddCommand(newAuthCmd())
 	rootCmd.AddCommand(newLoginCmd())
 	rootCmd.AddCommand(newProfileCmd())
 	rootCmd.AddCommand(newWorkspaceCmd())

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -18,7 +18,7 @@ func isolateConfig(t *testing.T) {
 
 func TestRootCmd_HasAllSubcommands(t *testing.T) {
 	root := NewRootCmd("1.0.0", "1.0.0")
-	expected := []string{"project", "trace", "run", "thread", "dataset", "example", "evaluator", "experiment", "sandbox", "auth", "login", "profile", "workspace", "self-update", "api"}
+	expected := []string{"project", "trace", "run", "thread", "dataset", "example", "evaluator", "experiment", "sandbox", "auth", "profile", "workspace", "self-update", "api"}
 	cmds := root.Commands()
 
 	names := make(map[string]bool, len(cmds))

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -18,7 +18,7 @@ func isolateConfig(t *testing.T) {
 
 func TestRootCmd_HasAllSubcommands(t *testing.T) {
 	root := NewRootCmd("1.0.0", "1.0.0")
-	expected := []string{"project", "trace", "run", "thread", "dataset", "example", "evaluator", "experiment", "sandbox", "login", "profile", "workspace", "self-update", "api"}
+	expected := []string{"project", "trace", "run", "thread", "dataset", "example", "evaluator", "experiment", "sandbox", "auth", "login", "profile", "workspace", "self-update", "api"}
 	cmds := root.Commands()
 
 	names := make(map[string]bool, len(cmds))


### PR DESCRIPTION
Adds `langsmith auth token` to print the selected OAuth profile access token. The command refreshes and saves the token first when the saved access token is expired or near expiry, and it ignores API-key auth so `LANGSMITH_API_KEY` does not mask a saved OAuth profile.

## Test Plan

- [x] `go test ./internal/cmd`