### PR TITLE
fix: let server choose sandbox resource defaults

### DIFF
--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -83,10 +83,7 @@ Examples:
   langsmith sandbox create my-vm --snapshot-id <id> --proxy-config @proxy.json`,
 	Args: cobra.ExactArgs(1),
 	Input: func(cmd *cobra.Command) *sandboxCreateInput {
-		in := &sandboxCreateInput{
-			VCPUs:  2,
-			Memory: "512mb",
-		}
+		in := &sandboxCreateInput{}
 		cmd.Flags().StringVar(&in.SnapshotID, "snapshot-id", in.SnapshotID, "Snapshot ID to boot from (required)")
 		cmd.Flags().IntVar(&in.VCPUs, "vcpus", in.VCPUs, "Number of vCPUs")
 		cmd.Flags().StringVar(&in.Memory, "memory", in.Memory, "Memory with unit (e.g. 512mb, 1gb)")
@@ -105,16 +102,19 @@ Examples:
 			return nil, err
 		}
 
-		memBytes, err := parseByteSize(in.Memory)
-		if err != nil {
-			return nil, fmt.Errorf("invalid --memory: %w", err)
-		}
-
 		params := langsmith.SandboxBoxNewParams{
 			Name:       langsmith.F(name),
 			SnapshotID: langsmith.F(in.SnapshotID),
-			Vcpus:      langsmith.F(int64(in.VCPUs)),
-			MemBytes:   langsmith.F(memBytes),
+		}
+		if cmd.Flags().Changed("vcpus") {
+			params.Vcpus = langsmith.F(int64(in.VCPUs))
+		}
+		if cmd.Flags().Changed("memory") {
+			memBytes, err := parseByteSize(in.Memory)
+			if err != nil {
+				return nil, fmt.Errorf("invalid --memory: %w", err)
+			}
+			params.MemBytes = langsmith.F(memBytes)
 		}
 		if in.RootFS != "" {
 			rootfsBytes, err := parseByteSize(in.RootFS)

--- a/internal/cmd/sandbox_test.go
+++ b/internal/cmd/sandbox_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // ==================== parseByteSize ====================
@@ -182,6 +184,18 @@ func TestSandboxCreateCmd_SizeFlags(t *testing.T) {
 			t.Errorf("flag --%s not found", name)
 		}
 	}
+}
+
+func TestSandboxCreateCmd_ResourceFlagsDefaultToServerSelected(t *testing.T) {
+	cmd := sandboxCreateCommand.Cobra()
+
+	vcpus := cmd.Flags().Lookup("vcpus")
+	require.NotNil(t, vcpus)
+	require.Equal(t, "0", vcpus.DefValue)
+
+	memory := cmd.Flags().Lookup("memory")
+	require.NotNil(t, memory)
+	require.Empty(t, memory.DefValue)
 }
 
 func TestSandboxUpdateCmd_SizeFlags(t *testing.T) {


### PR DESCRIPTION
## Summary

Remove the CLI-side default vCPU and memory values from `langsmith sandbox create` so omitted resource flags are left unset and the server selects defaults.

## Test Plan

- [x] `go test ./internal/cmd -run 'TestSandboxCreateCmd|TestSandboxUpdateCmd|TestParseByteSize'`
- [x] `deslop internal/cmd/sandbox_box.go internal/cmd/sandbox_test.go`
- [x] `git diff --check`

Note: `go test ./internal/cmd` currently fails at `TestTraceMessages_FeedbackStats` with `invalid JSON output: invalid character 'N' looking for beginning of value` from `No traces found.`