### PR TITLE
fix: allow sandbox create without args

### DIFF
--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -68,9 +68,11 @@ func sandboxCreateParams(name string, in *sandboxCreateInput) (langsmith.Sandbox
 	}
 
 	params := langsmith.SandboxBoxNewParams{
-		Name:     langsmith.F(name),
 		Vcpus:    langsmith.F(int64(in.VCPUs)),
 		MemBytes: langsmith.F(memBytes),
+	}
+	if name != "" {
+		params.Name = langsmith.F(name)
 	}
 	if in.SnapshotID != "" {
 		params.SnapshotID = langsmith.F(in.SnapshotID)
@@ -93,7 +95,7 @@ func sandboxCreateParams(name string, in *sandboxCreateInput) (langsmith.Sandbox
 }
 
 var sandboxCreateCommand = structured.Command[*sandboxCreateInput]{
-	Use:   "create <name>",
+	Use:   "create [name]",
 	Short: "Create a sandbox VM",
 	Long: `Create a sandbox VM.
 
@@ -123,12 +125,13 @@ Header types: "plaintext" (literal value), "opaque" (encrypted, hidden in API
 responses), "workspace_secret" (resolved from workspace secrets via {KEY}).
 
 Examples:
+  langsmith sandbox create
   langsmith sandbox create my-vm
   langsmith sandbox create my-vm --snapshot-id <id>
   langsmith sandbox create my-vm --snapshot-id <id> --vcpus 4 --memory 1gb
   langsmith sandbox create my-vm --snapshot-id <id> --rootfs-capacity 8gb
   langsmith sandbox create my-vm --snapshot-id <id> --proxy-config @proxy.json`,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	Input: func(cmd *cobra.Command) *sandboxCreateInput {
 		in := &sandboxCreateInput{
 			VCPUs:  2,
@@ -142,7 +145,10 @@ Examples:
 		return in
 	},
 	Action: func(ctx context.Context, cmd *cobra.Command, in *sandboxCreateInput, args []string) (any, error) {
-		name := args[0]
+		name := ""
+		if len(args) > 0 {
+			name = args[0]
+		}
 
 		c, err := cmdutil.GetClient(cmd)
 		if err != nil {

--- a/internal/cmd/sandbox_test.go
+++ b/internal/cmd/sandbox_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -125,13 +126,35 @@ func TestSandboxCreateCmd_PositionalName(t *testing.T) {
 	if cmd.Args == nil {
 		t.Fatal("expected Args validator")
 	}
-	// Should require exactly 1 arg
-	if err := cmd.Args(cmd, []string{}); err == nil {
-		t.Error("expected error with 0 args")
+	if err := cmd.Args(cmd, []string{}); err != nil {
+		t.Errorf("expected no error with 0 args, got: %v", err)
 	}
 	if err := cmd.Args(cmd, []string{"my-vm"}); err != nil {
 		t.Errorf("expected no error with 1 arg, got: %v", err)
 	}
+	if err := cmd.Args(cmd, []string{"a", "b"}); err == nil {
+		t.Error("expected error with 2 args")
+	}
+}
+
+func TestSandboxCreateCmd_AllowsNoArgs(t *testing.T) {
+	var body map[string]any
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v2/sandboxes/boxes", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"id":"box-id","name":"my-vm","status":"running","vcpus":2,"mem_bytes":536870912}`))
+		require.NoError(t, err)
+	})
+
+	out, err := executeCommand(t, "--api-key", "test-key", "--api-url", ts.URL, "sandbox", "create", "--format", "json")
+
+	require.NoError(t, err)
+	require.NotEmpty(t, out)
+	require.NotContains(t, body, "name")
+	require.NotContains(t, body, "snapshot_id")
 }
 
 func TestSandboxTunnelCmd_PositionalNameOrURL(t *testing.T) {


### PR DESCRIPTION
Allow `langsmith sandbox create` to use server defaults when no name or snapshot is provided.

The command now accepts an optional name, only sends `name` when one is provided, and keeps `snapshot_id` optional.

## Test Plan
- [x] `go test ./internal/cmd -run 'TestSandboxCreateCmd'`
- [x] `go test ./...`
