### PR TITLE
feat: allow sandbox create without snapshot id

### DIFF
--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -39,7 +39,7 @@ var severityLabels = map[int]string{
 
 func newProjectIssuesCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "issues",
+		Use:   "issues",
 		Short: "Manage issues for a tracing project",
 		Long: `Manage Issues Board issues for a tracing project.
 
@@ -453,7 +453,7 @@ func truncate(s string, n int) string {
 
 func newProjectIssuesRunsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "runs",
+		Use:   "runs",
 		Short: "Manage linked runs for an issue",
 		Long: `Link and unlink runs to/from an issue.
 

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -37,7 +37,7 @@ func newTraceMessagesCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:    "messages",
+		Use:   "messages",
 		Short: "Get conversation messages for multiple traces (batch)",
 		Long: `Get conversation messages for multiple traces in a single request.
 

--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -61,10 +61,41 @@ var sandboxBoxDetailRender = structured.PropertyList{
 	},
 }
 
+func sandboxCreateParams(name string, in *sandboxCreateInput) (langsmith.SandboxBoxNewParams, error) {
+	memBytes, err := parseByteSize(in.Memory)
+	if err != nil {
+		return langsmith.SandboxBoxNewParams{}, fmt.Errorf("invalid --memory: %w", err)
+	}
+
+	params := langsmith.SandboxBoxNewParams{
+		Name:     langsmith.F(name),
+		Vcpus:    langsmith.F(int64(in.VCPUs)),
+		MemBytes: langsmith.F(memBytes),
+	}
+	if in.SnapshotID != "" {
+		params.SnapshotID = langsmith.F(in.SnapshotID)
+	}
+	if in.RootFS != "" {
+		rootfsBytes, err := parseByteSize(in.RootFS)
+		if err != nil {
+			return langsmith.SandboxBoxNewParams{}, fmt.Errorf("invalid --rootfs-capacity: %w", err)
+		}
+		params.FsCapacityBytes = langsmith.F(rootfsBytes)
+	}
+	if in.ProxyConfig != "" {
+		pc, err := loadJSONArg(in.ProxyConfig)
+		if err != nil {
+			return langsmith.SandboxBoxNewParams{}, fmt.Errorf("invalid --proxy-config: %w", err)
+		}
+		params.ProxyConfig = langsmith.Raw[langsmith.SandboxBoxNewParamsProxyConfig](pc)
+	}
+	return params, nil
+}
+
 var sandboxCreateCommand = structured.Command[*sandboxCreateInput]{
 	Use:   "create <name>",
-	Short: "Create a sandbox VM from a snapshot",
-	Long: `Create a sandbox VM from a snapshot.
+	Short: "Create a sandbox VM",
+	Long: `Create a sandbox VM.
 
 The --proxy-config flag accepts inline JSON or a file path prefixed with @.
 The proxy config controls which outbound HTTP requests the sandbox proxy
@@ -92,6 +123,7 @@ Header types: "plaintext" (literal value), "opaque" (encrypted, hidden in API
 responses), "workspace_secret" (resolved from workspace secrets via {KEY}).
 
 Examples:
+  langsmith sandbox create my-vm
   langsmith sandbox create my-vm --snapshot-id <id>
   langsmith sandbox create my-vm --snapshot-id <id> --vcpus 4 --memory 1gb
   langsmith sandbox create my-vm --snapshot-id <id> --rootfs-capacity 8gb
@@ -102,7 +134,7 @@ Examples:
 			VCPUs:  2,
 			Memory: "512mb",
 		}
-		cmd.Flags().StringVar(&in.SnapshotID, "snapshot-id", in.SnapshotID, "Snapshot ID to boot from (required)")
+		cmd.Flags().StringVar(&in.SnapshotID, "snapshot-id", in.SnapshotID, "Snapshot ID to boot from")
 		cmd.Flags().IntVar(&in.VCPUs, "vcpus", in.VCPUs, "Number of vCPUs")
 		cmd.Flags().StringVar(&in.Memory, "memory", in.Memory, "Memory with unit (e.g. 512mb, 1gb)")
 		cmd.Flags().StringVar(&in.RootFS, "rootfs-capacity", in.RootFS, "Root filesystem capacity with unit (e.g. 4gb, 8gb)")
@@ -111,39 +143,15 @@ Examples:
 	},
 	Action: func(ctx context.Context, cmd *cobra.Command, in *sandboxCreateInput, args []string) (any, error) {
 		name := args[0]
-		if in.SnapshotID == "" {
-			return nil, fmt.Errorf("--snapshot-id is required")
-		}
 
 		c, err := cmdutil.GetClient(cmd)
 		if err != nil {
 			return nil, err
 		}
 
-		memBytes, err := parseByteSize(in.Memory)
+		params, err := sandboxCreateParams(name, in)
 		if err != nil {
-			return nil, fmt.Errorf("invalid --memory: %w", err)
-		}
-
-		params := langsmith.SandboxBoxNewParams{
-			Name:       langsmith.F(name),
-			SnapshotID: langsmith.F(in.SnapshotID),
-			Vcpus:      langsmith.F(int64(in.VCPUs)),
-			MemBytes:   langsmith.F(memBytes),
-		}
-		if in.RootFS != "" {
-			rootfsBytes, err := parseByteSize(in.RootFS)
-			if err != nil {
-				return nil, fmt.Errorf("invalid --rootfs-capacity: %w", err)
-			}
-			params.FsCapacityBytes = langsmith.F(rootfsBytes)
-		}
-		if in.ProxyConfig != "" {
-			pc, err := loadJSONArg(in.ProxyConfig)
-			if err != nil {
-				return nil, fmt.Errorf("invalid --proxy-config: %w", err)
-			}
-			params.ProxyConfig = langsmith.Raw[langsmith.SandboxBoxNewParamsProxyConfig](pc)
+			return nil, err
 		}
 		resp, err := c.SDK.Sandboxes.Boxes.New(ctx, params)
 		if err != nil {

--- a/internal/cmd/sandbox_test.go
+++ b/internal/cmd/sandbox_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	langsmith "github.com/langchain-ai/langsmith-go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -260,6 +261,38 @@ func TestSandboxBoxDetailRenderSupportsSDKResponseTypes(t *testing.T) {
 			require.Contains(t, out.String(), tc.wantTTL)
 		})
 	}
+}
+
+func TestSandboxCreateParams_OmitsEmptySnapshotID(t *testing.T) {
+	params, err := sandboxCreateParams("my-vm", &sandboxCreateInput{
+		VCPUs:  2,
+		Memory: "512mb",
+	})
+	require.NoError(t, err)
+
+	raw, err := json.Marshal(params)
+	require.NoError(t, err)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(raw, &body))
+
+	assert.NotContains(t, body, "snapshot_id")
+	assert.Equal(t, "my-vm", body["name"])
+}
+
+func TestSandboxCreateParams_IncludesSnapshotIDWhenSet(t *testing.T) {
+	params, err := sandboxCreateParams("my-vm", &sandboxCreateInput{
+		SnapshotID: "snap-123",
+		VCPUs:      2,
+		Memory:     "512mb",
+	})
+	require.NoError(t, err)
+
+	raw, err := json.Marshal(params)
+	require.NoError(t, err)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(raw, &body))
+
+	assert.Equal(t, "snap-123", body["snapshot_id"])
 }
 
 func TestSandboxUpdateCmd_SizeFlags(t *testing.T) {


### PR DESCRIPTION
## Summary

- allow `langsmith sandbox create <name>` without a local `--snapshot-id` requirement
- omit `snapshot_id` from the SDK request when it is not provided
- update create help text and request-body coverage for both snapshot and no-snapshot paths

## Test Plan

- [x] go test ./internal/cmd -run 'TestSandboxCreate|TestSandboxCmd|TestParseByteSize'
- [x] deslop internal/cmd/sandbox_box.go internal/cmd/sandbox_test.go