### PR TITLE
feat: add global workspace flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,14 @@ Optionally set defaults:
 
 ```bash
 export LANGSMITH_ENDPOINT="https://api.smith.langchain.com"  # For self-hosted
+export LANGSMITH_WORKSPACE_ID="<workspace-id>"                # Default workspace
 export LANGSMITH_PROJECT="my-default-project"                 # Default project for queries
 ```
 
 Or pass them as flags:
 
 ```bash
-langsmith --api-key lsv2_pt_... trace list --project my-app
+langsmith --api-key lsv2_pt_... --workspace <workspace-id> trace list --project my-app
 ```
 
 ## Quick Start

--- a/internal/cmd/api/testutil_test.go
+++ b/internal/cmd/api/testutil_test.go
@@ -4,11 +4,13 @@ import "github.com/spf13/cobra"
 
 // newTestRoot wraps the api command under a minimal root that defines the same
 // persistent flags as the real root command. This avoids flag shadowing while
-// allowing tests to pass --api-key, --api-url, and --format.
+// allowing tests to pass global flags.
 func newTestRoot() *cobra.Command {
 	root := &cobra.Command{Use: "langsmith"}
 	root.PersistentFlags().String("api-key", "", "")
 	root.PersistentFlags().String("api-url", "", "")
+	root.PersistentFlags().String("workspace", "", "")
+	root.PersistentFlags().String("workspace-id", "", "")
 	root.PersistentFlags().String("format", "pretty", "")
 	root.AddCommand(NewCmd())
 	return root

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -62,7 +62,6 @@ func newLoginCmd() *cobra.Command {
 	var (
 		noBrowser       bool
 		timeout         time.Duration
-		workspaceID     string
 		promptWorkspace bool
 	)
 
@@ -74,12 +73,11 @@ func newLoginCmd() *cobra.Command {
 The command stores OAuth tokens in ~/.langsmith/config.json under the selected
 profile. Select a profile with --profile or LANGSMITH_PROFILE.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLogin(cmd, noBrowser, timeout, workspaceID, promptWorkspace)
+			return runLogin(cmd, noBrowser, timeout, flagWorkspaceID, promptWorkspace)
 		},
 	}
 	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Do not open a browser automatically")
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "Maximum time to wait for authorization (default: device-code expiry)")
-	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "Workspace ID override to save in the selected profile")
 	cmd.Flags().BoolVar(&promptWorkspace, "prompt-workspace", false, "Prompt to select and save a workspace override")
 	return cmd
 }

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -16,6 +16,13 @@ import (
 	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
 )
 
+func TestLoginDoesNotDefineLocalWorkspaceIDFlag(t *testing.T) {
+	cmd := newLoginCmd()
+	if f := cmd.Flags().Lookup("workspace-id"); f != nil {
+		t.Fatal("auth login should use the inherited workspace flag, not a local --workspace-id flag")
+	}
+}
+
 func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
 	oldKey := flagAPIKey
 	oldURL := flagAPIURL

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -48,18 +48,16 @@ func newProfileCmd() *cobra.Command {
 
 func newProfileCreateCmd() *cobra.Command {
 	var (
-		workspaceID string
-		setCurrent  bool
+		setCurrent bool
 	)
 	cmd := &cobra.Command{
 		Use:   "create NAME",
 		Short: "Create an API-key profile",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runProfileCreate(cmd, args[0], workspaceID, setCurrent)
+			return runProfileCreate(cmd, args[0], flagWorkspaceID, setCurrent)
 		},
 	}
-	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "Default workspace ID to save in the profile")
 	cmd.Flags().BoolVar(&setCurrent, "set-current", false, "Set the new profile as the current profile")
 	return cmd
 }

--- a/internal/cmd/profile_test.go
+++ b/internal/cmd/profile_test.go
@@ -84,6 +84,13 @@ func TestProfileCreate(t *testing.T) {
 	}
 }
 
