### PR TITLE
refactor: convert auth and profile commands to structured framework

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -114,8 +114,7 @@ var authTokenCommand = structured.Command[struct{}]{
 
 		return profile.AccessToken(), nil
 	},
-	Render: structured.Template(`{{.}}
-`),
+	Render: structured.Template(`{{.}}`),
 }
 
 func resolveAuthInfo() (authInfoResult, error) {

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -91,90 +91,84 @@ profile. Select a profile with --profile or LANGSMITH_PROFILE.`,
 			return in
 		},
 		Action: func(ctx context.Context, cmd *cobra.Command, in *loginInput, args []string) (any, error) {
-			return runLogin(cmd, in.noBrowser, in.timeout, in.workspaceID, in.promptWorkspace)
+			cfg, err := lsconfig.Load()
+			if err != nil {
+				return loginResult{}, err
+			}
+			workspaceID := strings.TrimSpace(in.workspaceID)
+			if workspaceID != "" {
+				if err := validateWorkspaceID(workspaceID); err != nil {
+					return loginResult{}, err
+				}
+			}
+
+			profileName := loginProfileName(cfg)
+			if err := validateProfileName(profileName); err != nil {
+				return loginResult{}, err
+			}
+			apiURL := loginAPIURL(cfg, profileName)
+			if ctx == nil {
+				ctx = context.Background()
+			}
+
+			device, err := requestDeviceCode(ctx, apiURL)
+			if err != nil {
+				return loginResult{}, err
+			}
+
+			errOut := cmd.ErrOrStderr()
+			fmt.Fprintf(errOut, "Open this URL to authorize the LangSmith CLI:\n%s\n\nEnter code: %s\n\n", device.VerificationURI, device.UserCode)
+			if !in.noBrowser {
+				if err := openBrowser(device.VerificationURI); err != nil {
+					fmt.Fprintf(errOut, "Could not open a browser automatically: %v\n\n", err)
+				}
+			}
+			fmt.Fprintln(errOut, "Waiting for authorization...")
+
+			waitFor := in.timeout
+			if waitFor <= 0 {
+				waitFor = time.Duration(device.ExpiresIn+10) * time.Second
+			}
+			pollCtx, cancel := context.WithTimeout(ctx, waitFor)
+			defer cancel()
+
+			interval := normalizeDeviceCodePollInterval(time.Duration(device.Interval) * time.Second)
+			token, err := pollDeviceToken(pollCtx, apiURL, device.DeviceCode, interval)
+			if err != nil {
+				return loginResult{}, err
+			}
+
+			profile := cfg.Profiles[profileName]
+			if profile.APIURL == "" || flagAPIURL != "" || strings.TrimSpace(profile.APIURL) != apiURL {
+				profile.APIURL = apiURL
+			}
+			if workspaceID == "" && in.promptWorkspace {
+				workspaceID, err = promptWorkspaceSelection(cmd, apiURL, token.AccessToken)
+				if err != nil {
+					return loginResult{}, err
+				}
+			}
+			if workspaceID != "" {
+				profile.WorkspaceID = workspaceID
+			}
+			applyTokenResponse(&profile, token, time.Now())
+			cfg.Profiles[profileName] = profile
+			cfg.CurrentProfile = profileName
+			if err := cfg.Save(); err != nil {
+				return loginResult{}, err
+			}
+
+			return loginResult{
+				Status:         "logged_in",
+				Profile:        profileName,
+				APIURL:         apiURL,
+				WorkspaceID:    profile.WorkspaceID,
+				OAuthExpiresAt: profile.OAuth.ExpiresAt,
+			}, nil
 		},
 		Render: structured.Template(`Logged in to {{.APIURL}} as profile {{printf "%q" .Profile}}
 `),
 	}.Cobra()
-}
-
-func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspaceID string, promptWorkspace bool) (loginResult, error) {
-	cfg, err := lsconfig.Load()
-	if err != nil {
-		return loginResult{}, err
-	}
-	workspaceID = strings.TrimSpace(workspaceID)
-	if workspaceID != "" {
-		if err := validateWorkspaceID(workspaceID); err != nil {
-			return loginResult{}, err
-		}
-	}
-
-	profileName := loginProfileName(cfg)
-	if err := validateProfileName(profileName); err != nil {
-		return loginResult{}, err
-	}
-	apiURL := loginAPIURL(cfg, profileName)
-
-	ctx := cmd.Context()
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
-	device, err := requestDeviceCode(ctx, apiURL)
-	if err != nil {
-		return loginResult{}, err
-	}
-
-	errOut := cmd.ErrOrStderr()
-	fmt.Fprintf(errOut, "Open this URL to authorize the LangSmith CLI:\n%s\n\nEnter code: %s\n\n", device.VerificationURI, device.UserCode)
-	if !noBrowser {
-		if err := openBrowser(device.VerificationURI); err != nil {
-			fmt.Fprintf(errOut, "Could not open a browser automatically: %v\n\n", err)
-		}
-	}
-	fmt.Fprintln(errOut, "Waiting for authorization...")
-
-	waitFor := timeout
-	if waitFor <= 0 {
-		waitFor = time.Duration(device.ExpiresIn+10) * time.Second
-	}
-	pollCtx, cancel := context.WithTimeout(ctx, waitFor)
-	defer cancel()
-
-	interval := normalizeDeviceCodePollInterval(time.Duration(device.Interval) * time.Second)
-	token, err := pollDeviceToken(pollCtx, apiURL, device.DeviceCode, interval)
-	if err != nil {
-		return loginResult{}, err
-	}
-
-	profile := cfg.Profiles[profileName]
-	if profile.APIURL == "" || flagAPIURL != "" || strings.TrimSpace(profile.APIURL) != apiURL {
-		profile.APIURL = apiURL
-	}
-	if workspaceID == "" && promptWorkspace {
-		workspaceID, err = promptWorkspaceSelection(cmd, apiURL, token.AccessToken)
-		if err != nil {
-			return loginResult{}, err
-		}
-	}
-	if workspaceID != "" {
-		profile.WorkspaceID = workspaceID
-	}
-	applyTokenResponse(&profile, token, time.Now())
-	cfg.Profiles[profileName] = profile
-	cfg.CurrentProfile = profileName
-	if err := cfg.Save(); err != nil {
-		return loginResult{}, err
-	}
-
-	return loginResult{
-		Status:         "logged_in",
-		Profile:        profileName,
-		APIURL:         apiURL,
-		WorkspaceID:    profile.WorkspaceID,
-		OAuthExpiresAt: profile.OAuth.ExpiresAt,
-	}, nil
 }
 
 func loginProfileName(cfg *lsconfig.Config) string {

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -166,8 +166,7 @@ profile. Select a profile with --profile or LANGSMITH_PROFILE.`,
 				OAuthExpiresAt: profile.OAuth.ExpiresAt,
 			}, nil
 		},
-		Render: structured.Template(`Logged in to {{.APIURL}} as profile {{printf "%q" .Profile}}
-`),
+		Render: structured.Template(`Logged in to {{.APIURL}} as profile {{printf "%q" .Profile}}`),
 	}.Cobra()
 }
 

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -91,13 +91,15 @@ profile. Select a profile with --profile or LANGSMITH_PROFILE.`,
 			return in
 		},
 		Action: func(ctx context.Context, cmd *cobra.Command, in *loginInput, args []string) (any, error) {
-			return runLogin(ctx, cmd, in)
+			return runLogin(ctx, in, cmd.ErrOrStderr(), func(apiURL, accessToken string) (string, error) {
+				return promptWorkspaceSelection(cmd, apiURL, accessToken)
+			})
 		},
 		Render: structured.Template(`Logged in to {{.APIURL}} as profile {{printf "%q" .Profile}}`),
 	}.Cobra()
 }
 
-func runLogin(ctx context.Context, cmd *cobra.Command, in *loginInput) (loginResult, error) {
+func runLogin(ctx context.Context, in *loginInput, errOut io.Writer, promptWorkspace func(apiURL, accessToken string) (string, error)) (loginResult, error) {
 	cfg, err := lsconfig.Load()
 	if err != nil {
 		return loginResult{}, err
@@ -123,7 +125,6 @@ func runLogin(ctx context.Context, cmd *cobra.Command, in *loginInput) (loginRes
 		return loginResult{}, err
 	}
 
-	errOut := cmd.ErrOrStderr()
 	fmt.Fprintf(errOut, "Open this URL to authorize the LangSmith CLI:\n%s\n\nEnter code: %s\n\n", device.VerificationURI, device.UserCode)
 	if !in.noBrowser {
 		if err := openBrowser(device.VerificationURI); err != nil {
@@ -150,7 +151,7 @@ func runLogin(ctx context.Context, cmd *cobra.Command, in *loginInput) (loginRes
 		profile.APIURL = apiURL
 	}
 	if workspaceID == "" && in.promptWorkspace {
-		workspaceID, err = promptWorkspaceSelection(cmd, apiURL, token.AccessToken)
+		workspaceID, err = promptWorkspace(apiURL, token.AccessToken)
 		if err != nil {
 			return loginResult{}, err
 		}

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/langchain-ai/langsmith-cli/internal/client"
 	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
+	"github.com/langchain-ai/langsmith-cli/internal/structured"
 	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -51,6 +52,21 @@ type oauthErrorResponse struct {
 	ErrorDescription string `json:"error_description"`
 }
 
+type loginInput struct {
+	noBrowser       bool
+	timeout         time.Duration
+	workspaceID     string
+	promptWorkspace bool
+}
+
+type loginResult struct {
+	Status         string `json:"status"`
+	Profile        string `json:"profile"`
+	APIURL         string `json:"api_url"`
+	WorkspaceID    string `json:"workspace_id,omitempty"`
+	OAuthExpiresAt string `json:"oauth_expires_at"`
+}
+
 func (e *oauthErrorResponse) Error() string {
 	if e.ErrorDescription == "" {
 		return e.Code
@@ -59,46 +75,44 @@ func (e *oauthErrorResponse) Error() string {
 }
 
 func newLoginCmd() *cobra.Command {
-	var (
-		noBrowser       bool
-		timeout         time.Duration
-		workspaceID     string
-		promptWorkspace bool
-	)
-
-	cmd := &cobra.Command{
+	return structured.Command[*loginInput]{
 		Use:   "login",
 		Short: "Authenticate with LangSmith using OAuth",
 		Long: `Authenticate with LangSmith using OAuth.
 
 The command stores OAuth tokens in ~/.langsmith/config.json under the selected
 profile. Select a profile with --profile or LANGSMITH_PROFILE.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLogin(cmd, noBrowser, timeout, workspaceID, promptWorkspace)
