### PR TITLE
fix(cli): print plain errors

### DIFF
--- a/cmd/langsmith/main.go
+++ b/cmd/langsmith/main.go
@@ -16,7 +16,7 @@ var (
 func main() {
 	rootCmd := cmd.NewRootCmd(version, fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date))
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, `{"error": %q}`+"\n", err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -195,13 +195,13 @@ func resolveClientOptions(refreshOAuth bool) (client.Options, error) {
 	return opts, nil
 }
 
-// ExitError prints a JSON error to stderr and exits.
+// ExitError prints an error to stderr and exits.
 func ExitError(msg string) {
-	fmt.Fprintf(os.Stderr, `{"error": %q}`+"\n", msg)
+	fmt.Fprintln(os.Stderr, msg)
 	os.Exit(1)
 }
 
-// ExitErrorf prints a formatted JSON error to stderr and exits.
+// ExitErrorf prints a formatted error to stderr and exits.
 func ExitErrorf(format string, args ...any) {
 	ExitError(fmt.Sprintf(format, args...))
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -153,9 +153,9 @@ func PrintOutput(data any, format string, filePath string) {
 	}
 }
 
-// PrintError prints a JSON error to stderr.
+// PrintError prints an error to stderr.
 func PrintError(msg string) {
-	fmt.Fprintf(os.Stderr, `{"error": %q}`+"\n", msg)
+	fmt.Fprintln(os.Stderr, msg)
 }
 
 // PrintRunsTable prints a table of runs in pretty format.


### PR DESCRIPTION
Changes CLI error handling to print plain stderr messages instead of JSON objects for command execution failures and shared error helpers. This makes errors behave like a conventional command-line tool while preserving non-zero exits.

## Test Plan

- [x] `go test ./internal/cmd ./internal/output`