### PR TITLE
fix: warn when env API key overrides profile

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -169,6 +169,9 @@ func resolveClientOptions(refreshOAuth bool) (client.Options, error) {
 	case flagAPIKey != "":
 		opts.APIKey = flagAPIKey
 	case os.Getenv("LANGSMITH_API_KEY") != "":
+		if flagProfile != "" {
+			fmt.Fprintln(os.Stderr, "warning: --profile was specified, but LANGSMITH_API_KEY is set and takes precedence over saved profile auth")
+		}
 		opts.APIKey = os.Getenv("LANGSMITH_API_KEY")
 	case hasProfile && (profile.AccessToken() != "" || (refreshOAuth && profile.OAuth.RefreshToken != "")):
 		if refreshOAuth && profile.OAuth.RefreshToken != "" &&

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -50,6 +50,16 @@ func getFlagString(cmd *cobra.Command, name string) string {
 	return ""
 }
 
+func isFlagChanged(cmd *cobra.Command, name string) bool {
+	if f := cmd.Flags().Lookup(name); f != nil {
+		return f.Changed
+	}
+	if f := cmd.PersistentFlags().Lookup(name); f != nil {
+		return f.Changed
+	}
+	return false
+}
+
 // ResolveAPIKey reads the API key from cobra's flag tree → env.
 func ResolveAPIKey(cmd *cobra.Command) string {
 	if v := getFlagString(cmd, "api-key"); v != "" {
@@ -147,6 +157,9 @@ func ResolveClientOptions(cmd *cobra.Command, refreshOAuth bool) (client.Options
 	case getFlagString(cmd, "api-key") != "":
 		opts.APIKey = getFlagString(cmd, "api-key")
 	case os.Getenv("LANGSMITH_API_KEY") != "":
+		if isFlagChanged(cmd, "profile") {
+			fmt.Fprintln(cmd.ErrOrStderr(), "warning: --profile was specified, but LANGSMITH_API_KEY is set and takes precedence over saved profile auth")
+		}
 		opts.APIKey = os.Getenv("LANGSMITH_API_KEY")
 	case hasProfile && (profile.AccessToken() != "" || (refreshOAuth && profile.OAuth.RefreshToken != "")):
 		if refreshOAuth && profile.OAuth.RefreshToken != "" &&

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -1,6 +1,7 @@
 package cmdutil
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -233,6 +234,35 @@ func TestResolveClientOptions_EnvAPIKeyOverridesProfileBearer(t *testing.T) {
 	if opts.ProfileName != "" {
 		t.Fatalf("expected profile name to be ignored when API key auth wins, got %q", opts.ProfileName)
 	}
+}
+
+func TestResolveClientOptions_ProfileFlagWarnsWhenEnvAPIKeyOverrides(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "from-env")
+	err := os.WriteFile(path, []byte(`{
+  "profiles": {
+    "prod": {
+      "oauth": {
+        "access_token": "test-access-token"
+      }
+    }
+  }
+}
+`), 0600)
+	require.NoError(t, err)
+
+	cmd := newTestCmd()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	err = cmd.PersistentFlags().Set("profile", "prod")
+	require.NoError(t, err)
+
+	opts, err := ResolveClientOptions(cmd, false)
+	require.NoError(t, err)
+	require.Equal(t, "from-env", opts.APIKey)
+	require.Empty(t, opts.OAuthAccessToken)
+	require.Contains(t, stderr.String(), "warning: --profile was specified, but LANGSMITH_API_KEY is set")
 }
 
 func TestResolveClientOptionsRefreshesProfileWithoutAccessToken(t *testing.T) {


### PR DESCRIPTION
## Summary

Warn to stderr when --profile is explicitly specified but LANGSMITH_API_KEY is set and wins auth precedence.

## Test Plan

- [x] go test ./internal/cmdutil ./internal/cmd