+		Input: func(cmd *cobra.Command) *loginInput {
+			in := &loginInput{}
+			cmd.Flags().BoolVar(&in.noBrowser, "no-browser", false, "Do not open a browser automatically")
+			cmd.Flags().DurationVar(&in.timeout, "timeout", 0, "Maximum time to wait for authorization (default: device-code expiry)")
+			cmd.Flags().StringVar(&in.workspaceID, "workspace-id", "", "Workspace ID override to save in the selected profile")
+			cmd.Flags().BoolVar(&in.promptWorkspace, "prompt-workspace", false, "Prompt to select and save a workspace override")
+			return in
 		},
-	}
-	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Do not open a browser automatically")
-	cmd.Flags().DurationVar(&timeout, "timeout", 0, "Maximum time to wait for authorization (default: device-code expiry)")
-	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "Workspace ID override to save in the selected profile")
-	cmd.Flags().BoolVar(&promptWorkspace, "prompt-workspace", false, "Prompt to select and save a workspace override")
-	return cmd
+		Action: func(ctx context.Context, cmd *cobra.Command, in *loginInput, args []string) (any, error) {
+			return runLogin(cmd, in.noBrowser, in.timeout, in.workspaceID, in.promptWorkspace)
+		},
+		Render: structured.Template(`Logged in to {{.APIURL}} as profile {{printf "%q" .Profile}}
+`),
+	}.Cobra()
 }
 