+func TestProfileCreateDoesNotDefineLocalWorkspaceIDFlag(t *testing.T) {
+	cmd := newProfileCreateCmd()
+	if f := cmd.Flags().Lookup("workspace-id"); f != nil {
+		t.Fatal("profile create should use the inherited workspace flag, not a local --workspace-id flag")
+	}
+}
+
 func TestProfileCreateUsesEnvAPIKeyAndEndpoint(t *testing.T) {
 	oldKey := flagAPIKey
 	oldURL := flagAPIURL

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -18,6 +18,7 @@ var (
 	flagAPIKey       string
 	flagAPIURL       string
 	flagProfile      string
+	flagWorkspaceID  string
 	flagOutputFormat string
 )
 
@@ -35,6 +36,7 @@ Authentication:
   Run 'langsmith auth login', set LANGSMITH_API_KEY, or pass --api-key.
   Optionally set LANGSMITH_ENDPOINT for self-hosted instances.
   Use --profile or LANGSMITH_PROFILE to select a saved profile.
+  Pass --workspace to target a specific workspace for one command.
   Set a default workspace with 'langsmith profile set-workspace <workspace-id>'.
   Set LANGSMITH_PROJECT as a default project name for trace/run queries.
 
@@ -57,6 +59,9 @@ Quick start:
 	rootCmd.PersistentFlags().StringVar(&flagAPIKey, "api-key", "", "LangSmith API key [env: LANGSMITH_API_KEY]")
 	rootCmd.PersistentFlags().StringVar(&flagAPIURL, "api-url", "", "LangSmith API URL [env: LANGSMITH_ENDPOINT]")
 	rootCmd.PersistentFlags().StringVar(&flagProfile, "profile", "", "Named profile to use [env: LANGSMITH_PROFILE]")
+	rootCmd.PersistentFlags().StringVar(&flagWorkspaceID, "workspace", "", "LangSmith workspace ID [env: LANGSMITH_WORKSPACE_ID]")
+	rootCmd.PersistentFlags().StringVar(&flagWorkspaceID, "workspace-id", "", "LangSmith workspace ID [env: LANGSMITH_WORKSPACE_ID]")
+	_ = rootCmd.PersistentFlags().MarkHidden("workspace-id")
 	rootCmd.PersistentFlags().StringVar(&flagOutputFormat, "format", "pretty", "Output format: pretty or json")
 
 	// Register all subcommand groups
@@ -100,7 +105,7 @@ func GetAPIURL() string {
 	return opts.APIURL
 }
 
-// GetWorkspaceID resolves the workspace ID from env → profile.
+// GetWorkspaceID resolves the workspace ID from flag → env → profile.
 func GetWorkspaceID() string {
 	opts, _ := resolveClientOptions(false)
 	return opts.WorkspaceID
@@ -164,6 +169,9 @@ func resolveClientOptions(refreshOAuth bool) (client.Options, error) {
 	}
 	if v := os.Getenv("LANGSMITH_WORKSPACE_ID"); v != "" {
 		opts.WorkspaceID = v
+	}
+	if flagWorkspaceID != "" {
+		opts.WorkspaceID = flagWorkspaceID
 	}
 	switch {
 	case flagAPIKey != "":

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -102,6 +102,28 @@ func TestRootCmd_PersistentFlags_Profile(t *testing.T) {
 	}
 }
 
+func TestRootCmd_PersistentFlags_Workspace(t *testing.T) {
+	root := NewRootCmd("dev", "dev")
+	f := root.PersistentFlags().Lookup("workspace")
+	if f == nil {
+		t.Fatal("--workspace flag not found")
+	}
+	if f.DefValue != "" {
+		t.Errorf("expected default empty, got %q", f.DefValue)
+	}
+}
+
+func TestRootCmd_PersistentFlags_WorkspaceIDAlias(t *testing.T) {
+	root := NewRootCmd("dev", "dev")
+	f := root.PersistentFlags().Lookup("workspace-id")
+	if f == nil {
+		t.Fatal("--workspace-id flag not found")
+	}
+	if !f.Hidden {
+		t.Fatal("expected --workspace-id alias to be hidden")
+	}
+}
+
 // ---------- getAPIKey ----------
 
 func TestGetAPIKey_FlagPrecedence(t *testing.T) {
@@ -332,6 +354,42 @@ func TestGetOAuthAccessToken_ProfileFallback(t *testing.T) {
 	}
 	if got := GetWorkspaceID(); got != "ws-123" {
 		t.Fatalf("expected profile workspace, got %q", got)
+	}
+}
+
+func TestGetWorkspaceID_FlagOverridesEnv(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv("LANGSMITH_WORKSPACE_ID", "ws-env")
+
+	oldWorkspace := flagWorkspaceID
+	defer func() {
+		flagWorkspaceID = oldWorkspace
+	}()
+
+	root := NewRootCmd("dev", "dev")
+	if err := root.PersistentFlags().Set("workspace", "ws-flag"); err != nil {
+		t.Fatalf("setting workspace flag: %v", err)
+	}
+	if got := GetWorkspaceID(); got != "ws-flag" {
+		t.Fatalf("expected flag workspace, got %q", got)
+	}
+}
+
+func TestGetWorkspaceID_WorkspaceIDAliasOverridesEnv(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv("LANGSMITH_WORKSPACE_ID", "ws-env")
+
+	oldWorkspace := flagWorkspaceID
+	defer func() {
+		flagWorkspaceID = oldWorkspace
+	}()
+
+	root := NewRootCmd("dev", "dev")
+	if err := root.PersistentFlags().Set("workspace-id", "ws-alias"); err != nil {
+		t.Fatalf("setting workspace-id flag: %v", err)
+	}
+	if got := GetWorkspaceID(); got != "ws-alias" {
+		t.Fatalf("expected alias workspace, got %q", got)
 	}
 }
 

--- a/internal/cmd/testutil_test.go
+++ b/internal/cmd/testutil_test.go
@@ -45,17 +45,20 @@ func setupTestEnv(t *testing.T, serverURL string) func() {
 	oldKey := flagAPIKey
 	oldURL := flagAPIURL
 	oldProfile := flagProfile
+	oldWorkspace := flagWorkspaceID
 	oldFmt := flagOutputFormat
 
 	flagAPIKey = "test-api-key"
 	flagAPIURL = serverURL
 	flagProfile = ""
+	flagWorkspaceID = ""
 	flagOutputFormat = "pretty"
 
 	return func() {
 		flagAPIKey = oldKey
 		flagAPIURL = oldURL
 		flagProfile = oldProfile
+		flagWorkspaceID = oldWorkspace
 		flagOutputFormat = oldFmt
 	}
 }
@@ -64,6 +67,19 @@ func setupTestEnv(t *testing.T, serverURL string) func() {
 // and returns captured stdout and any error.
 func executeCommand(t *testing.T, args ...string) (string, error) {
 	t.Helper()
+	oldKey := flagAPIKey
+	oldURL := flagAPIURL
+	oldProfile := flagProfile
+	oldWorkspace := flagWorkspaceID
+	oldFormat := flagOutputFormat
+	defer func() {
+		flagAPIKey = oldKey
+		flagAPIURL = oldURL
+		flagProfile = oldProfile
+		flagWorkspaceID = oldWorkspace
+		flagOutputFormat = oldFormat
+	}()
+
 	cmd := NewRootCmd("test", "test")
 	var outBuf bytes.Buffer
 	cmd.SetOut(&outBuf)

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -152,6 +152,11 @@ func ResolveClientOptions(cmd *cobra.Command, refreshOAuth bool) (client.Options
 	if v := os.Getenv("LANGSMITH_WORKSPACE_ID"); v != "" {
 		opts.WorkspaceID = v
 	}
+	if v := getFlagString(cmd, "workspace"); v != "" {
+		opts.WorkspaceID = v
+	} else if v := getFlagString(cmd, "workspace-id"); v != "" {
+		opts.WorkspaceID = v
+	}
 
 	switch {
 	case getFlagString(cmd, "api-key") != "":

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -18,6 +18,8 @@ func newTestCmd() *cobra.Command {
 	root.PersistentFlags().String("api-key", "", "")
 	root.PersistentFlags().String("api-url", "", "")
 	root.PersistentFlags().String("profile", "", "")
+	root.PersistentFlags().String("workspace", "", "")
+	root.PersistentFlags().String("workspace-id", "", "")
 	root.PersistentFlags().String("format", "pretty", "")
 	return root
 }
@@ -200,6 +202,66 @@ func TestResolveClientOptions_ProfileFlagSetsProfileName(t *testing.T) {
 	}
 	if opts.WorkspaceID != "ws-prod" {
 		t.Fatalf("expected profile workspace ID, got %q", opts.WorkspaceID)
+	}
+}
+
+func TestResolveClientOptions_WorkspaceFlagOverridesEnvAndProfile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_WORKSPACE_ID", "ws-env")
+	if err := os.WriteFile(path, []byte(`{
+  "current_profile": "default",
+  "profiles": {
+    "default": {
+      "api_key": "default-key",
+      "workspace_id": "ws-profile"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTestCmd()
+	_ = cmd.PersistentFlags().Set("workspace", "ws-flag")
+	opts, err := ResolveClientOptions(cmd, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.WorkspaceID != "ws-flag" {
+		t.Fatalf("expected flag workspace ID, got %q", opts.WorkspaceID)
+	}
+}
+
+func TestResolveClientOptions_WorkspaceIDAliasOverridesEnvAndProfile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_WORKSPACE_ID", "ws-env")
+	if err := os.WriteFile(path, []byte(`{
+  "current_profile": "default",
+  "profiles": {
+    "default": {
+      "api_key": "default-key",
+      "workspace_id": "ws-profile"
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTestCmd()
+	_ = cmd.PersistentFlags().Set("workspace-id", "ws-alias")
+	opts, err := ResolveClientOptions(cmd, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.WorkspaceID != "ws-alias" {
+		t.Fatalf("expected alias workspace ID, got %q", opts.WorkspaceID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a global `--workspace` flag that overrides profile/env workspace routing.
- Keep hidden global `--workspace-id` compatibility while removing login/profile-local workspace flags.
- Update tests and README usage for workspace selection.

## Test Plan
- [x] `GOCACHE=/private/tmp/langsmith-cli-go-cache go test ./...`
- [x] Binary e2e with local mock OAuth server: `auth login --workspace <workspace-id>` saves the workspace to the profile
- [x] Binary e2e: `profile create --workspace <workspace-id>` saves the workspace to the profile