### PR TITLE
fix: accept traces key in trace messages

### DIFF
--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -30,6 +30,18 @@ type traceTrajectory struct {
 	Steps         []trajectoryStep `json:"steps"`
 }
 
+func traceMessageItems(result map[string]any) []any {
+	traces, _ := result["items"].([]any)
+	if traces != nil {
+		return traces
+	}
+	traces, _ = result["traces"].([]any)
+	if traces != nil {
+		return traces
+	}
+	return []any{}
+}
+
 func newTraceMessagesCmd() *cobra.Command {
 	var (
 		ff         FilterFlags
@@ -127,10 +139,7 @@ Examples:
 					ExitErrorf("%v", err)
 				}
 
-				traces, _ := result["items"].([]any)
-				if traces == nil {
-					traces = []any{}
-				}
+				traces := traceMessageItems(result)
 
 				attachRootIO(ctx, c, sessionID, startTime, traces)
 				for _, t := range traces {
@@ -175,7 +184,7 @@ Examples:
 					ExitErrorf("%v", err)
 				}
 
-				traces, _ := result["items"].([]any)
+				traces := traceMessageItems(result)
 				allTraces = append(allTraces, traces...)
 				remaining -= len(traces)
 

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -606,6 +606,7 @@ func TestTraceMessages_FeedbackStats(t *testing.T) {
 	t.Setenv("LANGSMITH_API_KEY", "test-api-key")
 	cleanup := setupTestEnv(t, ts.URL)
 	defer cleanup()
+	flagOutputFormat = "json"
 
 	out := captureStdout(t, func() {
 		cmd := newTraceMessagesCmd()


### PR DESCRIPTION
## Summary

- accept either `items` or `traces` from `/v2/traces/messages`
- keep feedback_stats output intact for both traces with and without feedback
- set the feedback stats test to JSON mode before parsing output

## Test Plan

- [x] go test ./internal/cmd -run 'TestTraceMessages'
- [x] deslop internal/cmd/message.go internal/cmd/message_test.go