### PR TITLE
feat(sandbox): add service URL command

### DIFF
--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -30,6 +30,9 @@ Common workflows:
   # Tunnel a remote port (e.g. Postgres) to localhost
   langsmith sandbox tunnel my-vm --remote-port 5432
 
+  # Generate an authenticated HTTP URL for a service inside the sandbox
+  langsmith sandbox service-url my-vm --port 8000
+
   # Set up SSH access (writes ~/.ssh/config so "ssh sandbox-my-vm" works)
   # Requires sshd to be installed in your Docker image.
   langsmith sandbox ssh-setup my-vm`,
@@ -47,6 +50,7 @@ Common workflows:
 	// Connectivity
 	cmd.AddCommand(newSandboxExecCmd())
 	cmd.AddCommand(newSandboxConsoleCmd())
+	cmd.AddCommand(sandboxServiceURLCommand.Cobra())
 	cmd.AddCommand(newSandboxTunnelCmd())
 	cmd.AddCommand(newSandboxSSHSetupCmd())
 

--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -176,11 +176,13 @@ Examples:
 
 var sandboxServiceURLRender = structured.PropertyList{
 	Properties: []structured.Property{
-		{Label: "Service URL", Template: "{{.ServiceURL}}"},
 		{Label: "Browser URL", Template: "{{.BrowserURL}}"},
+		{Label: "Service URL", Template: "{{.ServiceURL}}"},
 		{Label: "Expires", Template: "{{formatTime .ExpiresAt}}"},
-		{Label: "Token", Template: "{{.Token}}"},
+		{Label: "Service Token", Template: "{{.Token}}"},
 	},
+	Commentary: `Example:
+  curl -H "X-Langsmith-Sandbox-Service-Token: {{.Token}}" "{{.ServiceURL}}"`,
 }
 
 var sandboxServiceURLCommand = structured.Command[*sandboxServiceURLInput]{

--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -46,6 +46,11 @@ type sandboxCreateInput struct {
 	ProxyConfig string
 }
 
+type sandboxServiceURLInput struct {
+	Port             int
+	ExpiresInSeconds int64
+}
+
 var sandboxBoxDetailRender = structured.PropertyList{
 	Properties: []structured.Property{
 		{Label: "Name", Template: "{{.Name}}"},
@@ -167,6 +172,63 @@ Examples:
 		return resp, nil
 	},
 	Render: sandboxBoxDetailRender,
+}
+
+var sandboxServiceURLRender = structured.PropertyList{
+	Properties: []structured.Property{
+		{Label: "Service URL", Template: "{{.ServiceURL}}"},
+		{Label: "Browser URL", Template: "{{.BrowserURL}}"},
+		{Label: "Expires", Template: "{{formatTime .ExpiresAt}}"},
+		{Label: "Token", Template: "{{.Token}}"},
+	},
+}
+
+var sandboxServiceURLCommand = structured.Command[*sandboxServiceURLInput]{
+	Use:   "service-url <name> --port <port>",
+	Short: "Generate an authenticated URL for a sandbox HTTP service",
+	Long: `Generate an authenticated URL for an HTTP service running inside a sandbox.
+
+Use the service URL with the X-Langsmith-Sandbox-Service-Token header, or open
+the browser URL directly.
+
+Examples:
+  langsmith sandbox service-url my-vm --port 8000
+  langsmith sandbox service-url my-vm --port 8000 --expires-in-seconds 3600`,
+	Args: cobra.ExactArgs(1),
+	Input: func(cmd *cobra.Command) *sandboxServiceURLInput {
+		in := &sandboxServiceURLInput{}
+		cmd.Flags().IntVar(&in.Port, "port", in.Port, "Port inside the sandbox")
+		cmd.Flags().Int64Var(&in.ExpiresInSeconds, "expires-in-seconds", in.ExpiresInSeconds, "URL TTL in seconds")
+		_ = cmd.MarkFlagRequired("port")
+		return in
+	},
+	Action: func(ctx context.Context, cmd *cobra.Command, in *sandboxServiceURLInput, args []string) (any, error) {
+		if in.Port < 1 || in.Port > 65535 {
+			return nil, fmt.Errorf("--port must be between 1 and 65535 (got %d)", in.Port)
+		}
+		if cmd.Flags().Changed("expires-in-seconds") && in.ExpiresInSeconds < 1 {
+			return nil, fmt.Errorf("--expires-in-seconds must be greater than 0")
+		}
+
+		c, err := cmdutil.GetClient(cmd)
+		if err != nil {
+			return nil, err
+		}
+
+		params := langsmith.SandboxBoxGenerateServiceURLParams{
+			Port: langsmith.F(int64(in.Port)),
+		}
+		if cmd.Flags().Changed("expires-in-seconds") {
+			params.ExpiresInSeconds = langsmith.F(in.ExpiresInSeconds)
+		}
+
+		resp, err := c.SDK.Sandboxes.Boxes.GenerateServiceURL(ctx, args[0], params)
+		if err != nil {
+			return nil, fmt.Errorf("generating service URL: %w", err)
+		}
+		return resp, nil
+	},
+	Render: sandboxServiceURLRender,
 }
 
 var sandboxListCommand = structured.Command[struct{}]{

--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -181,7 +181,7 @@ var sandboxServiceURLRender = structured.PropertyList{
 		{Label: "Expires", Template: "{{formatTime .ExpiresAt}}"},
 		{Label: "Service Token", Template: "{{.Token}}"},
 	},
-	Commentary: `Example:
+	Caption: `Example:
   curl -H "X-Langsmith-Sandbox-Service-Token: {{.Token}}" "{{.ServiceURL}}"`,
 }
 

