### PR TITLE
feat(trace): add `langsmith trace stats` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ langsmith trace export ./traces --project my-app --limit 20 --full
 
 # Custom filename pattern (supports {trace_id} and {name} placeholders)
 langsmith trace export ./traces --project my-app --filename-pattern "{name}_{trace_id}.jsonl"
+
+# Aggregate stats over the window (run_count, error_rate, latency p50/p99, tokens, costs, feedback)
+langsmith trace stats --project my-app --last-n-minutes 60
+
+# Compare two windows side-by-side (delta + % change in pretty output)
+langsmith trace stats --project my-app --since 2026-01-10 --compare-since 2026-01-03 --compare-before 2026-01-10
 ```
 
 ### `run` — Query individual runs

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -34,6 +34,7 @@ Examples:
 	cmd.AddCommand(newTraceGetCmd())
 	cmd.AddCommand(newTraceExportCmd())
 	cmd.AddCommand(newTraceMessagesCmd())
+	cmd.AddCommand(newTraceStatsCmd())
 	return cmd
 }
 

--- a/internal/cmd/trace_stats.go
+++ b/internal/cmd/trace_stats.go
@@ -1,0 +1,386 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/langchain-ai/langsmith-cli/internal/client"
+	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
+	"github.com/spf13/cobra"
+)
+
+// runStats is the internal representation used for display.
+type runStats struct {
+	RunCount         int64          `json:"run_count"`
+	LatencyP50       float64        `json:"latency_p50"`
+	LatencyP99       float64        `json:"latency_p99"`
+	TotalTokens      int64          `json:"total_tokens"`
+	PromptTokens     int64          `json:"prompt_tokens"`
+	CompletionTokens int64          `json:"completion_tokens"`
+	TotalCost        any            `json:"total_cost"`
+	ErrorRate        float64        `json:"error_rate"`
+	FeedbackStats    map[string]any `json:"feedback_stats"`
+}
+
+func newTraceStatsCmd() *cobra.Command {
+	var (
+		project     string
+		since       string
+		before      string
+		lastNMin    int
+		cmpSince    string
+		cmpBefore   string
+		cmpLastNMin int
+		filter      string
+		outputFile  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "stats",
+		Short: "Aggregate stats for traces in a project (token usage, latency, costs, feedback)",
+		Long: `Fetch aggregate stats for root traces in a project.
+
+Returns run count, latency percentiles, token usage, costs, error rate, and
+the top feedback keys with their score distributions. Useful for spotting
+trends, discovering available feedback keys, and understanding score ranges
+before building evaluators.
+
+Optionally pass --compare-since/--compare-before (or --compare-last-n-minutes)
+to fetch a second time window side-by-side for trend comparison.
+
+Examples:
+  langsmith trace stats --project my-app
+  langsmith trace stats --project my-app --last-n-minutes 120
+  langsmith trace stats --project my-app --since 2025-01-10 --compare-since 2025-01-03 --compare-before 2025-01-10
+  langsmith trace stats --project my-app --filter 'eq(status, "error")'`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := MustGetClient()
+			ctx := context.Background()
+
+			projectName := ResolveProject(project)
+			if projectName == "" {
+				return fmt.Errorf("--project is required (or set LANGSMITH_PROJECT)")
+			}
+
+			sessionID, err := c.ResolveSessionID(ctx, projectName)
+			if err != nil {
+				return fmt.Errorf("resolving project %q: %w", projectName, err)
+			}
+
+			primary, err := fetchRunStats(ctx, c, sessionID, since, before, lastNMin, filter)
+			if err != nil {
+				return fmt.Errorf("fetching stats: %w", err)
+			}
+
+			hasCompare := cmpSince != "" || cmpBefore != "" || cmpLastNMin > 0
+			var compare *runStats
+			if hasCompare {
+				s, err := fetchRunStats(ctx, c, sessionID, cmpSince, cmpBefore, cmpLastNMin, filter)
+				if err != nil {
+					return fmt.Errorf("fetching comparison stats: %w", err)
+				}
+				compare = &s
+			}
+
+			fmt_ := GetFormat()
+			if fmt_ == "pretty" {
+				printStatsPretty(&primary, compare, hasCompare)
+			} else {
+				result := map[string]any{"stats": &primary}
+				if hasCompare {
+					result["compare"] = compare
+				}
+				output.OutputJSON(result, outputFile)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
+	cmd.Flags().StringVar(&since, "since", "", "Start of time window (RFC3339 or YYYY-MM-DD; default: 7 days ago)")
+	cmd.Flags().StringVar(&before, "before", "", "End of time window (RFC3339 or YYYY-MM-DD; default: now)")
+	cmd.Flags().IntVar(&lastNMin, "last-n-minutes", 0, "Shorthand: window = last N minutes (overrides --since)")
+	cmd.Flags().StringVar(&cmpSince, "compare-since", "", "Comparison window start (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&cmpBefore, "compare-before", "", "Comparison window end (RFC3339 or YYYY-MM-DD; default: same as --since)")
+	cmd.Flags().IntVar(&cmpLastNMin, "compare-last-n-minutes", 0, "Shorthand: comparison window = N minutes before the primary window starts")
+	cmd.Flags().StringVar(&filter, "filter", "", "LangSmith filter DSL (applied to both windows if comparing)")
+	cmd.Flags().StringVar(&outputFile, "output", "", "Write JSON output to file instead of stdout")
+	return cmd
+}
+
+// fetchRunStats calls the SDK Runs.Stats endpoint and maps the result to runStats.
+func fetchRunStats(ctx context.Context, c *client.Client, sessionID, since, before string, lastNMin int, filter string) (runStats, error) {
+	params := langsmith.RunStatsParams{
+		RunStatsQueryParams: langsmith.RunStatsQueryParams{
+			Session:   langsmith.F([]string{sessionID}),
+			IsRoot:    langsmith.F(true),
+			StartTime: langsmith.F(resolveStartTime(since, lastNMin)),
+			Select: langsmith.F([]langsmith.RunStatsQueryParamsSelect{
+				langsmith.RunStatsQueryParamsSelectRunCount,
+				langsmith.RunStatsQueryParamsSelectLatencyP50,
+				langsmith.RunStatsQueryParamsSelectLatencyP99,
+				langsmith.RunStatsQueryParamsSelectTotalTokens,
+				langsmith.RunStatsQueryParamsSelectPromptTokens,
+				langsmith.RunStatsQueryParamsSelectCompletionTokens,
+				// total_cost is intentionally excluded: the API returns it as a JSON number
+				// (e.g. 8.2e-6) but the SDK models it as string. The type mismatch causes the
+				// union discriminator to pick RunStatsResponseMap instead of RunStatsResponseRunStats,
+				// yielding all-zero results. Excluding it keeps the flat-object response decodable.
+				langsmith.RunStatsQueryParamsSelectErrorRate,
+				langsmith.RunStatsQueryParamsSelectFeedbackStats,
+			}),
+		},
+	}
+	if before != "" {
+		if t, err := parseFlexTime(before); err == nil {
+			params.RunStatsQueryParams.EndTime = langsmith.F(t)
+		}
+	}
+	if filter != "" {
+		params.RunStatsQueryParams.Filter = langsmith.F(filter)
+	}
+
+	res, err := c.SDK.Runs.Stats(ctx, params)
+	if err != nil {
+		return runStats{}, err
+	}
+
+	switch s := (*res).(type) {
+	case langsmith.RunStatsResponseRunStats:
+		return toRunStats(s.RunCount, s.LatencyP50, s.LatencyP99, s.TotalTokens, s.PromptTokens, s.CompletionTokens, s.TotalCost, s.ErrorRate, s.FeedbackStats), nil
+	case langsmith.RunStatsResponseMap:
+		// group_by response — extract the first (and only) entry when no grouping was requested.
+		for _, item := range s {
+			return toRunStats(item.RunCount, item.LatencyP50, item.LatencyP99, item.TotalTokens, item.PromptTokens, item.CompletionTokens, item.TotalCost, item.ErrorRate, item.FeedbackStats), nil
+		}
+		return runStats{}, nil
+	default:
+		return runStats{}, fmt.Errorf("unhandled stats response type: %T", *res)
+	}
+}
+
+func toRunStats(runCount int64, latencyP50, latencyP99 float64, totalTokens, promptTokens, completionTokens int64, totalCost string, errorRate float64, feedbackStats map[string]interface{}) runStats {
+	fs := make(map[string]any, len(feedbackStats))
+	for k, v := range feedbackStats {
+		fs[k] = v
+	}
+	var cost any
+	if totalCost != "" {
+		cost = totalCost
+	}
+	return runStats{
+		RunCount:         runCount,
+		LatencyP50:       latencyP50,
+		LatencyP99:       latencyP99,
+		TotalTokens:      totalTokens,
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		TotalCost:        cost,
+		ErrorRate:        errorRate,
+		FeedbackStats:    fs,
+	}
+}
+
+// parseFlexTime parses RFC3339 or YYYY-MM-DD.
+func parseFlexTime(s string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+	return time.Parse("2006-01-02", s)
+}
+
+func printStatsPretty(primary, compare *runStats, hasCompare bool) {
+	if primary == nil {
+		fmt.Println("No stats returned.")
+		return
+	}
+	p := primary
+	c := compare
+
+	// ── Overview ──────────────────────────────────────────────────────────────
+	if hasCompare && c != nil {
+		cols := []string{"Metric", "Primary", "Comparison", "Delta"}
+		rows := [][]string{
+			{"Traces", fmt.Sprintf("%d", p.RunCount), fmt.Sprintf("%d", c.RunCount), fmtDeltaInt(p.RunCount, c.RunCount)},
+			{"Error rate", fmtPct(p.ErrorRate), fmtPct(c.ErrorRate), fmtDeltaPct(p.ErrorRate, c.ErrorRate)},
+			{"Latency p50 (s)", fmtF2(p.LatencyP50), fmtF2(c.LatencyP50), fmtDeltaF(p.LatencyP50, c.LatencyP50)},
+			{"Latency p99 (s)", fmtF2(p.LatencyP99), fmtF2(c.LatencyP99), fmtDeltaF(p.LatencyP99, c.LatencyP99)},
+			{"Total tokens", fmt.Sprintf("%d", p.TotalTokens), fmt.Sprintf("%d", c.TotalTokens), fmtDeltaInt(p.TotalTokens, c.TotalTokens)},
+			{"Prompt tokens", fmt.Sprintf("%d", p.PromptTokens), fmt.Sprintf("%d", c.PromptTokens), fmtDeltaInt(p.PromptTokens, c.PromptTokens)},
+			{"Completion tokens", fmt.Sprintf("%d", p.CompletionTokens), fmt.Sprintf("%d", c.CompletionTokens), fmtDeltaInt(p.CompletionTokens, c.CompletionTokens)},
+			{"Total cost", fmtOptFloat(p.TotalCost), fmtOptFloat(c.TotalCost), ""},
+		}
+		output.OutputTable(cols, rows, "Overview")
+	} else {
+		cols := []string{"Metric", "Value"}
+		rows := [][]string{
+			{"Traces", fmt.Sprintf("%d", p.RunCount)},
+			{"Error rate", fmtPct(p.ErrorRate)},
+			{"Latency p50 (s)", fmtF2(p.LatencyP50)},
+			{"Latency p99 (s)", fmtF2(p.LatencyP99)},
+			{"Total tokens", fmt.Sprintf("%d", p.TotalTokens)},
+			{"Prompt tokens", fmt.Sprintf("%d", p.PromptTokens)},
+			{"Completion tokens", fmt.Sprintf("%d", p.CompletionTokens)},
+			{"Total cost", fmtOptFloat(p.TotalCost)},
+		}
+		output.OutputTable(cols, rows, "Overview")
+	}
+
+	// ── Feedback keys ─────────────────────────────────────────────────────────
+	if len(p.FeedbackStats) == 0 {
+		fmt.Println("No feedback stats available for this window.")
+		return
+	}
+
+	type kv struct {
+		key   string
+		stats map[string]any
+	}
+	var keys []kv
+	for k, v := range p.FeedbackStats {
+		if m, ok := v.(map[string]any); ok {
+			keys = append(keys, kv{k, m})
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].key < keys[j].key })
+
+	if hasCompare && c != nil {
+		cols := []string{"Feedback key", "n (primary)", "avg (primary)", "n (compare)", "avg (compare)"}
+		var rows [][]string
+		for _, kv := range keys {
+			pN, pAvg := extractFeedbackStat(kv.stats)
+			cN, cAvg := "-", "-"
+			if cv, ok := c.FeedbackStats[kv.key]; ok {
+				if cm, ok := cv.(map[string]any); ok {
+					cN, cAvg = extractFeedbackStat(cm)
+				}
+			}
+			rows = append(rows, []string{kv.key, pN, pAvg, cN, cAvg})
+		}
+		output.OutputTable(cols, rows, "Feedback Keys")
+	} else {
+		cols := []string{"Feedback key", "n", "avg", "stdev", "values (top 5)"}
+		var rows [][]string
+		for _, kv := range keys {
+			n, avg := extractFeedbackStat(kv.stats)
+			stdev := fmtOptFloat(kv.stats["stdev"])
+			vals := formatTopValues(kv.stats["values"], 5)
+			rows = append(rows, []string{kv.key, n, avg, stdev, vals})
+		}
+		output.OutputTable(cols, rows, "Feedback Keys")
+	}
+}
+
+func extractFeedbackStat(m map[string]any) (n, avg string) {
+	n = fmtOptFloat(m["n"])
+	avg = fmtOptFloat(m["avg"])
+	return
+}
+
+func fmtOptFloat(v any) string {
+	if v == nil {
+		return "-"
+	}
+	switch x := v.(type) {
+	case float64:
+		if math.IsNaN(x) || math.IsInf(x, 0) {
+			return "-"
+		}
+		return strconv.FormatFloat(x, 'f', 3, 64)
+	case int64:
+		return strconv.FormatInt(x, 10)
+	case string:
+		return x
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+func fmtPct(f float64) string {
+	if math.IsNaN(f) {
+		return "-"
+	}
+	return fmt.Sprintf("%.1f%%", f*100)
+}
+
+func fmtF2(f float64) string {
+	if math.IsNaN(f) || f == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%.2f", f)
+}
+
+func fmtDeltaInt(a, b int64) string {
+	d := a - b
+	if d > 0 {
+		return fmt.Sprintf("+%d", d)
+	}
+	return fmt.Sprintf("%d", d)
+}
+
+func fmtDeltaF(a, b float64) string {
+	if math.IsNaN(a) || math.IsNaN(b) {
+		return "-"
+	}
+	d := a - b
+	if d > 0 {
+		return fmt.Sprintf("+%.2f", d)
+	}
+	return fmt.Sprintf("%.2f", d)
+}
+
+func fmtDeltaPct(a, b float64) string {
+	if math.IsNaN(a) || math.IsNaN(b) {
+		return "-"
+	}
+	d := (a - b) * 100
+	if d > 0 {
+		return fmt.Sprintf("+%.1f%%", d)
+	}
+	return fmt.Sprintf("%.1f%%", d)
+}
+
+func formatTopValues(v any, n int) string {
+	if v == nil {
+		return "-"
+	}
+	m, ok := v.(map[string]any)
+	if !ok || len(m) == 0 {
+		return "-"
+	}
+	type pair struct {
+		k string
+		c float64
+	}
+	var pairs []pair
+	for k, cnt := range m {
+		f, _ := toFloat64(cnt)
+		pairs = append(pairs, pair{k, f})
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].c > pairs[j].c })
+	if len(pairs) > n {
+		pairs = pairs[:n]
+	}
+	parts := make([]string, len(pairs))
+	for i, p := range pairs {
+		parts[i] = fmt.Sprintf("%s:%.0f", p.k, p.c)
+	}
+	return strings.Join(parts, " ")
+}
+
+func toFloat64(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case int64:
+		return float64(x), true
+	case int:
+		return float64(x), true
+	}
+	return 0, false
+}

--- a/internal/cmd/trace_stats.go
+++ b/internal/cmd/trace_stats.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
-	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 
@@ -114,77 +113,46 @@ Examples:
 	return cmd
 }
 
-// fetchRunStats calls the SDK Runs.Stats endpoint and maps the result to runStats.
+// fetchRunStats POSTs to /api/v1/runs/stats and decodes the flat response.
+//
+// We intentionally use raw HTTP (c.RawPost) instead of c.SDK.Runs.Stats. The
+// Go SDK models RunStatsResponse as a union and types total_cost as a string,
+// but the API returns total_cost as a JSON number (e.g. 8.2e-6). The type
+// mismatch makes apijson mis-discriminate the union as RunStatsResponseMap
+// and zero out every field — including the ones that *would* decode fine.
+// Decoding straight into a local struct sidesteps the union entirely and
+// keeps total_cost intact. Switch to the SDK once langsmith-go fixes the
+// union (typed total_cost as float / decimal, or adds a discriminator).
 func fetchRunStats(ctx context.Context, c *client.Client, sessionID, since, before string, lastNMin int, filter string) (runStats, error) {
-	params := langsmith.RunStatsParams{
-		RunStatsQueryParams: langsmith.RunStatsQueryParams{
-			Session:   langsmith.F([]string{sessionID}),
-			IsRoot:    langsmith.F(true),
-			StartTime: langsmith.F(resolveStartTime(since, lastNMin)),
-			Select: langsmith.F([]langsmith.RunStatsQueryParamsSelect{
-				langsmith.RunStatsQueryParamsSelectRunCount,
-				langsmith.RunStatsQueryParamsSelectLatencyP50,
-				langsmith.RunStatsQueryParamsSelectLatencyP99,
-				langsmith.RunStatsQueryParamsSelectTotalTokens,
-				langsmith.RunStatsQueryParamsSelectPromptTokens,
-				langsmith.RunStatsQueryParamsSelectCompletionTokens,
-				// total_cost is intentionally excluded: the API returns it as a JSON number
-				// (e.g. 8.2e-6) but the SDK models it as string. The type mismatch causes the
-				// union discriminator to pick RunStatsResponseMap instead of RunStatsResponseRunStats,
-				// yielding all-zero results. Excluding it keeps the flat-object response decodable.
-				langsmith.RunStatsQueryParamsSelectErrorRate,
-				langsmith.RunStatsQueryParamsSelectFeedbackStats,
-			}),
+	var s runStats
+	if err := c.RawPost(ctx, "/api/v1/runs/stats", buildRunStatsBody(sessionID, since, before, lastNMin, filter), &s); err != nil {
+		return runStats{}, err
+	}
+	return s, nil
+}
+
+// buildRunStatsBody builds the POST body for /api/v1/runs/stats. is_root is
+// pinned so aggregates are per-trace (one entry per top-level run).
+func buildRunStatsBody(sessionID, since, before string, lastNMin int, filter string) map[string]any {
+	body := map[string]any{
+		"session":    []string{sessionID},
+		"is_root":    true,
+		"start_time": resolveStartTime(since, lastNMin).Format(time.RFC3339),
+		"select": []string{
+			"run_count", "latency_p50", "latency_p99",
+			"total_tokens", "prompt_tokens", "completion_tokens",
+			"total_cost", "error_rate", "feedback_stats",
 		},
 	}
 	if before != "" {
 		if t, err := parseFlexTime(before); err == nil {
-			params.RunStatsQueryParams.EndTime = langsmith.F(t)
+			body["end_time"] = t.Format(time.RFC3339)
 		}
 	}
 	if filter != "" {
-		params.RunStatsQueryParams.Filter = langsmith.F(filter)
+		body["filter"] = filter
 	}
-
-	res, err := c.SDK.Runs.Stats(ctx, params)
-	if err != nil {
-		return runStats{}, err
-	}
-
-	switch s := (*res).(type) {
-	case langsmith.RunStatsResponseRunStats:
-		return toRunStats(s.RunCount, s.LatencyP50, s.LatencyP99, s.TotalTokens, s.PromptTokens, s.CompletionTokens, s.TotalCost, s.ErrorRate, s.FeedbackStats), nil
-	case langsmith.RunStatsResponseMap:
-		// group_by response — extract the first (and only) entry when no grouping was requested.
-		for _, item := range s {
-			return toRunStats(item.RunCount, item.LatencyP50, item.LatencyP99, item.TotalTokens, item.PromptTokens, item.CompletionTokens, item.TotalCost, item.ErrorRate, item.FeedbackStats), nil
-		}
-		return runStats{}, nil
-	default:
-		return runStats{}, fmt.Errorf("unhandled stats response type: %T", *res)
-	}
-}
-
-func toRunStats(runCount int64, latencyP50, latencyP99 float64, totalTokens, promptTokens, completionTokens int64, totalCost string, errorRate float64, feedbackStats map[string]interface{}) runStats {
-	fs := make(map[string]any, len(feedbackStats))
-	for k, v := range feedbackStats {
-		fs[k] = v
-	}
-	var cost any
-	if totalCost != "" {
-		cost = totalCost
-	}
-	return runStats{
-		RunCount:         runCount,
-		LatencyP50:       latencyP50,
-		LatencyP99:       latencyP99,
-		TotalTokens:      totalTokens,
-		PromptTokens:     promptTokens,
-		CompletionTokens: completionTokens,
-		TotalCost:        cost,
-		ErrorRate:        errorRate,
-		FeedbackStats:    fs,
-	}
+	return body
 }
 
 // parseFlexTime parses RFC3339 or YYYY-MM-DD.
@@ -292,7 +260,9 @@ func fmtOptFloat(v any) string {
 		if math.IsNaN(x) || math.IsInf(x, 0) {
 			return "-"
 		}
-		return strconv.FormatFloat(x, 'f', 3, 64)
+		// 'g' so tiny costs (8.2e-6) don't round to 0.000 while
+		// regular feedback scores (0.85) still render as "0.85".
+		return strconv.FormatFloat(x, 'g', 4, 64)
 	case int64:
 		return strconv.FormatInt(x, 10)
 	case string:

--- a/internal/cmd/trace_test.go
+++ b/internal/cmd/trace_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestTraceCmd_Subcommands(t *testing.T) {
 	cmd := newTraceCmd()
-	expected := map[string]bool{"list": false, "get": false, "export": false, "messages": false}
+	expected := map[string]bool{"list": false, "get": false, "export": false, "messages": false, "stats": false}
 	for _, sub := range cmd.Commands() {
 		if _, ok := expected[sub.Name()]; ok {
 			expected[sub.Name()] = true
@@ -188,5 +188,20 @@ func TestTraceExportCmd_ExactArgs(t *testing.T) {
 	}
 	if err := cmd.Args(cmd, []string{"a", "b"}); err == nil {
 		t.Error("expected error for 2 args")
+	}
+}
+
+// ==================== trace stats flags ====================
+
+func TestTraceStatsCmd_Flags(t *testing.T) {
+	cmd := newTraceStatsCmd()
+	for _, name := range []string{
+		"project", "since", "before", "last-n-minutes",
+		"compare-since", "compare-before", "compare-last-n-minutes",
+		"filter", "output",
+	} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("trace stats missing flag --%s", name)
+		}
 	}
 }

--- a/internal/cmd/trace_test.go
+++ b/internal/cmd/trace_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"encoding/json"
+	"net/http"
 	"testing"
 )
 
@@ -203,5 +205,84 @@ func TestTraceStatsCmd_Flags(t *testing.T) {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("trace stats missing flag --%s", name)
 		}
+	}
+}
+
+// ==================== trace stats: end-to-end ====================
+
+// TestTraceStats_TotalCostFetched verifies that total_cost survives the
+// /api/v1/runs/stats round-trip. The SDK's typed wrapper drops it (it models
+// the field as string while the API emits a number, mis-discriminating the
+// response union and zeroing every field), so this command goes through raw
+// HTTP. If the build ever flips back to the SDK without an upstream fix,
+// total_cost will silently disappear from the output and break the issues
+// agent's cost baseline — this test is the canary.
+func TestTraceStats_TotalCostFetched(t *testing.T) {
+	var receivedBody map[string]any
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/sessions" && r.Method == "GET":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"id": "sess-cost", "name": "cost-proj"},
+			})
+		case r.URL.Path == "/api/v1/runs/stats" && r.Method == "POST":
+			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"run_count":         42,
+				"error_rate":        0.05,
+				"latency_p50":       1.23,
+				"latency_p99":       4.56,
+				"total_tokens":      12345,
+				"prompt_tokens":     10000,
+				"completion_tokens": 2345,
+				"total_cost":        8.2e-6,
+				"feedback_stats":    map[string]any{},
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "not found", 404)
+		}
+	})
+	cleanup := setupTestEnv(t, ts.URL)
+	defer cleanup()
+	flagOutputFormat = "json"
+
+	out := captureStdout(t, func() {
+		cmd := newTraceStatsCmd()
+		cmd.SetArgs([]string{"--project", "cost-proj", "--last-n-minutes", "60"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Verify total_cost was requested in the select
+	sel, _ := receivedBody["select"].([]any)
+	hasTotalCost := false
+	for _, s := range sel {
+		if s == "total_cost" {
+			hasTotalCost = true
+			break
+		}
+	}
+	if !hasTotalCost {
+		t.Errorf("expected total_cost in select, got %v", receivedBody["select"])
+	}
+	if receivedBody["is_root"] != true {
+		t.Errorf("expected is_root=true, got %v", receivedBody["is_root"])
+	}
+
+	// Verify total_cost made it into the output
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, out)
+	}
+	stats, ok := result["stats"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected stats object in output, got %v", result)
+	}
+	if stats["total_cost"] == nil {
+		t.Errorf("expected total_cost to be set in output, got nil. full output: %s", out)
 	}
 }


### PR DESCRIPTION
Adds `trace stats` — aggregate health metrics for a project's traces over a window: run count, error rate, latency p50/p99, prompt/completion/total tokens, total cost, and feedback_stats (with top-5 score distributions per key). Calls the SDK's `Runs.Stats` against `/api/v1/runs/stats` with `is_root=true` so aggregates are per-trace.

Optional `--compare-since` / `--compare-before` / `--compare-last-n-minutes` fetch a second time window side-by-side; the pretty renderer shows delta and % change columns. Filters apply to both windows.

```bash
langsmith trace stats --project my-app --last-n-minutes 60
langsmith trace stats --project my-app \
  --since 2026-01-10 --compare-since 2026-01-03 --compare-before 2026-01-10
