### PR TITLE
fix(sandbox): defer create resources to server defaults [INF-0000]

### DIFF
--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -62,15 +62,18 @@ var sandboxBoxDetailRender = structured.PropertyList{
 }
 
 func sandboxCreateParams(name string, in *sandboxCreateInput) (langsmith.SandboxBoxNewParams, error) {
-	memBytes, err := parseByteSize(in.Memory)
-	if err != nil {
-		return langsmith.SandboxBoxNewParams{}, fmt.Errorf("invalid --memory: %w", err)
-	}
-
 	params := langsmith.SandboxBoxNewParams{
-		Name:     langsmith.F(name),
-		Vcpus:    langsmith.F(int64(in.VCPUs)),
-		MemBytes: langsmith.F(memBytes),
+		Name: langsmith.F(name),
+	}
+	if in.VCPUs != 0 {
+		params.Vcpus = langsmith.F(int64(in.VCPUs))
+	}
+	if in.Memory != "" {
+		memBytes, err := parseByteSize(in.Memory)
+		if err != nil {
+			return langsmith.SandboxBoxNewParams{}, fmt.Errorf("invalid --memory: %w", err)
+		}
+		params.MemBytes = langsmith.F(memBytes)
 	}
 	if in.SnapshotID != "" {
 		params.SnapshotID = langsmith.F(in.SnapshotID)
@@ -130,10 +133,7 @@ Examples:
   langsmith sandbox create my-vm --snapshot-id <id> --proxy-config @proxy.json`,
 	Args: cobra.ExactArgs(1),
 	Input: func(cmd *cobra.Command) *sandboxCreateInput {
-		in := &sandboxCreateInput{
-			VCPUs:  2,
-			Memory: "512mb",
-		}
+		in := &sandboxCreateInput{}
 		cmd.Flags().StringVar(&in.SnapshotID, "snapshot-id", in.SnapshotID, "Snapshot ID to boot from")
 		cmd.Flags().IntVar(&in.VCPUs, "vcpus", in.VCPUs, "Number of vCPUs")
 		cmd.Flags().StringVar(&in.Memory, "memory", in.Memory, "Memory with unit (e.g. 512mb, 1gb)")

--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -52,7 +52,7 @@ var sandboxBoxDetailRender = structured.PropertyList{
 		{Label: "ID", Template: "{{.ID}}"},
 		{Label: "Status", Template: "{{.Status}}"},
 		{Label: "Size", Template: "{{.SizeClass}}"},
-		{Label: "VCPUs", Template: "{{formatCount .Vcpus}}"},
+		{Label: "vCPU", Template: "{{formatCount .Vcpus}}"},
 		{Label: "Memory", Template: "{{formatBytesOrDash .MemBytes}}"},
 		{Label: "Rootfs", Template: "{{formatBytesOrDash .FsCapacityBytes}}"},
 		{Label: "Snapshot", Template: "{{shortID .SnapshotID}}"},
@@ -137,7 +137,7 @@ Examples:
 	Input: func(cmd *cobra.Command) *sandboxCreateInput {
 		in := &sandboxCreateInput{}
 		cmd.Flags().StringVar(&in.SnapshotID, "snapshot-id", in.SnapshotID, "Snapshot ID to boot from")
-		cmd.Flags().IntVar(&in.VCPUs, "vcpus", in.VCPUs, "Number of vCPUs")
+		cmd.Flags().IntVar(&in.VCPUs, "vcpus", in.VCPUs, "Number of vCPU cores")
 		cmd.Flags().StringVar(&in.Memory, "memory", in.Memory, "Memory with unit (e.g. 512mb, 1gb)")
 		cmd.Flags().StringVar(&in.RootFS, "rootfs-capacity", in.RootFS, "Root filesystem capacity with unit (e.g. 4gb, 8gb)")
 		cmd.Flags().StringVar(&in.ProxyConfig, "proxy-config", in.ProxyConfig, "Proxy config as JSON or @file.json")
@@ -189,7 +189,7 @@ var sandboxListCommand = structured.Command[struct{}]{
 		Columns: []structured.Column{
 			{Header: "Name", Template: "{{.Name}}"},
 			{Header: "Status", Template: "{{.Status}}"},
-			{Header: "VCPUs", Template: "{{formatCount .Vcpus}}"},
+			{Header: "vCPU", Template: "{{formatCount .Vcpus}}"},
 			{Header: "Mem", Template: "{{formatBytesOrDash .MemBytes}}"},
 			{Header: "Rootfs", Template: "{{formatBytesOrDash .FsCapacityBytes}}"},
 			{Header: "Snapshot", Template: "{{shortID .SnapshotID}}"},
@@ -238,7 +238,7 @@ for the proxy config JSON format.`,
 	Args: cobra.ExactArgs(1),
 	Input: func(cmd *cobra.Command) *sandboxUpdateInput {
 		in := &sandboxUpdateInput{}
-		cmd.Flags().IntVar(&in.VCPUs, "vcpus", in.VCPUs, "Number of vCPUs")
+		cmd.Flags().IntVar(&in.VCPUs, "vcpus", in.VCPUs, "Number of vCPU cores")
 		cmd.Flags().StringVar(&in.Memory, "memory", in.Memory, "Memory with unit (e.g. 512mb, 1gb)")
 		cmd.Flags().StringVar(&in.RootFS, "rootfs-capacity", in.RootFS, "Root filesystem capacity with unit (e.g. 4gb, 8gb)")
 		cmd.Flags().StringVar(&in.ProxyConfig, "proxy-config", in.ProxyConfig, "Proxy config as JSON or @file.json")

--- a/internal/cmd/sandbox_test.go
+++ b/internal/cmd/sandbox_test.go
@@ -264,10 +264,7 @@ func TestSandboxBoxDetailRenderSupportsSDKResponseTypes(t *testing.T) {
 }
 
 func TestSandboxCreateParams_OmitsEmptySnapshotID(t *testing.T) {
-	params, err := sandboxCreateParams("my-vm", &sandboxCreateInput{
-		VCPUs:  2,
-		Memory: "512mb",
-	})
+	params, err := sandboxCreateParams("my-vm", &sandboxCreateInput{})
 	require.NoError(t, err)
 
 	raw, err := json.Marshal(params)
@@ -276,14 +273,14 @@ func TestSandboxCreateParams_OmitsEmptySnapshotID(t *testing.T) {
 	require.NoError(t, json.Unmarshal(raw, &body))
 
 	assert.NotContains(t, body, "snapshot_id")
+	assert.NotContains(t, body, "vcpus")
+	assert.NotContains(t, body, "mem_bytes")
 	assert.Equal(t, "my-vm", body["name"])
 }
 
 func TestSandboxCreateParams_IncludesSnapshotIDWhenSet(t *testing.T) {
 	params, err := sandboxCreateParams("my-vm", &sandboxCreateInput{
 		SnapshotID: "snap-123",
-		VCPUs:      2,
-		Memory:     "512mb",
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

Stop sending implicit sandbox create resource values from the CLI so omitted --vcpus and --memory flags are left for the server to default.

## Test Plan

- [x] go test ./internal/cmd -run 'TestSandbox(CreateParams|BoxDetail|UpdateCmd)'
- [x] deslop internal/cmd/sandbox_box.go internal/cmd/sandbox_test.go