-func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspaceID string, promptWorkspace bool) error {
+func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspaceID string, promptWorkspace bool) (loginResult, error) {
 	cfg, err := lsconfig.Load()
 	if err != nil {
-		return err
+		return loginResult{}, err
 	}
 	workspaceID = strings.TrimSpace(workspaceID)
 	if workspaceID != "" {
 		if err := validateWorkspaceID(workspaceID); err != nil {
-			return err
+			return loginResult{}, err
 		}
 	}
 
 	profileName := loginProfileName(cfg)
 	if err := validateProfileName(profileName); err != nil {
-		return err
+		return loginResult{}, err
 	}
 	apiURL := loginAPIURL(cfg, profileName)
 
@@ -109,7 +123,7 @@ func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspa
 
 	device, err := requestDeviceCode(ctx, apiURL)
 	if err != nil {
-		return err
+		return loginResult{}, err
 	}
 
 	errOut := cmd.ErrOrStderr()
@@ -131,7 +145,7 @@ func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspa
 	interval := normalizeDeviceCodePollInterval(time.Duration(device.Interval) * time.Second)
 	token, err := pollDeviceToken(pollCtx, apiURL, device.DeviceCode, interval)
 	if err != nil {
-		return err
+		return loginResult{}, err
 	}
 
 	profile := cfg.Profiles[profileName]
@@ -141,7 +155,7 @@ func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspa
 	if workspaceID == "" && promptWorkspace {
 		workspaceID, err = promptWorkspaceSelection(cmd, apiURL, token.AccessToken)
 		if err != nil {
-			return err
+			return loginResult{}, err
 		}
 	}
 	if workspaceID != "" {
@@ -151,25 +165,16 @@ func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspa
 	cfg.Profiles[profileName] = profile
 	cfg.CurrentProfile = profileName
 	if err := cfg.Save(); err != nil {
-		return err
+		return loginResult{}, err
 	}
 
-	result := map[string]string{
-		"status":           "logged_in",
-		"profile":          profileName,
-		"api_url":          apiURL,
-		"oauth_expires_at": profile.OAuth.ExpiresAt,
-	}
-	if profile.WorkspaceID != "" {
-		result["workspace_id"] = profile.WorkspaceID
-	}
-	if GetFormat() == "pretty" {
-		fmt.Fprintf(cmd.OutOrStdout(), "Logged in to %s as profile %q\n", apiURL, profileName)
-		return nil
-	}
-	enc := json.NewEncoder(cmd.OutOrStdout())
-	enc.SetIndent("", "  ")
-	return enc.Encode(result)
+	return loginResult{
+		Status:         "logged_in",
+		Profile:        profileName,
+		APIURL:         apiURL,
+		WorkspaceID:    profile.WorkspaceID,
+		OAuthExpiresAt: profile.OAuth.ExpiresAt,
+	}, nil
 }
 
 func loginProfileName(cfg *lsconfig.Config) string {

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -91,83 +91,87 @@ profile. Select a profile with --profile or LANGSMITH_PROFILE.`,
 			return in
 		},
 		Action: func(ctx context.Context, cmd *cobra.Command, in *loginInput, args []string) (any, error) {
-			cfg, err := lsconfig.Load()
-			if err != nil {
-				return loginResult{}, err
-			}
-			workspaceID := strings.TrimSpace(in.workspaceID)
-			if workspaceID != "" {
-				if err := validateWorkspaceID(workspaceID); err != nil {
-					return loginResult{}, err
-				}
-			}
-
-			profileName := loginProfileName(cfg)
-			if err := validateProfileName(profileName); err != nil {
-				return loginResult{}, err
-			}
-			apiURL := loginAPIURL(cfg, profileName)
-			if ctx == nil {
-				ctx = context.Background()
-			}
-
-			device, err := requestDeviceCode(ctx, apiURL)
-			if err != nil {
-				return loginResult{}, err
-			}
-
-			errOut := cmd.ErrOrStderr()
-			fmt.Fprintf(errOut, "Open this URL to authorize the LangSmith CLI:\n%s\n\nEnter code: %s\n\n", device.VerificationURI, device.UserCode)
-			if !in.noBrowser {
-				if err := openBrowser(device.VerificationURI); err != nil {
-					fmt.Fprintf(errOut, "Could not open a browser automatically: %v\n\n", err)
-				}
-			}
-			fmt.Fprintln(errOut, "Waiting for authorization...")
-
-			waitFor := in.timeout
-			if waitFor <= 0 {
-				waitFor = time.Duration(device.ExpiresIn+10) * time.Second
-			}
-			pollCtx, cancel := context.WithTimeout(ctx, waitFor)
-			defer cancel()
-
-			interval := normalizeDeviceCodePollInterval(time.Duration(device.Interval) * time.Second)
-			token, err := pollDeviceToken(pollCtx, apiURL, device.DeviceCode, interval)
-			if err != nil {
-				return loginResult{}, err
-			}
-
-			profile := cfg.Profiles[profileName]
-			if profile.APIURL == "" || flagAPIURL != "" || strings.TrimSpace(profile.APIURL) != apiURL {
-				profile.APIURL = apiURL
-			}
-			if workspaceID == "" && in.promptWorkspace {
-				workspaceID, err = promptWorkspaceSelection(cmd, apiURL, token.AccessToken)
-				if err != nil {
-					return loginResult{}, err
-				}
-			}
-			if workspaceID != "" {
-				profile.WorkspaceID = workspaceID
-			}
-			applyTokenResponse(&profile, token, time.Now())
-			cfg.Profiles[profileName] = profile
-			cfg.CurrentProfile = profileName
-			if err := cfg.Save(); err != nil {
-				return loginResult{}, err
-			}
-
-			return loginResult{
-				Status:         "logged_in",
-				Profile:        profileName,
-				APIURL:         apiURL,
-				WorkspaceID:    profile.WorkspaceID,
-				OAuthExpiresAt: profile.OAuth.ExpiresAt,
-			}, nil
+			return runLogin(ctx, cmd, in)
 		},
 		Render: structured.Template(`Logged in to {{.APIURL}} as profile {{printf "%q" .Profile}}`),
 	}.Cobra()
+}
+
+func runLogin(ctx context.Context, cmd *cobra.Command, in *loginInput) (loginResult, error) {
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return loginResult{}, err
+	}
+	workspaceID := strings.TrimSpace(in.workspaceID)
+	if workspaceID != "" {
+		if err := validateWorkspaceID(workspaceID); err != nil {
+			return loginResult{}, err
+		}
+	}
+
+	profileName := loginProfileName(cfg)
+	if err := validateProfileName(profileName); err != nil {
+		return loginResult{}, err
+	}
+	apiURL := loginAPIURL(cfg, profileName)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	device, err := requestDeviceCode(ctx, apiURL)
+	if err != nil {
+		return loginResult{}, err
+	}
+
+	errOut := cmd.ErrOrStderr()
+	fmt.Fprintf(errOut, "Open this URL to authorize the LangSmith CLI:\n%s\n\nEnter code: %s\n\n", device.VerificationURI, device.UserCode)
+	if !in.noBrowser {
+		if err := openBrowser(device.VerificationURI); err != nil {
+			fmt.Fprintf(errOut, "Could not open a browser automatically: %v\n\n", err)
+		}
+	}
+	fmt.Fprintln(errOut, "Waiting for authorization...")
+
+	waitFor := in.timeout
+	if waitFor <= 0 {
+		waitFor = time.Duration(device.ExpiresIn+10) * time.Second
+	}
+	pollCtx, cancel := context.WithTimeout(ctx, waitFor)
+	defer cancel()
+
+	interval := normalizeDeviceCodePollInterval(time.Duration(device.Interval) * time.Second)
+	token, err := pollDeviceToken(pollCtx, apiURL, device.DeviceCode, interval)
+	if err != nil {
+		return loginResult{}, err
+	}
+
+	profile := cfg.Profiles[profileName]
+	if profile.APIURL == "" || flagAPIURL != "" || strings.TrimSpace(profile.APIURL) != apiURL {
+		profile.APIURL = apiURL
+	}
+	if workspaceID == "" && in.promptWorkspace {
+		workspaceID, err = promptWorkspaceSelection(cmd, apiURL, token.AccessToken)
+		if err != nil {
+			return loginResult{}, err
+		}
+	}
+	if workspaceID != "" {
+		profile.WorkspaceID = workspaceID
+	}
+	applyTokenResponse(&profile, token, time.Now())
+	cfg.Profiles[profileName] = profile
+	cfg.CurrentProfile = profileName
+	if err := cfg.Save(); err != nil {
+		return loginResult{}, err
+	}
+
+	return loginResult{
+		Status:         "logged_in",
+		Profile:        profileName,
+		APIURL:         apiURL,
+		WorkspaceID:    profile.WorkspaceID,
+		OAuthExpiresAt: profile.OAuth.ExpiresAt,
+	}, nil
 }
 
 func loginProfileName(cfg *lsconfig.Config) string {

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -81,60 +81,7 @@ func newProfileCreateCmd() *cobra.Command {
 			return in
 		},
 		Action: func(ctx context.Context, cmd *cobra.Command, in *profileCreateInput, args []string) (any, error) {
-			profileName := args[0]
-			workspaceID := in.workspaceID
-			if err := validateProfileName(profileName); err != nil {
-				return profileCreateResult{}, err
-			}
-			if workspaceID != "" {
-				if err := validateWorkspaceID(workspaceID); err != nil {
-					return profileCreateResult{}, err
-				}
-			}
-
-			cfg, err := lsconfig.Load()
-			if err != nil {
-				return profileCreateResult{}, err
-			}
-			if cfg.Profiles == nil {
-				cfg.Profiles = make(map[string]lsconfig.Profile)
-			}
-			if _, exists := cfg.Profiles[profileName]; exists {
-				return profileCreateResult{}, fmt.Errorf("profile %q already exists", profileName)
-			}
-
-			apiKey := profileCreateAPIKey()
-			if apiKey == "" {
-				return profileCreateResult{}, fmt.Errorf("api key required; pass --api-key or set LANGSMITH_API_KEY")
-			}
-			apiURL := profileCreateAPIURL()
-
-			cfg.Profiles[profileName] = lsconfig.Profile{
-				APIKey:      apiKey,
-				APIURL:      apiURL,
-				WorkspaceID: workspaceID,
-			}
-			if cfg.CurrentProfile == "" || in.setCurrent {
-				cfg.CurrentProfile = profileName
-			}
-			if err := cfg.Save(); err != nil {
-				return profileCreateResult{}, err
-			}
-
-			active := cfg.CurrentProfile == profileName
-			message := fmt.Sprintf("Created profile %q", profileName)
-			if active {
-				message = fmt.Sprintf("Created and selected profile %q", profileName)
-			}
-			return profileCreateResult{
-				Status:      "created",
-				Profile:     profileName,
-				APIURL:      apiURL,
-				WorkspaceID: workspaceID,
-				Auth:        "api_key",
-				Active:      active,
-				Message:     message,
-			}, nil
+			return runProfileCreate(args[0], in)
 		},
 		Render: structured.Template(`{{.Message}}`),
 	}.Cobra()
@@ -146,30 +93,7 @@ func newProfileListCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List saved profiles",
 		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
-			cfg, err := lsconfig.Load()
-			if err != nil {
-				return nil, err
-			}
-
-			activeName := cfg.ResolveProfileName(flagProfile, profileEnvName())
-			items := make([]profileListItem, 0, len(cfg.Profiles))
-			for name, profile := range cfg.Profiles {
-				items = append(items, profileListItem{
-					Name:           name,
-					Active:         name == activeName,
-					APIURL:         profile.APIURL,
-					WorkspaceID:    profile.WorkspaceID,
-					Auth:           profileAuthType(profile),
-					OAuthExpiresAt: profile.OAuth.ExpiresAt,
-				})
-			}
-			sort.Slice(items, func(i, j int) bool {
-				if items[i].Active != items[j].Active {
-					return items[i].Active
-				}
-				return items[i].Name < items[j].Name
-			})
-			return items, nil
+			return runProfileList()
 		},
 		Render: structured.Table{
 			Rows: ".",
@@ -191,29 +115,7 @@ func newProfileShowCmd() *cobra.Command {
 		Short: "Show a saved profile",
 		Args:  cobra.ExactArgs(1),
 		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
-			profileName := args[0]
-			cfg, err := lsconfig.Load()
-			if err != nil {
-				return profileShowItem{}, err
-			}
-			profile, ok := cfg.Profiles[profileName]
-			if !ok {
-				return profileShowItem{}, fmt.Errorf("profile %q not found", profileName)
-			}
-
-			activeName := cfg.ResolveProfileName(flagProfile, profileEnvName())
-			item := profileShowItem{
-				Name:           profileName,
-				Active:         profileName == activeName,
-				APIURL:         profile.APIURL,
-				WorkspaceID:    profile.WorkspaceID,
-				Auth:           profileAuthType(profile),
-				OAuthExpiresAt: profile.OAuth.ExpiresAt,
-			}
-			if profile.APIKey != "" {
-				item.APIKey = lsconfig.MaskSecret(profile.APIKey)
-			}
-			return item, nil
+			return runProfileShow(args[0])
 		},
 		Render: structured.Table{
 			Rows: ".",
@@ -236,27 +138,7 @@ func newProfileDeleteCmd() *cobra.Command {
 		Short: "Delete a saved profile",
 		Args:  cobra.ExactArgs(1),
 		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
-			profileName := args[0]
-			cfg, err := lsconfig.Load()
-			if err != nil {
-				return profileStatusResult{}, err
-			}
-			if _, ok := cfg.Profiles[profileName]; !ok {
-				return profileStatusResult{}, fmt.Errorf("profile %q not found", profileName)
-			}
-			delete(cfg.Profiles, profileName)
-			if cfg.CurrentProfile == profileName {
-				cfg.CurrentProfile = ""
-			}
-			if err := cfg.Save(); err != nil {
-				return profileStatusResult{}, err
-			}
-
-			return profileStatusResult{
-				Status:  "deleted",
-				Profile: profileName,
-				Message: fmt.Sprintf("Deleted profile %q", profileName),
-			}, nil
+			return runProfileDelete(args[0])
 		},
 		Render: structured.Template(`{{.Message}}`),
 	}.Cobra()
@@ -268,24 +150,7 @@ func newProfileUseCmd() *cobra.Command {
 		Short: "Set the current profile",
 		Args:  cobra.ExactArgs(1),
 		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
-			profileName := args[0]
-			cfg, err := lsconfig.Load()
-			if err != nil {
-				return profileStatusResult{}, err
-			}
-			if _, ok := cfg.Profiles[profileName]; !ok {
-				return profileStatusResult{}, fmt.Errorf("profile %q not found", profileName)
-			}
-			cfg.CurrentProfile = profileName
-			if err := cfg.Save(); err != nil {
-				return profileStatusResult{}, err
-			}
-
-			return profileStatusResult{
-				Status:  "switched",
-				Profile: profileName,
-				Message: fmt.Sprintf("Using profile %q", profileName),
-			}, nil
+			return runProfileUse(args[0])
 		},
 		Render: structured.Template(`{{.Message}}`),
 	}.Cobra()
@@ -297,41 +162,66 @@ func newProfileSetWorkspaceCmd() *cobra.Command {
 		Short: "Set the default workspace for a profile",
 		Args:  cobra.ExactArgs(1),
 		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
-			workspaceID := args[0]
-			if err := validateWorkspaceID(workspaceID); err != nil {
-				return profileStatusResult{}, err
-			}
-			cfg, err := lsconfig.Load()
-			if err != nil {
-				return profileStatusResult{}, err
-			}
-			if cfg.Profiles == nil {
-				cfg.Profiles = make(map[string]lsconfig.Profile)
-			}
-
-			profileName := loginProfileName(cfg)
-			if err := validateProfileName(profileName); err != nil {
-				return profileStatusResult{}, err
-			}
-			profile := cfg.Profiles[profileName]
-			profile.WorkspaceID = workspaceID
-			cfg.Profiles[profileName] = profile
-			if cfg.CurrentProfile == "" {
-				cfg.CurrentProfile = profileName
-			}
-			if err := cfg.Save(); err != nil {
-				return profileStatusResult{}, err
-			}
-
-			return profileStatusResult{
-				Status:      "workspace_set",
-				Profile:     profileName,
-				WorkspaceID: workspaceID,
-				Message:     fmt.Sprintf("Set default workspace for profile %q", profileName),
-			}, nil
+			return runProfileSetWorkspace(args[0])
 		},
 		Render: structured.Template(`{{.Message}}`),
 	}.Cobra()
+}
+
+func runProfileCreate(profileName string, in *profileCreateInput) (profileCreateResult, error) {
+	workspaceID := in.workspaceID
+	if err := validateProfileName(profileName); err != nil {
+		return profileCreateResult{}, err
+	}
+	if workspaceID != "" {
+		if err := validateWorkspaceID(workspaceID); err != nil {
+			return profileCreateResult{}, err
+		}
+	}
+
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return profileCreateResult{}, err
+	}
+	if cfg.Profiles == nil {
+		cfg.Profiles = make(map[string]lsconfig.Profile)
+	}
+	if _, exists := cfg.Profiles[profileName]; exists {
+		return profileCreateResult{}, fmt.Errorf("profile %q already exists", profileName)
+	}
+
+	apiKey := profileCreateAPIKey()
+	if apiKey == "" {
+		return profileCreateResult{}, fmt.Errorf("api key required; pass --api-key or set LANGSMITH_API_KEY")
+	}
+	apiURL := profileCreateAPIURL()
+
+	cfg.Profiles[profileName] = lsconfig.Profile{
+		APIKey:      apiKey,
+		APIURL:      apiURL,
+		WorkspaceID: workspaceID,
+	}
+	if cfg.CurrentProfile == "" || in.setCurrent {
+		cfg.CurrentProfile = profileName
+	}
+	if err := cfg.Save(); err != nil {
+		return profileCreateResult{}, err
+	}
+
+	active := cfg.CurrentProfile == profileName
+	message := fmt.Sprintf("Created profile %q", profileName)
+	if active {
+		message = fmt.Sprintf("Created and selected profile %q", profileName)
+	}
+	return profileCreateResult{
+		Status:      "created",
+		Profile:     profileName,
+		APIURL:      apiURL,
+		WorkspaceID: workspaceID,
+		Auth:        "api_key",
+		Active:      active,
+		Message:     message,
+	}, nil
 }
 
 func profileCreateAPIKey() string {
@@ -352,6 +242,103 @@ func profileCreateAPIURL() string {
 	return client.NormalizeURL(apiURL)
 }
 
+func runProfileShow(profileName string) (profileShowItem, error) {
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return profileShowItem{}, err
+	}
+	profile, ok := cfg.Profiles[profileName]
+	if !ok {
+		return profileShowItem{}, fmt.Errorf("profile %q not found", profileName)
+	}
+
+	activeName := cfg.ResolveProfileName(flagProfile, profileEnvName())
+	item := profileShowItem{
+		Name:           profileName,
+		Active:         profileName == activeName,
+		APIURL:         profile.APIURL,
+		WorkspaceID:    profile.WorkspaceID,
+		Auth:           profileAuthType(profile),
+		OAuthExpiresAt: profile.OAuth.ExpiresAt,
+	}
+	if profile.APIKey != "" {
+		item.APIKey = lsconfig.MaskSecret(profile.APIKey)
+	}
+
+	return item, nil
+}
+
+func runProfileDelete(profileName string) (profileStatusResult, error) {
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return profileStatusResult{}, err
+	}
+	if _, ok := cfg.Profiles[profileName]; !ok {
+		return profileStatusResult{}, fmt.Errorf("profile %q not found", profileName)
+	}
+	delete(cfg.Profiles, profileName)
+	if cfg.CurrentProfile == profileName {
+		cfg.CurrentProfile = ""
+	}
+	if err := cfg.Save(); err != nil {
+		return profileStatusResult{}, err
+	}
+
+	return profileStatusResult{
+		Status:  "deleted",
+		Profile: profileName,
+		Message: fmt.Sprintf("Deleted profile %q", profileName),
+	}, nil
+}
+
+func runProfileUse(profileName string) (profileStatusResult, error) {
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return profileStatusResult{}, err
+	}
+	if _, ok := cfg.Profiles[profileName]; !ok {
+		return profileStatusResult{}, fmt.Errorf("profile %q not found", profileName)
+	}
+	cfg.CurrentProfile = profileName
+	if err := cfg.Save(); err != nil {
+		return profileStatusResult{}, err
+	}
+
+	return profileStatusResult{
+		Status:  "switched",
+		Profile: profileName,
+		Message: fmt.Sprintf("Using profile %q", profileName),
+	}, nil
+}
+
+func runProfileList() ([]profileListItem, error) {
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	activeName := cfg.ResolveProfileName(flagProfile, profileEnvName())
+	items := make([]profileListItem, 0, len(cfg.Profiles))
+	for name, profile := range cfg.Profiles {
+		items = append(items, profileListItem{
+			Name:           name,
+			Active:         name == activeName,
+			APIURL:         profile.APIURL,
+			WorkspaceID:    profile.WorkspaceID,
+			Auth:           profileAuthType(profile),
+			OAuthExpiresAt: profile.OAuth.ExpiresAt,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Active != items[j].Active {
+			return items[i].Active
+		}
+		return items[i].Name < items[j].Name
+	})
+
+	return items, nil
+}
+
 func profileAuthType(profile lsconfig.Profile) string {
 	switch {
 	case profile.AccessToken() != "" || profile.OAuth.RefreshToken != "":
@@ -365,4 +352,38 @@ func profileAuthType(profile lsconfig.Profile) string {
 
 func profileEnvName() string {
 	return strings.TrimSpace(os.Getenv("LANGSMITH_PROFILE"))
+}
+
+func runProfileSetWorkspace(workspaceID string) (profileStatusResult, error) {
+	if err := validateWorkspaceID(workspaceID); err != nil {
+		return profileStatusResult{}, err
+	}
+	cfg, err := lsconfig.Load()
+	if err != nil {
+		return profileStatusResult{}, err
+	}
+	if cfg.Profiles == nil {
+		cfg.Profiles = make(map[string]lsconfig.Profile)
+	}
+
+	profileName := loginProfileName(cfg)
+	if err := validateProfileName(profileName); err != nil {
+		return profileStatusResult{}, err
+	}
+	profile := cfg.Profiles[profileName]
+	profile.WorkspaceID = workspaceID
+	cfg.Profiles[profileName] = profile
+	if cfg.CurrentProfile == "" {
+		cfg.CurrentProfile = profileName
+	}
+	if err := cfg.Save(); err != nil {
+		return profileStatusResult{}, err
+	}
+
+	return profileStatusResult{
+		Status:      "workspace_set",
+		Profile:     profileName,
+		WorkspaceID: workspaceID,
+		Message:     fmt.Sprintf("Set default workspace for profile %q", profileName),
+	}, nil
 }

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -81,7 +81,60 @@ func newProfileCreateCmd() *cobra.Command {
 			return in
 		},
 		Action: func(ctx context.Context, cmd *cobra.Command, in *profileCreateInput, args []string) (any, error) {
-			return runProfileCreate(args[0], in.workspaceID, in.setCurrent)
+			profileName := args[0]
+			workspaceID := in.workspaceID
+			if err := validateProfileName(profileName); err != nil {
+				return profileCreateResult{}, err
+			}
+			if workspaceID != "" {
+				if err := validateWorkspaceID(workspaceID); err != nil {
+					return profileCreateResult{}, err
+				}
+			}
+
+			cfg, err := lsconfig.Load()
+			if err != nil {
+				return profileCreateResult{}, err
+			}
+			if cfg.Profiles == nil {
+				cfg.Profiles = make(map[string]lsconfig.Profile)
+			}
+			if _, exists := cfg.Profiles[profileName]; exists {
+				return profileCreateResult{}, fmt.Errorf("profile %q already exists", profileName)
+			}
+
+			apiKey := profileCreateAPIKey()
+			if apiKey == "" {
+				return profileCreateResult{}, fmt.Errorf("api key required; pass --api-key or set LANGSMITH_API_KEY")
+			}
+			apiURL := profileCreateAPIURL()
+
+			cfg.Profiles[profileName] = lsconfig.Profile{
+				APIKey:      apiKey,
+				APIURL:      apiURL,
+				WorkspaceID: workspaceID,
+			}
+			if cfg.CurrentProfile == "" || in.setCurrent {
+				cfg.CurrentProfile = profileName
+			}
+			if err := cfg.Save(); err != nil {
+				return profileCreateResult{}, err
+			}
+
+			active := cfg.CurrentProfile == profileName
+			message := fmt.Sprintf("Created profile %q", profileName)
+			if active {
+				message = fmt.Sprintf("Created and selected profile %q", profileName)
+			}
+			return profileCreateResult{
+				Status:      "created",
+				Profile:     profileName,
+				APIURL:      apiURL,
+				WorkspaceID: workspaceID,
+				Auth:        "api_key",
+				Active:      active,
+				Message:     message,
+			}, nil
 		},
 		Render: structured.Template(`{{.Message}}
 `),
@@ -94,7 +147,30 @@ func newProfileListCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List saved profiles",
 		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
-			return runProfileList()
+			cfg, err := lsconfig.Load()
+			if err != nil {
+				return nil, err
+			}
+
+			activeName := cfg.ResolveProfileName(flagProfile, profileEnvName())
+			items := make([]profileListItem, 0, len(cfg.Profiles))
+			for name, profile := range cfg.Profiles {
+				items = append(items, profileListItem{
+					Name:           name,
+					Active:         name == activeName,
+					APIURL:         profile.APIURL,
+					WorkspaceID:    profile.WorkspaceID,
+					Auth:           profileAuthType(profile),
+					OAuthExpiresAt: profile.OAuth.ExpiresAt,
+				})
+			}
+			sort.Slice(items, func(i, j int) bool {
+				if items[i].Active != items[j].Active {
+					return items[i].Active
+				}
+				return items[i].Name < items[j].Name
+			})
+			return items, nil
 		},
 		Render: structured.Table{
 			Rows: ".",
@@ -116,7 +192,29 @@ func newProfileShowCmd() *cobra.Command {
 		Short: "Show a saved profile",
 		Args:  cobra.ExactArgs(1),
 		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
-			return runProfileShow(args[0])
+			profileName := args[0]
+			cfg, err := lsconfig.Load()
+			if err != nil {
+				return profileShowItem{}, err
+			}
+			profile, ok := cfg.Profiles[profileName]
+			if !ok {
+				return profileShowItem{}, fmt.Errorf("profile %q not found", profileName)
+			}
+
+			activeName := cfg.ResolveProfileName(flagProfile, profileEnvName())
+			item := profileShowItem{
+				Name:           profileName,
+				Active:         profileName == activeName,
+				APIURL:         profile.APIURL,
+				WorkspaceID:    profile.WorkspaceID,
+				Auth:           profileAuthType(profile),
+				OAuthExpiresAt: profile.OAuth.ExpiresAt,
+			}
+			if profile.APIKey != "" {
+				item.APIKey = lsconfig.MaskSecret(profile.APIKey)
+			}
+			return item, nil
 		},
 		Render: structured.Table{
 			Rows: ".",
@@ -139,7 +237,27 @@ func newProfileDeleteCmd() *cobra.Command {
 		Short: "Delete a saved profile",
 		Args:  cobra.ExactArgs(1),
 		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
-			return runProfileDelete(args[0])
+			profileName := args[0]
+			cfg, err := lsconfig.Load()
+			if err != nil {
+				return profileStatusResult{}, err
+			}
+			if _, ok := cfg.Profiles[profileName]; !ok {
+				return profileStatusResult{}, fmt.Errorf("profile %q not found", profileName)
+			}
+			delete(cfg.Profiles, profileName)
+			if cfg.CurrentProfile == profileName {
+				cfg.CurrentProfile = ""
+			}
+			if err := cfg.Save(); err != nil {
+				return profileStatusResult{}, err
+			}
+
+			return profileStatusResult{
+				Status:  "deleted",
+				Profile: profileName,
+				Message: fmt.Sprintf("Deleted profile %q", profileName),
+			}, nil
 		},
 		Render: structured.Template(`{{.Message}}
 `),
@@ -152,7 +270,24 @@ func newProfileUseCmd() *cobra.Command {
 		Short: "Set the current profile",
 		Args:  cobra.ExactArgs(1),
 		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
-			return runProfileUse(args[0])
+			profileName := args[0]
+			cfg, err := lsconfig.Load()
+			if err != nil {
+				return profileStatusResult{}, err
+			}
+			if _, ok := cfg.Profiles[profileName]; !ok {
+				return profileStatusResult{}, fmt.Errorf("profile %q not found", profileName)
+			}
+			cfg.CurrentProfile = profileName
+			if err := cfg.Save(); err != nil {
+				return profileStatusResult{}, err
+			}
+
+			return profileStatusResult{
+				Status:  "switched",
+				Profile: profileName,
+				Message: fmt.Sprintf("Using profile %q", profileName),
+			}, nil
 		},
 		Render: structured.Template(`{{.Message}}
 `),
@@ -165,66 +300,42 @@ func newProfileSetWorkspaceCmd() *cobra.Command {
 		Short: "Set the default workspace for a profile",
 		Args:  cobra.ExactArgs(1),
 		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
-			return runProfileSetWorkspace(args[0])
+			workspaceID := args[0]
+			if err := validateWorkspaceID(workspaceID); err != nil {
+				return profileStatusResult{}, err
+			}
+			cfg, err := lsconfig.Load()
+			if err != nil {
+				return profileStatusResult{}, err
+			}
+			if cfg.Profiles == nil {
+				cfg.Profiles = make(map[string]lsconfig.Profile)
+			}
+
+			profileName := loginProfileName(cfg)
+			if err := validateProfileName(profileName); err != nil {
+				return profileStatusResult{}, err
+			}
+			profile := cfg.Profiles[profileName]
+			profile.WorkspaceID = workspaceID
+			cfg.Profiles[profileName] = profile
+			if cfg.CurrentProfile == "" {
+				cfg.CurrentProfile = profileName
+			}
+			if err := cfg.Save(); err != nil {
+				return profileStatusResult{}, err
+			}
+
+			return profileStatusResult{
+				Status:      "workspace_set",
+				Profile:     profileName,
+				WorkspaceID: workspaceID,
+				Message:     fmt.Sprintf("Set default workspace for profile %q", profileName),
+			}, nil
 		},
 		Render: structured.Template(`{{.Message}}
 `),
 	}.Cobra()
-}
-
-func runProfileCreate(profileName, workspaceID string, setCurrent bool) (profileCreateResult, error) {
-	if err := validateProfileName(profileName); err != nil {
-		return profileCreateResult{}, err
-	}
-	if workspaceID != "" {
-		if err := validateWorkspaceID(workspaceID); err != nil {
-			return profileCreateResult{}, err
-		}
-	}
-
-	cfg, err := lsconfig.Load()
-	if err != nil {
-		return profileCreateResult{}, err
-	}
-	if cfg.Profiles == nil {
-		cfg.Profiles = make(map[string]lsconfig.Profile)
-	}
-	if _, exists := cfg.Profiles[profileName]; exists {
-		return profileCreateResult{}, fmt.Errorf("profile %q already exists", profileName)
-	}
-
-	apiKey := profileCreateAPIKey()
-	if apiKey == "" {
-		return profileCreateResult{}, fmt.Errorf("api key required; pass --api-key or set LANGSMITH_API_KEY")
-	}
-	apiURL := profileCreateAPIURL()
-
-	cfg.Profiles[profileName] = lsconfig.Profile{
-		APIKey:      apiKey,
-		APIURL:      apiURL,
-		WorkspaceID: workspaceID,
-	}
-	if cfg.CurrentProfile == "" || setCurrent {
-		cfg.CurrentProfile = profileName
-	}
-	if err := cfg.Save(); err != nil {
-		return profileCreateResult{}, err
-	}
-
-	active := cfg.CurrentProfile == profileName
-	message := fmt.Sprintf("Created profile %q", profileName)
-	if active {
-		message = fmt.Sprintf("Created and selected profile %q", profileName)
-	}
-	return profileCreateResult{
-		Status:      "created",
-		Profile:     profileName,
-		APIURL:      apiURL,
-		WorkspaceID: workspaceID,
-		Auth:        "api_key",
-		Active:      active,
-		Message:     message,
-	}, nil
 }
 
 func profileCreateAPIKey() string {
@@ -245,103 +356,6 @@ func profileCreateAPIURL() string {
 	return client.NormalizeURL(apiURL)
 }
 
-func runProfileShow(profileName string) (profileShowItem, error) {
-	cfg, err := lsconfig.Load()
-	if err != nil {
-		return profileShowItem{}, err
-	}
-	profile, ok := cfg.Profiles[profileName]
-	if !ok {
-		return profileShowItem{}, fmt.Errorf("profile %q not found", profileName)
-	}
-
-	activeName := cfg.ResolveProfileName(flagProfile, profileEnvName())
-	item := profileShowItem{
-		Name:           profileName,
-		Active:         profileName == activeName,
-		APIURL:         profile.APIURL,
-		WorkspaceID:    profile.WorkspaceID,
-		Auth:           profileAuthType(profile),
-		OAuthExpiresAt: profile.OAuth.ExpiresAt,
-	}
-	if profile.APIKey != "" {
-		item.APIKey = lsconfig.MaskSecret(profile.APIKey)
-	}
-
-	return item, nil
-}
-
-func runProfileDelete(profileName string) (profileStatusResult, error) {
-	cfg, err := lsconfig.Load()
-	if err != nil {
-		return profileStatusResult{}, err
-	}
-	if _, ok := cfg.Profiles[profileName]; !ok {
-		return profileStatusResult{}, fmt.Errorf("profile %q not found", profileName)
-	}
-	delete(cfg.Profiles, profileName)
-	if cfg.CurrentProfile == profileName {
-		cfg.CurrentProfile = ""
-	}
-	if err := cfg.Save(); err != nil {
-		return profileStatusResult{}, err
-	}
-
-	return profileStatusResult{
-		Status:  "deleted",
-		Profile: profileName,
-		Message: fmt.Sprintf("Deleted profile %q", profileName),
-	}, nil
-}
-
-func runProfileUse(profileName string) (profileStatusResult, error) {
-	cfg, err := lsconfig.Load()
-	if err != nil {
-		return profileStatusResult{}, err
-	}
-	if _, ok := cfg.Profiles[profileName]; !ok {
-		return profileStatusResult{}, fmt.Errorf("profile %q not found", profileName)
-	}
-	cfg.CurrentProfile = profileName
-	if err := cfg.Save(); err != nil {
-		return profileStatusResult{}, err
-	}
-
-	return profileStatusResult{
-		Status:  "switched",
-		Profile: profileName,
-		Message: fmt.Sprintf("Using profile %q", profileName),
-	}, nil
-}
-
-func runProfileList() ([]profileListItem, error) {
-	cfg, err := lsconfig.Load()
-	if err != nil {
-		return nil, err
-	}
-
-	activeName := cfg.ResolveProfileName(flagProfile, profileEnvName())
-	items := make([]profileListItem, 0, len(cfg.Profiles))
-	for name, profile := range cfg.Profiles {
-		items = append(items, profileListItem{
-			Name:           name,
-			Active:         name == activeName,
-			APIURL:         profile.APIURL,
-			WorkspaceID:    profile.WorkspaceID,
-			Auth:           profileAuthType(profile),
-			OAuthExpiresAt: profile.OAuth.ExpiresAt,
-		})
-	}
-	sort.Slice(items, func(i, j int) bool {
-		if items[i].Active != items[j].Active {
-			return items[i].Active
-		}
-		return items[i].Name < items[j].Name
-	})
-
-	return items, nil
-}
-
 func profileAuthType(profile lsconfig.Profile) string {
 	switch {
 	case profile.AccessToken() != "" || profile.OAuth.RefreshToken != "":
@@ -355,38 +369,4 @@ func profileAuthType(profile lsconfig.Profile) string {
 
 func profileEnvName() string {
 	return strings.TrimSpace(os.Getenv("LANGSMITH_PROFILE"))
-}
-
-func runProfileSetWorkspace(workspaceID string) (profileStatusResult, error) {
-	if err := validateWorkspaceID(workspaceID); err != nil {
-		return profileStatusResult{}, err
-	}
-	cfg, err := lsconfig.Load()
-	if err != nil {
-		return profileStatusResult{}, err
-	}
-	if cfg.Profiles == nil {
-		cfg.Profiles = make(map[string]lsconfig.Profile)
-	}
-
-	profileName := loginProfileName(cfg)
-	if err := validateProfileName(profileName); err != nil {
-		return profileStatusResult{}, err
-	}
-	profile := cfg.Profiles[profileName]
-	profile.WorkspaceID = workspaceID
-	cfg.Profiles[profileName] = profile
-	if cfg.CurrentProfile == "" {
-		cfg.CurrentProfile = profileName
-	}
-	if err := cfg.Save(); err != nil {
-		return profileStatusResult{}, err
-	}
-
-	return profileStatusResult{
-		Status:      "workspace_set",
-		Profile:     profileName,
-		WorkspaceID: workspaceID,
-		Message:     fmt.Sprintf("Set default workspace for profile %q", profileName),
-	}, nil
 }

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -136,8 +136,7 @@ func newProfileCreateCmd() *cobra.Command {
 				Message:     message,
 			}, nil
 		},
-		Render: structured.Template(`{{.Message}}
-`),
+		Render: structured.Template(`{{.Message}}`),
 	}.Cobra()
 }
 
@@ -259,8 +258,7 @@ func newProfileDeleteCmd() *cobra.Command {
 				Message: fmt.Sprintf("Deleted profile %q", profileName),
 			}, nil
 		},
-		Render: structured.Template(`{{.Message}}
-`),
+		Render: structured.Template(`{{.Message}}`),
 	}.Cobra()
 }
 
@@ -289,8 +287,7 @@ func newProfileUseCmd() *cobra.Command {
 				Message: fmt.Sprintf("Using profile %q", profileName),
 			}, nil
 		},
-		Render: structured.Template(`{{.Message}}
-`),
+		Render: structured.Template(`{{.Message}}`),
 	}.Cobra()
 }
 
@@ -333,8 +330,7 @@ func newProfileSetWorkspaceCmd() *cobra.Command {
 				Message:     fmt.Sprintf("Set default workspace for profile %q", profileName),
 			}, nil
 		},
-		Render: structured.Template(`{{.Message}}
-`),
+		Render: structured.Template(`{{.Message}}`),
 	}.Cobra()
 }
 

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 	"os"
 	"sort"
@@ -9,7 +9,7 @@ import (
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
 	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
-	"github.com/olekukonko/tablewriter"
+	"github.com/langchain-ai/langsmith-cli/internal/structured"
 	"github.com/spf13/cobra"
 )
 
@@ -32,117 +32,170 @@ type profileShowItem struct {
 	OAuthExpiresAt string `json:"oauth_expires_at,omitempty"`
 }
 
+type profileCreateInput struct {
+	workspaceID string
+	setCurrent  bool
+}
+
+type profileCreateResult struct {
+	Status      string `json:"status"`
+	Profile     string `json:"profile"`
+	APIURL      string `json:"api_url"`
+	WorkspaceID string `json:"workspace_id,omitempty"`
+	Auth        string `json:"auth"`
+	Active      bool   `json:"active"`
+	Message     string `json:"message"`
+}
+
+type profileStatusResult struct {
+	Status      string `json:"status"`
+	Profile     string `json:"profile"`
+	WorkspaceID string `json:"workspace_id,omitempty"`
+	Message     string `json:"message"`
+}
+
 func newProfileCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	return structured.Parent{
 		Use:   "profile",
 		Short: "Manage saved LangSmith profiles",
-	}
-	cmd.AddCommand(newProfileCreateCmd())
-	cmd.AddCommand(newProfileListCmd())
-	cmd.AddCommand(newProfileShowCmd())
-	cmd.AddCommand(newProfileDeleteCmd())
-	cmd.AddCommand(newProfileUseCmd())
-	cmd.AddCommand(newProfileSetWorkspaceCmd())
-	return cmd
+		Children: []func() *cobra.Command{
+			newProfileCreateCmd,
+			newProfileListCmd,
+			newProfileShowCmd,
+			newProfileDeleteCmd,
+			newProfileUseCmd,
+			newProfileSetWorkspaceCmd,
+		},
+	}.Cobra()
 }
 
 func newProfileCreateCmd() *cobra.Command {
-	var (
-		workspaceID string
-		setCurrent  bool
-	)
-	cmd := &cobra.Command{
+	return structured.Command[*profileCreateInput]{
 		Use:   "create NAME",
 		Short: "Create an API-key profile",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runProfileCreate(cmd, args[0], workspaceID, setCurrent)
+		Input: func(cmd *cobra.Command) *profileCreateInput {
+			in := &profileCreateInput{}
+			cmd.Flags().StringVar(&in.workspaceID, "workspace-id", "", "Default workspace ID to save in the profile")
+			cmd.Flags().BoolVar(&in.setCurrent, "set-current", false, "Set the new profile as the current profile")
+			return in
 		},
-	}
-	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "Default workspace ID to save in the profile")
-	cmd.Flags().BoolVar(&setCurrent, "set-current", false, "Set the new profile as the current profile")
-	return cmd
+		Action: func(ctx context.Context, cmd *cobra.Command, in *profileCreateInput, args []string) (any, error) {
+			return runProfileCreate(args[0], in.workspaceID, in.setCurrent)
+		},
+		Render: structured.Template(`{{.Message}}
+`),
+	}.Cobra()
 }
 
 func newProfileListCmd() *cobra.Command {
-	return &cobra.Command{
+	return structured.Command[struct{}]{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List saved profiles",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runProfileList(cmd)
+		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+			return runProfileList()
 		},
-	}
+		Render: structured.Table{
+			Rows: ".",
+			Columns: []structured.Column{
+				{Header: "Active", Template: "{{if .Active}}*{{end}}"},
+				{Header: "Name", Template: "{{.Name}}"},
+				{Header: "API URL", Template: "{{.APIURL}}"},
+				{Header: "Workspace ID", Template: "{{.WorkspaceID}}"},
+				{Header: "Auth", Template: "{{.Auth}}"},
+				{Header: "Expires At", Template: "{{.OAuthExpiresAt}}"},
+			},
+		},
+	}.Cobra()
 }
 
 func newProfileShowCmd() *cobra.Command {
-	return &cobra.Command{
+	return structured.Command[struct{}]{
 		Use:   "show NAME",
 		Short: "Show a saved profile",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runProfileShow(cmd, args[0])
+		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+			return runProfileShow(args[0])
 		},
-	}
+		Render: structured.Table{
+			Rows: ".",
+			Columns: []structured.Column{
+				{Header: "Active", Template: "{{if .Active}}*{{end}}"},
+				{Header: "Name", Template: "{{.Name}}"},
+				{Header: "API URL", Template: "{{.APIURL}}"},
+				{Header: "Workspace ID", Template: "{{.WorkspaceID}}"},
+				{Header: "Auth", Template: "{{.Auth}}"},
+				{Header: "API Key", Template: "{{.APIKey}}"},
+				{Header: "Expires At", Template: "{{.OAuthExpiresAt}}"},
+			},
+		},
+	}.Cobra()
 }
 
 func newProfileDeleteCmd() *cobra.Command {
-	return &cobra.Command{
+	return structured.Command[struct{}]{
 		Use:   "delete NAME",
 		Short: "Delete a saved profile",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runProfileDelete(cmd, args[0])
+		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+			return runProfileDelete(args[0])
 		},
-	}
+		Render: structured.Template(`{{.Message}}
+`),
+	}.Cobra()
 }
 
 func newProfileUseCmd() *cobra.Command {
-	return &cobra.Command{
+	return structured.Command[struct{}]{
 		Use:   "use NAME",
 		Short: "Set the current profile",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runProfileUse(cmd, args[0])
+		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+			return runProfileUse(args[0])
 		},
-	}
+		Render: structured.Template(`{{.Message}}
+`),
+	}.Cobra()
 }
 
 func newProfileSetWorkspaceCmd() *cobra.Command {
-	return &cobra.Command{
+	return structured.Command[struct{}]{
 		Use:   "set-workspace WORKSPACE_ID",
 		Short: "Set the default workspace for a profile",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runProfileSetWorkspace(cmd, args[0])
+		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+			return runProfileSetWorkspace(args[0])
 		},
-	}
+		Render: structured.Template(`{{.Message}}
+`),
+	}.Cobra()
 }
 
-func runProfileCreate(cmd *cobra.Command, profileName, workspaceID string, setCurrent bool) error {
+func runProfileCreate(profileName, workspaceID string, setCurrent bool) (profileCreateResult, error) {
 	if err := validateProfileName(profileName); err != nil {
-		return err
+		return profileCreateResult{}, err
 	}
 	if workspaceID != "" {
 		if err := validateWorkspaceID(workspaceID); err != nil {
-			return err
+			return profileCreateResult{}, err
 		}
 	}
 
 	cfg, err := lsconfig.Load()
 	if err != nil {
-		return err
+		return profileCreateResult{}, err
 	}
 	if cfg.Profiles == nil {
 		cfg.Profiles = make(map[string]lsconfig.Profile)
 	}
 	if _, exists := cfg.Profiles[profileName]; exists {
-		return fmt.Errorf("profile %q already exists", profileName)
+		return profileCreateResult{}, fmt.Errorf("profile %q already exists", profileName)
 	}
 
 	apiKey := profileCreateAPIKey()
 	if apiKey == "" {
-		return fmt.Errorf("api key required; pass --api-key or set LANGSMITH_API_KEY")
+		return profileCreateResult{}, fmt.Errorf("api key required; pass --api-key or set LANGSMITH_API_KEY")
 	}
 	apiURL := profileCreateAPIURL()
 
@@ -155,31 +208,23 @@ func runProfileCreate(cmd *cobra.Command, profileName, workspaceID string, setCu
 		cfg.CurrentProfile = profileName
 	}
 	if err := cfg.Save(); err != nil {
-		return err
+		return profileCreateResult{}, err
 	}
 
-	if GetFormat() == "pretty" {
-		if cfg.CurrentProfile == profileName {
-			fmt.Fprintf(cmd.OutOrStdout(), "Created and selected profile %q\n", profileName)
-		} else {
-			fmt.Fprintf(cmd.OutOrStdout(), "Created profile %q\n", profileName)
-		}
-		return nil
+	active := cfg.CurrentProfile == profileName
+	message := fmt.Sprintf("Created profile %q", profileName)
+	if active {
+		message = fmt.Sprintf("Created and selected profile %q", profileName)
 	}
-
-	result := map[string]any{
-		"status":  "created",
-		"profile": profileName,
-		"api_url": apiURL,
-		"auth":    "api_key",
-		"active":  cfg.CurrentProfile == profileName,
-	}
-	if workspaceID != "" {
-		result["workspace_id"] = workspaceID
-	}
-	enc := json.NewEncoder(cmd.OutOrStdout())
-	enc.SetIndent("", "  ")
-	return enc.Encode(result)
+	return profileCreateResult{
+		Status:      "created",
+		Profile:     profileName,
+		APIURL:      apiURL,
+		WorkspaceID: workspaceID,
+		Auth:        "api_key",
+		Active:      active,
+		Message:     message,
+	}, nil
 }
 
 func profileCreateAPIKey() string {
@@ -200,14 +245,14 @@ func profileCreateAPIURL() string {
 	return client.NormalizeURL(apiURL)
 }
 
-func runProfileShow(cmd *cobra.Command, profileName string) error {
+func runProfileShow(profileName string) (profileShowItem, error) {
 	cfg, err := lsconfig.Load()
 	if err != nil {
-		return err
+		return profileShowItem{}, err
 	}
 	profile, ok := cfg.Profiles[profileName]
 	if !ok {
-		return fmt.Errorf("profile %q not found", profileName)
+		return profileShowItem{}, fmt.Errorf("profile %q not found", profileName)
 	}
 
 	activeName := cfg.ResolveProfileName(flagProfile, profileEnvName())
@@ -223,72 +268,56 @@ func runProfileShow(cmd *cobra.Command, profileName string) error {
 		item.APIKey = lsconfig.MaskSecret(profile.APIKey)
 	}
 
-	if GetFormat() == "pretty" {
-		renderProfileShowTable(cmd, item)
-		return nil
-	}
-	enc := json.NewEncoder(cmd.OutOrStdout())
-	enc.SetIndent("", "  ")
-	return enc.Encode(item)
+	return item, nil
 }
 
-func runProfileDelete(cmd *cobra.Command, profileName string) error {
+func runProfileDelete(profileName string) (profileStatusResult, error) {
 	cfg, err := lsconfig.Load()
 	if err != nil {
-		return err
+		return profileStatusResult{}, err
 	}
 	if _, ok := cfg.Profiles[profileName]; !ok {
-		return fmt.Errorf("profile %q not found", profileName)
+		return profileStatusResult{}, fmt.Errorf("profile %q not found", profileName)
 	}
 	delete(cfg.Profiles, profileName)
 	if cfg.CurrentProfile == profileName {
 		cfg.CurrentProfile = ""
 	}
 	if err := cfg.Save(); err != nil {
-		return err
+		return profileStatusResult{}, err
 	}
 
-	if GetFormat() == "pretty" {
-		fmt.Fprintf(cmd.OutOrStdout(), "Deleted profile %q\n", profileName)
-		return nil
-	}
-	enc := json.NewEncoder(cmd.OutOrStdout())
-	enc.SetIndent("", "  ")
-	return enc.Encode(map[string]string{
-		"status":  "deleted",
-		"profile": profileName,
-	})
+	return profileStatusResult{
+		Status:  "deleted",
+		Profile: profileName,
+		Message: fmt.Sprintf("Deleted profile %q", profileName),
+	}, nil
 }
 
-func runProfileUse(cmd *cobra.Command, profileName string) error {
+func runProfileUse(profileName string) (profileStatusResult, error) {
 	cfg, err := lsconfig.Load()
 	if err != nil {
-		return err
+		return profileStatusResult{}, err
 	}
 	if _, ok := cfg.Profiles[profileName]; !ok {
-		return fmt.Errorf("profile %q not found", profileName)
+		return profileStatusResult{}, fmt.Errorf("profile %q not found", profileName)
 	}
 	cfg.CurrentProfile = profileName
 	if err := cfg.Save(); err != nil {
-		return err
+		return profileStatusResult{}, err
 	}
 
-	if GetFormat() == "pretty" {
-		fmt.Fprintf(cmd.OutOrStdout(), "Using profile %q\n", profileName)
-		return nil
-	}
-	enc := json.NewEncoder(cmd.OutOrStdout())
-	enc.SetIndent("", "  ")
-	return enc.Encode(map[string]string{
-		"status":  "switched",
-		"profile": profileName,
-	})
+	return profileStatusResult{
+		Status:  "switched",
+		Profile: profileName,
+		Message: fmt.Sprintf("Using profile %q", profileName),
+	}, nil
 }
 
-func runProfileList(cmd *cobra.Command) error {
+func runProfileList() ([]profileListItem, error) {
 	cfg, err := lsconfig.Load()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	activeName := cfg.ResolveProfileName(flagProfile, profileEnvName())
@@ -310,13 +339,7 @@ func runProfileList(cmd *cobra.Command) error {
 		return items[i].Name < items[j].Name
 	})
 
-	if GetFormat() == "pretty" {
-		renderProfileTable(cmd, items)
-		return nil
-	}
-	enc := json.NewEncoder(cmd.OutOrStdout())
-	enc.SetIndent("", "  ")
-	return enc.Encode(items)
+	return items, nil
 }
 
 func profileAuthType(profile lsconfig.Profile) string {
@@ -334,60 +357,13 @@ func profileEnvName() string {
 	return strings.TrimSpace(os.Getenv("LANGSMITH_PROFILE"))
 }
 
-func renderProfileTable(cmd *cobra.Command, profiles []profileListItem) {
-	table := tablewriter.NewWriter(cmd.OutOrStdout())
-	table.SetHeader([]string{"Active", "Name", "API URL", "Workspace ID", "Auth", "Expires At"})
-	table.SetBorder(false)
-	table.SetColumnSeparator("  ")
-	table.SetHeaderLine(true)
-	table.SetAutoWrapText(false)
-	for _, profile := range profiles {
-		active := ""
-		if profile.Active {
-			active = "*"
-		}
-		table.Append([]string{
-			active,
-			profile.Name,
-			profile.APIURL,
-			profile.WorkspaceID,
-			profile.Auth,
-			profile.OAuthExpiresAt,
-		})
-	}
-	table.Render()
-}
-
-func renderProfileShowTable(cmd *cobra.Command, profile profileShowItem) {
-	table := tablewriter.NewWriter(cmd.OutOrStdout())
-	table.SetHeader([]string{"Active", "Name", "API URL", "Workspace ID", "Auth", "API Key", "Expires At"})
-	table.SetBorder(false)
-	table.SetColumnSeparator("  ")
-	table.SetHeaderLine(true)
-	table.SetAutoWrapText(false)
-	active := ""
-	if profile.Active {
-		active = "*"
-	}
-	table.Append([]string{
-		active,
-		profile.Name,
-		profile.APIURL,
-		profile.WorkspaceID,
-		profile.Auth,
-		profile.APIKey,
-		profile.OAuthExpiresAt,
-	})
-	table.Render()
-}
-
-func runProfileSetWorkspace(cmd *cobra.Command, workspaceID string) error {
+func runProfileSetWorkspace(workspaceID string) (profileStatusResult, error) {
 	if err := validateWorkspaceID(workspaceID); err != nil {
-		return err
+		return profileStatusResult{}, err
 	}
 	cfg, err := lsconfig.Load()
 	if err != nil {
-		return err
+		return profileStatusResult{}, err
 	}
 	if cfg.Profiles == nil {
 		cfg.Profiles = make(map[string]lsconfig.Profile)
@@ -395,7 +371,7 @@ func runProfileSetWorkspace(cmd *cobra.Command, workspaceID string) error {
 
 	profileName := loginProfileName(cfg)
 	if err := validateProfileName(profileName); err != nil {
-		return err
+		return profileStatusResult{}, err
 	}
 	profile := cfg.Profiles[profileName]
 	profile.WorkspaceID = workspaceID
@@ -404,18 +380,13 @@ func runProfileSetWorkspace(cmd *cobra.Command, workspaceID string) error {
 		cfg.CurrentProfile = profileName
 	}
 	if err := cfg.Save(); err != nil {
-		return err
+		return profileStatusResult{}, err
 	}
 
-	if GetFormat() == "pretty" {
-		fmt.Fprintf(cmd.OutOrStdout(), "Set default workspace for profile %q\n", profileName)
-		return nil
-	}
-	enc := json.NewEncoder(cmd.OutOrStdout())
-	enc.SetIndent("", "  ")
-	return enc.Encode(map[string]string{
-		"status":       "workspace_set",
-		"profile":      profileName,
-		"workspace_id": workspaceID,
-	})
+	return profileStatusResult{
+		Status:      "workspace_set",
+		Profile:     profileName,
+		WorkspaceID: workspaceID,
+		Message:     fmt.Sprintf("Set default workspace for profile %q", profileName),
+	}, nil
 }

--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -143,8 +143,7 @@ VCPUs:    {{formatCount .Vcpus}}
 Memory:   {{formatBytesOrDash .MemBytes}}
 Rootfs:   {{formatBytesOrDash .FsCapacityBytes}}
 Snapshot: {{shortID .SnapshotID}}
-Created:  {{formatTime .CreatedAt}}
-`),
+Created:  {{formatTime .CreatedAt}}`),
 }
 
 var sandboxListCommand = structured.Command[struct{}]{
@@ -200,8 +199,7 @@ VCPUs:    {{formatCount .Vcpus}}
 Memory:   {{formatBytesOrDash .MemBytes}}
 Rootfs:   {{formatBytesOrDash .FsCapacityBytes}}
 Snapshot: {{shortID .SnapshotID}}
-Created:  {{formatTime .CreatedAt}}
-`),
+Created:  {{formatTime .CreatedAt}}`),
 }
 
 type sandboxUpdateInput struct {
@@ -279,8 +277,7 @@ VCPUs:    {{formatCount .Vcpus}}
 Memory:   {{formatBytesOrDash .MemBytes}}
 Rootfs:   {{formatBytesOrDash .FsCapacityBytes}}
 Snapshot: {{shortID .SnapshotID}}
-Created:  {{formatTime .CreatedAt}}
-`),
+Created:  {{formatTime .CreatedAt}}`),
 }
 
 var sandboxDeleteCommand = structured.Command[struct{}]{
@@ -299,8 +296,7 @@ var sandboxDeleteCommand = structured.Command[struct{}]{
 
 		return sandboxMessage{Name: args[0], Message: "Sandbox deleted."}, nil
 	},
-	Render: structured.Template(`{{.Message}}
-`),
+	Render: structured.Template(`{{.Message}}`),
 }
 
 var sandboxStartCommand = structured.Command[struct{}]{
@@ -322,8 +318,7 @@ var sandboxStartCommand = structured.Command[struct{}]{
 		}
 		return sandboxMessage{Name: args[0], Message: fmt.Sprintf("Sandbox %s started", args[0])}, nil
 	},
-	Render: structured.Template(`{{.Message}}
-`),
+	Render: structured.Template(`{{.Message}}`),
 }
 
 var sandboxStopCommand = structured.Command[struct{}]{
@@ -342,8 +337,7 @@ var sandboxStopCommand = structured.Command[struct{}]{
 
 		return sandboxMessage{Name: args[0], Message: "Sandbox stopped."}, nil
 	},
-	Render: structured.Template(`{{.Message}}
-`),
+	Render: structured.Template(`{{.Message}}`),
 }
 
 func newSandboxExecCmd() *cobra.Command {

--- a/internal/cmd/sandbox_snapshot.go
+++ b/internal/cmd/sandbox_snapshot.go
@@ -125,8 +125,7 @@ Name:    {{.Name}}
 Image:   {{dash .DockerImage}}
 Status:  {{.Status}}
 Size:    {{formatBytesOrDash .FsUsedBytes}}
-Created: {{formatTime .CreatedAt}}
-`),
+Created: {{formatTime .CreatedAt}}`),
 }
 
 type snapshotCaptureInput struct {
@@ -181,8 +180,7 @@ Name:    {{.Name}}
 Image:   {{dash .DockerImage}}
 Status:  {{.Status}}
 Size:    {{formatBytesOrDash .FsUsedBytes}}
-Created: {{formatTime .CreatedAt}}
-`),
+Created: {{formatTime .CreatedAt}}`),
 }
 
 var snapshotGetCommand = structured.Command[struct{}]{
@@ -207,8 +205,7 @@ Name:    {{.Name}}
 Image:   {{dash .DockerImage}}
 Status:  {{.Status}}
 Size:    {{formatBytesOrDash .FsUsedBytes}}
-Created: {{formatTime .CreatedAt}}
-`),
+Created: {{formatTime .CreatedAt}}`),
 }
 
 var snapshotDeleteCommand = structured.Command[struct{}]{
@@ -227,8 +224,7 @@ var snapshotDeleteCommand = structured.Command[struct{}]{
 
 		return sandboxMessage{Name: args[0], Message: "Snapshot deleted."}, nil
 	},
-	Render: structured.Template(`{{.Message}}
-`),
+	Render: structured.Template(`{{.Message}}`),
 }
 
 func parseByteSize(s string) (int64, error) {

--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -62,7 +62,17 @@ func newWorkspaceSetDefaultCmd() *cobra.Command {
 		Short: "Set the default workspace for the selected profile",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runProfileSetWorkspace(cmd, args[0])
+			result, err := runProfileSetWorkspace(args[0])
+			if err != nil {
+				return err
+			}
+			if GetFormat() == "pretty" {
+				fmt.Fprintln(cmd.OutOrStdout(), result.Message)
+				return nil
+			}
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(result)
 		},
 	}
 }

--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
 	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -62,9 +63,37 @@ func newWorkspaceSetDefaultCmd() *cobra.Command {
 		Short: "Set the default workspace for the selected profile",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			result, err := runProfileSetWorkspace(args[0])
+			workspaceID := args[0]
+			if err := validateWorkspaceID(workspaceID); err != nil {
+				return err
+			}
+			cfg, err := lsconfig.Load()
 			if err != nil {
 				return err
+			}
+			if cfg.Profiles == nil {
+				cfg.Profiles = make(map[string]lsconfig.Profile)
+			}
+
+			profileName := loginProfileName(cfg)
+			if err := validateProfileName(profileName); err != nil {
+				return err
+			}
+			profile := cfg.Profiles[profileName]
+			profile.WorkspaceID = workspaceID
+			cfg.Profiles[profileName] = profile
+			if cfg.CurrentProfile == "" {
+				cfg.CurrentProfile = profileName
+			}
+			if err := cfg.Save(); err != nil {
+				return err
+			}
+
+			result := profileStatusResult{
+				Status:      "workspace_set",
+				Profile:     profileName,
+				WorkspaceID: workspaceID,
+				Message:     fmt.Sprintf("Set default workspace for profile %q", profileName),
 			}
 			if GetFormat() == "pretty" {
 				fmt.Fprintln(cmd.OutOrStdout(), result.Message)

--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
 	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -63,37 +62,9 @@ func newWorkspaceSetDefaultCmd() *cobra.Command {
 		Short: "Set the default workspace for the selected profile",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			workspaceID := args[0]
-			if err := validateWorkspaceID(workspaceID); err != nil {
-				return err
-			}
-			cfg, err := lsconfig.Load()
+			result, err := runProfileSetWorkspace(args[0])
 			if err != nil {
 				return err
-			}
-			if cfg.Profiles == nil {
-				cfg.Profiles = make(map[string]lsconfig.Profile)
-			}
-
-			profileName := loginProfileName(cfg)
-			if err := validateProfileName(profileName); err != nil {
-				return err
-			}
-			profile := cfg.Profiles[profileName]
-			profile.WorkspaceID = workspaceID
-			cfg.Profiles[profileName] = profile
-			if cfg.CurrentProfile == "" {
-				cfg.CurrentProfile = profileName
-			}
-			if err := cfg.Save(); err != nil {
-				return err
-			}
-
-			result := profileStatusResult{
-				Status:      "workspace_set",
-				Profile:     profileName,
-				WorkspaceID: workspaceID,
-				Message:     fmt.Sprintf("Set default workspace for profile %q", profileName),
 			}
 			if GetFormat() == "pretty" {
 				fmt.Fprintln(cmd.OutOrStdout(), result.Message)

--- a/internal/structured/command.go
+++ b/internal/structured/command.go
@@ -7,22 +7,24 @@ import (
 )
 
 type Command[I any] struct {
-	Use    string
-	Short  string
-	Long   string
-	Args   cobra.PositionalArgs
-	Input  func(*cobra.Command) I
-	Action func(context.Context, *cobra.Command, I, []string) (any, error)
-	Render Spec
+	Use     string
+	Aliases []string
+	Short   string
+	Long    string
+	Args    cobra.PositionalArgs
+	Input   func(*cobra.Command) I
+	Action  func(context.Context, *cobra.Command, I, []string) (any, error)
+	Render  Spec
 }
 
 func (c Command[I]) Cobra() *cobra.Command {
 	var input I
 	cmd := &cobra.Command{
-		Use:   c.Use,
-		Short: c.Short,
-		Long:  c.Long,
-		Args:  c.Args,
+		Use:     c.Use,
+		Aliases: c.Aliases,
+		Short:   c.Short,
+		Long:    c.Long,
+		Args:    c.Args,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			result, err := c.Action(cmd.Context(), cmd, input, args)
 			if err != nil {

--- a/internal/structured/specs.go
+++ b/internal/structured/specs.go
@@ -171,7 +171,7 @@ func resolveRows(model any, path string) ([]any, error) {
 		return nil, nil
 	}
 	if value.Kind() != reflect.Slice && value.Kind() != reflect.Array {
-		return nil, fmt.Errorf("rows path %q resolved to %s, want slice or array", path, value.Kind())
+		return []any{value.Interface()}, nil
 	}
 
 	rows := make([]any, 0, value.Len())

--- a/internal/structured/specs.go
+++ b/internal/structured/specs.go
@@ -18,7 +18,17 @@ func (s Template) RenderText(w io.Writer, model any) error {
 	if err != nil {
 		return err
 	}
-	return tmpl.Execute(w, model)
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, model); err != nil {
+		return err
+	}
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		return err
+	}
+	if !strings.HasSuffix(buf.String(), "\n") {
+		_, err = fmt.Fprintln(w)
+	}
+	return err
 }
 
 type PropertyList struct {

--- a/internal/structured/structured_test.go
+++ b/internal/structured/structured_test.go
@@ -35,7 +35,17 @@ func TestTemplateRenderText(t *testing.T) {
 	err := Render(cmd, struct{ Name string }{Name: "sandbox"}, Template(`Name: {{.Name}}`))
 
 	require.NoError(t, err)
-	require.Equal(t, "Name: sandbox", out.String())
+	require.Equal(t, "Name: sandbox\n", out.String())
+}
+
+func TestTemplateRenderTextDoesNotDoubleNewline(t *testing.T) {
+	var out bytes.Buffer
+	cmd := testCmd("pretty", &out)
+
+	err := Render(cmd, struct{ Name string }{Name: "sandbox"}, Template("Name: {{.Name}}\n"))
+
+	require.NoError(t, err)
+	require.Equal(t, "Name: sandbox\n", out.String())
 }
 
 func TestPropertyListRenderText(t *testing.T) {

--- a/internal/structured/structured_test.go
+++ b/internal/structured/structured_test.go
@@ -141,6 +141,25 @@ func TestTableRenderText(t *testing.T) {
 	require.False(t, strings.Contains(got, "{{"))
 }
 
+func TestTableRenderTextSingleRow(t *testing.T) {
+	var out bytes.Buffer
+	cmd := testCmd("pretty", &out)
+
+	err := Render(cmd, struct {
+		Name string
+	}{
+		Name: "default",
+	}, Table{
+		Rows: ".",
+		Columns: []Column{
+			{Header: "Name", Template: "{{.Name}}"},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "default")
+}
+
 func TestTableRenderTextMissingRowsPath(t *testing.T) {
 	var out bytes.Buffer
 	cmd := testCmd("pretty", &out)


### PR DESCRIPTION
## Summary
- Convert auth login and all profile subcommands to the structured command framework
- Add structured command alias support for profile ls
- Allow structured tables to render a single object for profile show while preserving object-shaped JSON

## Test Plan
- [x] go test ./internal/cmd -run 'Test(Auth|Profile)'
- [x] go test ./internal/structured
- [x] deslop internal/structured/command.go internal/structured/specs.go internal/structured/structured_test.go internal/cmd/login.go internal/cmd/profile.go internal/cmd/workspace.go

Note: go test ./... still fails in existing TestTraceMessages_FeedbackStats because it emits "No traces found." where JSON is expected.