### PR TITLE
feat(issues): add examples propose subcommand [LSEN-119]

### DIFF
--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -53,6 +53,7 @@ Examples:
 	cmd.AddCommand(newProjectIssuesEventsCmd())
 	cmd.AddCommand(newProjectIssuesUpdateCmd())
 	cmd.AddCommand(newProjectIssuesRunsCmd())
+	cmd.AddCommand(newProjectIssuesExamplesCmd())
 	return cmd
 }
 
@@ -539,5 +540,122 @@ func newProjectIssuesRunsRemoveCmd() *cobra.Command {
 		},
 	}
 
+	return cmd
+}
+
+func newProjectIssuesExamplesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "examples",
+		Short: "Manage regression examples for an issue",
+		Long: `Propose regression examples for an issue.
+
+Examples:
+  langsmith project issues examples propose <issue-id> --run-id <run-id> --assertion correctness="Response must be factually correct"
+  langsmith project issues examples propose <issue-id> --run-id <run-id> --assertion correctness="Must be correct" --assertion format="Output must be JSON"`,
+	}
+
+	cmd.AddCommand(newProjectIssuesProposeExampleCmd())
+	return cmd
+}
+
+// exampleAssertion is a single key=comment assertion for a proposed regression example.
+type exampleAssertion struct {
+	Key     string `json:"key"`
+	Comment string `json:"comment"`
+}
+
+// parseAssertion parses a "key=comment" string into an exampleAssertion.
+// The first '=' is the delimiter; the comment may contain '=' characters.
+func parseAssertion(s string) (exampleAssertion, error) {
+	idx := strings.IndexByte(s, '=')
+	if idx < 1 {
+		return exampleAssertion{}, fmt.Errorf("assertion %q must be in key=comment format", s)
+	}
+	key := strings.TrimSpace(s[:idx])
+	comment := strings.TrimSpace(s[idx+1:])
+	if key == "" {
+		return exampleAssertion{}, fmt.Errorf("assertion key cannot be empty in %q", s)
+	}
+	if comment == "" {
+		return exampleAssertion{}, fmt.Errorf("assertion comment cannot be empty in %q", s)
+	}
+	return exampleAssertion{Key: key, Comment: comment}, nil
+}
+
+func newProjectIssuesProposeExampleCmd() *cobra.Command {
+	var (
+		runID      string
+		assertions []string
+		outputFile string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "propose <issue-id>",
+		Short: "Propose a regression example for an issue",
+		Long: `Propose a run as a regression example for an issue, with assertions that
+the run should satisfy. The issues agent uses these to generate evaluators
+and test cases for the issue.
+
+Each --assertion flag takes a key=comment pair. The key is a short identifier
+for the assertion (e.g. "correctness"), and the comment describes what the run
+should demonstrate. You may specify up to 10 assertions; keys must be unique.
+
+Examples:
+  langsmith project issues examples propose <issue-id> \
+    --run-id <run-id> \
+    --assertion correctness="Response must be factually correct"
+
+  langsmith project issues examples propose <issue-id> \
+    --run-id <run-id> \
+    --assertion correctness="Must cite sources" \
+    --assertion format="Output must be valid JSON"`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			issueID := args[0]
+			if runID == "" {
+				ExitError("--run-id is required")
+			}
+			if len(assertions) == 0 {
+				ExitError("at least one --assertion is required")
+			}
+			if len(assertions) > 10 {
+				ExitError("at most 10 assertions are allowed")
+			}
+
+			parsed := make([]exampleAssertion, 0, len(assertions))
+			seen := make(map[string]bool, len(assertions))
+			for _, raw := range assertions {
+				a, err := parseAssertion(raw)
+				if err != nil {
+					ExitErrorf("invalid assertion: %v", err)
+				}
+				if seen[a.Key] {
+					ExitErrorf("duplicate assertion key %q", a.Key)
+				}
+				seen[a.Key] = true
+				parsed = append(parsed, a)
+			}
+
+			c := MustGetClient()
+			ctx := context.Background()
+
+			body := map[string]any{
+				"run_id":     runID,
+				"assertions": parsed,
+			}
+
+			path := fmt.Sprintf("/v1/platform/issues/%s/proposed-examples", issueID)
+			var result map[string]any
+			if err := c.RawPost(ctx, path, body, &result); err != nil {
+				ExitErrorf("proposing example: %v", err)
+			}
+
+			output.OutputJSON(result, outputFile)
+		},
+	}
+
+	cmd.Flags().StringVar(&runID, "run-id", "", "Run ID to propose as a regression example (required)")
+	cmd.Flags().StringArrayVar(&assertions, "assertion", nil, `Assertion in key=comment format. May be repeated up to 10 times.`)
+	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 	return cmd
 }

