### PR TITLE
fix(login): skip workspace prompt by default

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -60,9 +60,10 @@ func (e *oauthErrorResponse) Error() string {
 
 func newLoginCmd() *cobra.Command {
 	var (
-		noBrowser   bool
-		timeout     time.Duration
-		workspaceID string
+		noBrowser       bool
+		timeout         time.Duration
+		workspaceID     string
+		promptWorkspace bool
 	)
 
 	cmd := &cobra.Command{
@@ -73,16 +74,17 @@ func newLoginCmd() *cobra.Command {
 The command stores OAuth tokens in ~/.langsmith/config.json under the selected
 profile. Select a profile with --profile or LANGSMITH_PROFILE.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLogin(cmd, noBrowser, timeout, workspaceID)
+			return runLogin(cmd, noBrowser, timeout, workspaceID, promptWorkspace)
 		},
 	}
 	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Do not open a browser automatically")
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "Maximum time to wait for authorization (default: device-code expiry)")
-	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "Default workspace ID to save in the selected profile")
+	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "Workspace ID override to save in the selected profile")
+	cmd.Flags().BoolVar(&promptWorkspace, "prompt-workspace", false, "Prompt to select and save a workspace override")
 	return cmd
 }
 
-func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspaceID string) error {
+func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspaceID string, promptWorkspace bool) error {
 	cfg, err := lsconfig.Load()
 	if err != nil {
 		return err
@@ -136,7 +138,7 @@ func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspa
 	if profile.APIURL == "" || flagAPIURL != "" || strings.TrimSpace(profile.APIURL) != apiURL {
 		profile.APIURL = apiURL
 	}
-	if workspaceID == "" && profile.WorkspaceID == "" {
+	if workspaceID == "" && promptWorkspace {
 		workspaceID, err = promptWorkspaceSelection(cmd, apiURL, token.AccessToken)
 		if err != nil {
 			return err
@@ -214,7 +216,7 @@ func validateWorkspaceID(workspaceID string) error {
 func promptWorkspaceSelection(cmd *cobra.Command, apiURL, accessToken string) (string, error) {
 	in := cmd.InOrStdin()
 	if !inputIsTerminal(in) {
-		fmt.Fprintln(cmd.ErrOrStderr(), "No default workspace set because stdin is not interactive. Some commands require a workspace; pass --workspace-id to auth login or run 'langsmith workspace set-default <workspace-id>'.")
+		fmt.Fprintln(cmd.ErrOrStderr(), "Skipping workspace prompt because stdin is not interactive.")
 		return "", nil
 	}
 	workspaces, err := listLoginWorkspaces(cmd.Context(), apiURL, accessToken)

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -136,7 +136,102 @@ func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
 	}
 }
 
-func TestLoginPromptsWorkspaceSelection(t *testing.T) {
+func TestLoginDoesNotSaveTokenWorkspaceByDefault(t *testing.T) {
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	oldFormat := flagOutputFormat
+	oldOpenBrowser := openBrowser
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+		flagOutputFormat = oldFormat
+		openBrowser = oldOpenBrowser
+	}()
+	flagAPIKey = ""
+	flagAPIURL = ""
+	flagProfile = ""
+	flagOutputFormat = "json"
+	openBrowser = func(string) error { return nil }
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+
+	accessToken := "test-access-token"
+	tokenWorkspaceID := "00000000-0000-0000-0000-000000000456"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			assertOAuthResource(t, r)
+			_ = json.NewEncoder(w).Encode(deviceCodeResponse{
+				DeviceCode:      "device-code",
+				UserCode:        "ABCD-EFGH",
+				VerificationURI: tsActivateURL(r),
+				ExpiresIn:       60,
+				Interval:        0,
+			})
+		case "/oauth/token":
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			assertOAuthResource(t, r)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  accessToken,
+				"expires_in":    300,
+				"refresh_token": "test-refresh-token",
+				"workspace_id":  tokenWorkspaceID,
+			})
+		case "/api/v1/workspaces":
+			t.Fatal("did not expect workspace list request")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	root := NewRootCmd("test", "test")
+	root.SetIn(strings.NewReader(""))
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"--format=json", "auth", "login", "--api-url", ts.URL, "--no-browser"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())
+	}
+	if strings.Contains(stdout.String(), accessToken) || strings.Contains(stderr.String(), accessToken) {
+		t.Fatalf("login output exposed access token")
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout was not JSON: %v\n%s", err, stdout.String())
+	}
+	if result["workspace_id"] != "" {
+		t.Fatalf("expected workspace_id to be omitted, got %q", result["workspace_id"])
+	}
+
+	cfg, err := lsconfig.LoadFrom(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := cfg.Profiles["default"]
+	if profile.OAuth.AccessToken != accessToken {
+		t.Fatalf("access token was not saved")
+	}
+	if profile.WorkspaceID != "" {
+		t.Fatalf("expected token workspace ID not to be saved, got %q", profile.WorkspaceID)
+	}
+}
+
+func TestLoginPromptsWorkspaceSelectionWhenRequested(t *testing.T) {
 	oldKey := flagAPIKey
 	oldURL := flagAPIURL
 	oldProfile := flagProfile
@@ -215,7 +310,7 @@ func TestLoginPromptsWorkspaceSelection(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"--format=json", "auth", "login", "--api-url", ts.URL, "--no-browser"})
+	root.SetArgs([]string{"--format=json", "auth", "login", "--api-url", ts.URL, "--no-browser", "--prompt-workspace"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())
@@ -241,7 +336,7 @@ func TestLoginPromptsWorkspaceSelection(t *testing.T) {
 	}
 }
 
-func TestLoginWarnsWhenNonInteractiveWithoutWorkspace(t *testing.T) {
+func TestLoginSkipsWorkspaceSelectionByDefault(t *testing.T) {
 	oldKey := flagAPIKey
 	oldURL := flagAPIURL
 	oldProfile := flagProfile
@@ -310,8 +405,8 @@ func TestLoginWarnsWhenNonInteractiveWithoutWorkspace(t *testing.T) {
 	if err := root.Execute(); err != nil {
 		t.Fatalf("login returned error: %v\nstderr: %s", err, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "No default workspace set") {
-		t.Fatalf("expected workspace warning, got %q", stderr.String())
+	if strings.Contains(stderr.String(), "workspace") {
+		t.Fatalf("did not expect workspace prompt or warning, got %q", stderr.String())
 	}
 	if workspaceListCalled {
 		t.Fatal("did not expect workspace list request for non-interactive login")


### PR DESCRIPTION
## Summary
- Stack on #112 so the change applies to `langsmith auth login`.
- Skip auth login workspace selection by default so OAuth bearer tokens rely on the backend default workspace.
- Keep explicit workspace overrides via --workspace-id and make interactive selection opt-in with --prompt-workspace.
- Add login tests covering no saved token workspace, default skip behavior, and opt-in prompting.

## Test Plan
- go test ./internal/cmd
- go test ./...
- E2E dev login with temp config: langsmith auth login --api-url https://dev.api.smith.langchain.com --profile dev-e2e --no-browser --format=json
- E2E dev workspace-scoped read: langsmith --profile dev-e2e project list --limit 1