### PR TITLE
chore: add pre-commit formatting checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: local
+    hooks:
+      - id: gofmt
+        name: gofmt
+        entry: gofmt -w
+        language: system
+        files: \.go$
+      - id: golangci-lint
+        name: golangci-lint
+        entry: golangci-lint run
+        language: system
+        pass_filenames: false
+        files: \.go$

--- a/internal/cmd/trace_stats.go
+++ b/internal/cmd/trace_stats.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
## Summary

- add local prek hooks for gofmt and golangci-lint
- fix gofmt import ordering in `trace_stats.go` so lint catches/passes consistently

## Test Plan

- [x] prek run --all-files
- [x] deslop .pre-commit-config.yaml internal/cmd/trace_stats.go