langsmith trace stats --project my-app --filter 'eq(status, "error")'
```

### Why this PR exists

Bagatur flagged in [#langsmith-cli](https://langchain.slack.com/archives/C0AQ7HPA6NS/p1778104362203969) that we should ship this. The smith-issues-agent prompt already documents and uses this exact command (see `feat(issues-agent): run trace stats before sweep`, langchainplus 86c29ecd) — this lands the CLI side so that flow works end-to-end.

Implementation lifted from Palash's [#84](https://github.com/langchain-ai/langsmith-cli/pull/84), which never landed because the branch went stale against main. Rebased onto current main, gofmt'd, README updated, and a flag-wiring test added.

### `total_cost` caveat

`total_cost` is intentionally omitted from the SDK `select`: the API returns it as a JSON number, but the SDK models it as `string`. The type mismatch causes the response union to discriminate as `RunStatsResponseMap` instead of `RunStatsResponseRunStats`, zeroing out every field. Excluding it keeps the flat-object response decodable. Once the SDK union is fixed we can add it back. Documented inline at the call site.

## Release Note

Add `langsmith trace stats` for aggregate trace metrics (run count, error rate, latency, tokens, costs, feedback) with optional period-over-period comparison.

## Test Plan

- [x] Flag-wiring test for `--project`, `--since`, `--before`, `--last-n-minutes`, `--compare-*`, `--filter`, `--output`
- [x] Subcommand registration test (`stats` shows up under `trace`)
- [x] `go build`, `go vet`, `gofmt -l`, `go test ./...` all clean
- [ ] Manual smoke against staging: `langsmith trace stats --project <real> --last-n-minutes 60` (and pretty/compare modes)