--- a/internal/cmd/issues_test.go
+++ b/internal/cmd/issues_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"testing"
+)
+
+// ==================== Command structure ====================
+
+func TestProjectIssuesCmd_Subcommands(t *testing.T) {
+	cmd := newProjectIssuesCmd()
+	expected := map[string]bool{
+		"list":     false,
+		"events":   false,
+		"update":   false,
+		"runs":     false,
+		"examples": false,
+	}
+	for _, sub := range cmd.Commands() {
+		if _, ok := expected[sub.Name()]; ok {
+			expected[sub.Name()] = true
+		}
+	}
+	for name, found := range expected {
+		if !found {
+			t.Errorf("issues missing subcommand %q", name)
+		}
+	}
+}
+
+func TestProjectIssuesExamplesCmd_Subcommands(t *testing.T) {
+	cmd := newProjectIssuesExamplesCmd()
+	expected := map[string]bool{"propose": false}
+	for _, sub := range cmd.Commands() {
+		if _, ok := expected[sub.Name()]; ok {
+			expected[sub.Name()] = true
+		}
+	}
+	for name, found := range expected {
+		if !found {
+			t.Errorf("examples missing subcommand %q", name)
+		}
+	}
+}
+
+func TestProjectIssuesProposeExampleCmd_UseField(t *testing.T) {
+	cmd := newProjectIssuesProposeExampleCmd()
+	if cmd.Use != "propose <issue-id>" {
+		t.Errorf("expected Use=%q, got %q", "propose <issue-id>", cmd.Use)
+	}
+}
+
+// ==================== Propose example flags ====================
+
+func TestProjectIssuesProposeExampleCmd_Flags(t *testing.T) {
+	cmd := newProjectIssuesProposeExampleCmd()
+	tests := []struct {
+		name   string
+		defVal string
+	}{
+		{"run-id", ""},
+		{"output", ""},
+	}
+	for _, tc := range tests {
+		f := cmd.Flags().Lookup(tc.name)
+		if f == nil {
+			t.Errorf("flag --%s not found", tc.name)
+			continue
+		}
+		if f.DefValue != tc.defVal {
+			t.Errorf("flag --%s: expected default %q, got %q", tc.name, tc.defVal, f.DefValue)
+		}
+	}
+	// --assertion is a StringArray; default is "[]"
+	f := cmd.Flags().Lookup("assertion")
+	if f == nil {
+		t.Error("flag --assertion not found")
+	}
+}
+
+// ==================== parseAssertion ====================
+
+func TestParseAssertion_Valid(t *testing.T) {
+	cases := []struct {
+		input   string
+		wantKey string
+		wantCmt string
+	}{
+		{"correctness=Response must cite sources", "correctness", "Response must cite sources"},
+		{"format=Output must be valid JSON", "format", "Output must be valid JSON"},
+		// comment may itself contain '='
+		{"eq=a=b is valid", "eq", "a=b is valid"},
+		// whitespace is trimmed
+		{"  key  =  comment here  ", "key", "comment here"},
+	}
+	for _, tc := range cases {
+		a, err := parseAssertion(tc.input)
+		if err != nil {
+			t.Errorf("parseAssertion(%q): unexpected error: %v", tc.input, err)
+			continue
+		}
+		if a.Key != tc.wantKey {
+			t.Errorf("parseAssertion(%q): key=%q, want %q", tc.input, a.Key, tc.wantKey)
+		}
+		if a.Comment != tc.wantCmt {
+			t.Errorf("parseAssertion(%q): comment=%q, want %q", tc.input, a.Comment, tc.wantCmt)
+		}
+	}
+}
+
+func TestParseAssertion_Invalid(t *testing.T) {
+	cases := []struct {
+		input string
+		desc  string
+	}{
+		{"no-equals", "missing '='"},
+		{"=no-key", "empty key"},
+		{"key=", "empty comment"},
+		{"  =  ", "both empty after trim"},
+	}
+	for _, tc := range cases {
+		_, err := parseAssertion(tc.input)
+		if err == nil {
+			t.Errorf("parseAssertion(%q) [%s]: expected error, got nil", tc.input, tc.desc)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `langsmith project issues examples propose <issue-id>` — a CLI command that proposes a run as a regression example for an issue by calling `POST /v1/platform/issues/{issue_id}/proposed-examples`.

This mirrors the `propose_regression_example` tool from `smith-issues-agent`, making the same operation available to users and automation scripts outside the agent context.

**Usage:**
```
langsmith project issues examples propose <issue-id> \
  --run-id <run-id> \
  --assertion correctness="Response must cite sources" \
  --assertion format="Output must be valid JSON"
```

Each `--assertion` flag takes a `key=comment` pair. Client-side validation enforces:
- At least one assertion required
- At most 10 assertions
- Unique non-empty keys
- Non-empty comments

The body sent to the API is `{"run_id": "...", "assertions": [{"key": "...", "comment": "..."}, ...]}`.

## Test Plan

- [x] 6 unit tests added in `issues_test.go`: command structure, flag presence, `parseAssertion` valid/invalid cases
- [x] `go test ./internal/cmd/` passes (full suite)
- [x] `go build ./...` succeeds

## Release Note

none