--- a/internal/cmd/sandbox_test.go
+++ b/internal/cmd/sandbox_test.go
@@ -354,7 +354,10 @@ func TestSandboxServiceURLCmd_GeneratesServiceURL(t *testing.T) {
 	assert.Equal(t, float64(3600), body["expires_in_seconds"])
 	assert.Contains(t, out, "Service URL:")
 	assert.Contains(t, out, "https://service.example")
-	assert.Contains(t, out, "Token:")
+	assert.Contains(t, out, "Browser URL:")
+	assert.Contains(t, out, "https://browser.example")
+	assert.Contains(t, out, "Service Token:")
+	assert.Contains(t, out, `curl -H "X-Langsmith-Sandbox-Service-Token: token-123" "https://service.example"`)
 }
 
 func TestSandboxServiceURLCmd_OmitsExpiresInSecondsWhenUnset(t *testing.T) {

--- a/internal/cmd/sandbox_test.go
+++ b/internal/cmd/sandbox_test.go
@@ -88,7 +88,7 @@ func TestSandboxCmd_FlatSubcommands(t *testing.T) {
 	expected := map[string]bool{
 		"create": false, "list": false, "get": false, "update": false,
 		"delete": false, "start": false, "stop": false,
-		"exec": false, "console": false, "tunnel": false, "ssh-setup": false,
+		"exec": false, "console": false, "service-url": false, "tunnel": false, "ssh-setup": false,
 		"snapshot": false,
 	}
 	for _, sub := range cmd.Commands() {
@@ -326,6 +326,59 @@ func TestSandboxUpdateCmd_SizeFlags(t *testing.T) {
 			t.Errorf("flag --%s not found", name)
 		}
 	}
+}
+
+func TestSandboxServiceURLCmd_Flags(t *testing.T) {
+	cmd := sandboxServiceURLCommand.Cobra()
+
+	require.NotNil(t, cmd.Flags().Lookup("port"))
+	require.NotNil(t, cmd.Flags().Lookup("expires-in-seconds"))
+}
+
+func TestSandboxServiceURLCmd_GeneratesServiceURL(t *testing.T) {
+	var body map[string]any
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v2/sandboxes/boxes/my-vm/service-url", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"service_url":"https://service.example","browser_url":"https://browser.example","expires_at":"2026-05-27T12:00:00Z","token":"token-123"}`))
+		require.NoError(t, err)
+	})
+
+	out, err := executeCommand(t, "--api-key", "test-key", "--api-url", ts.URL, "sandbox", "service-url", "my-vm", "--port", "8000", "--expires-in-seconds", "3600")
+
+	require.NoError(t, err)
+	assert.Equal(t, float64(8000), body["port"])
+	assert.Equal(t, float64(3600), body["expires_in_seconds"])
+	assert.Contains(t, out, "Service URL:")
+	assert.Contains(t, out, "https://service.example")
+	assert.Contains(t, out, "Token:")
+}
+
+func TestSandboxServiceURLCmd_OmitsExpiresInSecondsWhenUnset(t *testing.T) {
+	var body map[string]any
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"service_url":"https://service.example","browser_url":"https://browser.example","expires_at":"2026-05-27T12:00:00Z","token":"token-123"}`))
+		require.NoError(t, err)
+	})
+
+	_, err := executeCommand(t, "--api-key", "test-key", "--api-url", ts.URL, "sandbox", "service-url", "my-vm", "--port", "8000")
+
+	require.NoError(t, err)
+	assert.Equal(t, float64(8000), body["port"])
+	assert.NotContains(t, body, "expires_in_seconds")
+}
+
+func TestSandboxServiceURLCmd_RejectsInvalidPort(t *testing.T) {
+	_, err := executeCommand(t, "--api-key", "test-key", "sandbox", "service-url", "my-vm", "--port", "0")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--port must be between 1 and 65535")
 }
 
 func TestSnapshotBuildCmd_CapacityFlag(t *testing.T) {

--- a/internal/structured/specs.go
+++ b/internal/structured/specs.go
@@ -24,6 +24,7 @@ func (s Template) RenderText(w io.Writer, model any) error {
 type PropertyList struct {
 	Title      string
 	Properties []Property
+	Commentary string
 }
 
 type Property struct {
@@ -75,6 +76,21 @@ func (p PropertyList) RenderText(w io.Writer, model any) error {
 		fmt.Fprintf(w, "%-*s  %s\n", maxLabelWidth, prop.label+":", lines[0])
 		for _, line := range lines[1:] {
 			fmt.Fprintf(w, "%-*s  %s\n", maxLabelWidth, "", line)
+		}
+	}
+	if p.Commentary != "" {
+		tmpl, err := template.New("commentary").Funcs(templateFuncs()).Parse(p.Commentary)
+		if err != nil {
+			return fmt.Errorf("parsing commentary: %w", err)
+		}
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, model); err != nil {
+			return fmt.Errorf("rendering commentary: %w", err)
+		}
+		text := strings.TrimSpace(buf.String())
+		if text != "" {
+			fmt.Fprintln(w)
+			fmt.Fprintln(w, text)
 		}
 	}
 	return nil

--- a/internal/structured/specs.go
+++ b/internal/structured/specs.go
@@ -24,7 +24,7 @@ func (s Template) RenderText(w io.Writer, model any) error {
 type PropertyList struct {
 	Title      string
 	Properties []Property
-	Commentary string
+	Caption    string
 }
 
 type Property struct {
@@ -78,14 +78,14 @@ func (p PropertyList) RenderText(w io.Writer, model any) error {
 			fmt.Fprintf(w, "%-*s  %s\n", maxLabelWidth, "", line)
 		}
 	}
-	if p.Commentary != "" {
-		tmpl, err := template.New("commentary").Funcs(templateFuncs()).Parse(p.Commentary)
+	if p.Caption != "" {
+		tmpl, err := template.New("caption").Funcs(templateFuncs()).Parse(p.Caption)
 		if err != nil {
-			return fmt.Errorf("parsing commentary: %w", err)
+			return fmt.Errorf("parsing caption: %w", err)
 		}
 		var buf bytes.Buffer
 		if err := tmpl.Execute(&buf, model); err != nil {
-			return fmt.Errorf("rendering commentary: %w", err)
+			return fmt.Errorf("rendering caption: %w", err)
 		}
 		text := strings.TrimSpace(buf.String())
 		if text != "" {

--- a/internal/structured/structured_test.go
+++ b/internal/structured/structured_test.go
@@ -72,7 +72,7 @@ func TestPropertyListRenderTextMultiline(t *testing.T) {
 	require.Equal(t, "Message:  first\n          second\n", out.String())
 }
 
-func TestPropertyListRenderTextCommentary(t *testing.T) {
+func TestPropertyListRenderTextCaption(t *testing.T) {
 	var out bytes.Buffer
 	cmd := testCmd("pretty", &out)
 
@@ -80,7 +80,7 @@ func TestPropertyListRenderTextCommentary(t *testing.T) {
 		Properties: []Property{
 			{Label: "Name", Template: "{{.Name}}"},
 		},
-		Commentary: "Example: {{.Name}}",
+		Caption: "Example: {{.Name}}",
 	})
 
 	require.NoError(t, err)

--- a/internal/structured/structured_test.go
+++ b/internal/structured/structured_test.go
@@ -72,6 +72,21 @@ func TestPropertyListRenderTextMultiline(t *testing.T) {
 	require.Equal(t, "Message:  first\n          second\n", out.String())
 }
 
+func TestPropertyListRenderTextCommentary(t *testing.T) {
+	var out bytes.Buffer
+	cmd := testCmd("pretty", &out)
+
+	err := Render(cmd, struct{ Name string }{Name: "sandbox"}, PropertyList{
+		Properties: []Property{
+			{Label: "Name", Template: "{{.Name}}"},
+		},
+		Commentary: "Example: {{.Name}}",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "Name:  sandbox\n\nExample: sandbox\n", out.String())
+}
+
 func TestRenderJQFiltersModel(t *testing.T) {
 	var out bytes.Buffer
 	cmd := testCmd("pretty", &out)


### PR DESCRIPTION
Adds a `langsmith sandbox service-url <name> --port <port>` command for generating authenticated HTTP service URLs for ports inside a sandbox.

The command calls the existing sandbox service-url API, supports an optional `--expires-in-seconds` TTL, validates port input, and renders the service URL, browser URL, expiry, and token in the standard CLI formats.

## Test Plan

- [x] `go test ./...`
