### PR TITLE
refactor(sandbox): use structured commands

### DIFF
--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -417,60 +417,59 @@ var sandboxStopCommand = structured.Command[struct{}]{
 `),
 }
 
-func newSandboxExecCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "exec <name> -- <command>",
-		Short: "Execute a command inside a sandbox",
-		Long: `Execute a one-off command inside a running sandbox and print its output.
+type sandboxExecInput struct{}
+
+var sandboxExecCommand = structured.Command[sandboxExecInput]{
+	Use:   "exec <name> -- <command>",
+	Short: "Execute a command inside a sandbox",
+	Long: `Execute a one-off command inside a running sandbox and print its output.
 
 Examples:
   langsmith sandbox exec my-vm -- uname -a
   langsmith sandbox exec my-vm -- ls -la /
   langsmith sandbox exec my-vm -- cat /etc/os-release`,
-		Args:               cobra.MinimumNArgs(1),
-		DisableFlagParsing: false,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			name := args[0]
+	Args:         cobra.MinimumNArgs(1),
+	Input:        func(cmd *cobra.Command) sandboxExecInput { return sandboxExecInput{} },
+	CustomOutput: true,
+	Action: func(ctx context.Context, cmd *cobra.Command, in sandboxExecInput, args []string) (any, error) {
+		name := args[0]
 
-			// Everything after "--" is the command.
-			cmdArgs := cmd.ArgsLenAtDash()
-			if cmdArgs < 0 || cmdArgs >= len(args) {
-				return fmt.Errorf("usage: langsmith sandbox exec <name> -- <command>")
-			}
-			command := args[cmdArgs:]
-			if len(command) == 0 {
-				return fmt.Errorf("no command specified")
-			}
+		cmdArgs := cmd.ArgsLenAtDash()
+		if cmdArgs < 0 || cmdArgs >= len(args) {
+			return nil, fmt.Errorf("usage: langsmith sandbox exec <name> -- <command>")
+		}
+		command := args[cmdArgs:]
+		if len(command) == 0 {
+			return nil, fmt.Errorf("no command specified")
+		}
 
-			ctx := cmd.Context()
-			if ctx == nil {
-				ctx = context.Background()
-			}
-			c, err := cmdutil.GetClient(cmd)
-			if err != nil {
-				return err
-			}
+		c, err := cmdutil.GetClient(cmd)
+		if err != nil {
+			return nil, err
+		}
 
-			result, err := c.SDK.Sandboxes.Boxes.Run(ctx, name, langsmith.SandboxBoxRunParams{
-				Command: langsmith.F(sandboxShellCommand(command)),
-			})
-			if err != nil {
-				return fmt.Errorf("execute: %w", err)
-			}
+		result, err := c.SDK.Sandboxes.Boxes.Run(ctx, name, langsmith.SandboxBoxRunParams{
+			Command: langsmith.F(sandboxShellCommand(command)),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("execute: %w", err)
+		}
 
-			if result.Stdout != "" {
-				fmt.Print(result.Stdout)
-			}
-			if result.Stderr != "" {
-				fmt.Fprint(os.Stderr, result.Stderr)
-			}
-			if result.ExitCode != 0 {
-				os.Exit(int(result.ExitCode))
-			}
-			return nil
-		},
-	}
-	return cmd
+		if result.Stdout != "" {
+			fmt.Print(result.Stdout)
+		}
+		if result.Stderr != "" {
+			fmt.Fprint(os.Stderr, result.Stderr)
+		}
+		if result.ExitCode != 0 {
+			os.Exit(int(result.ExitCode))
+		}
+		return nil, nil
+	},
+}
+
+func newSandboxExecCmd() *cobra.Command {
+	return sandboxExecCommand.Cobra()
 }
 
 func sandboxShellCommand(args []string) string {

--- a/internal/cmd/sandbox_console.go
+++ b/internal/cmd/sandbox_console.go
@@ -11,16 +11,21 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/langchain-ai/langsmith-cli/internal/structured"
 	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
 
-func newSandboxConsoleCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "console <name>",
-		Short: "Open an interactive shell inside a sandbox",
-		Long: `Open an interactive terminal session inside a running sandbox.
+type sandboxConsoleInput struct {
+	Shell           string
+	ForwardSSHAgent bool
+}
+
+var sandboxConsoleCommand = structured.Command[*sandboxConsoleInput]{
+	Use:   "console <name>",
+	Short: "Open an interactive shell inside a sandbox",
+	Long: `Open an interactive terminal session inside a running sandbox.
 
 Connects via WebSocket to the sandbox daemon and allocates a PTY,
 giving you a full interactive shell (bash by default).
@@ -29,18 +34,21 @@ Examples:
   langsmith sandbox console my-vm
   langsmith sandbox console my-vm --shell /bin/sh
   langsmith sandbox console my-vm --forward-ssh-agent`,
-		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			shell, _ := cmd.Flags().GetString("shell")
-			forwardSSHAgent, _ := cmd.Flags().GetBool("forward-ssh-agent")
-			return runConsole(args[0], shell, forwardSSHAgent)
-		},
-	}
+	Args: cobra.ExactArgs(1),
+	Input: func(cmd *cobra.Command) *sandboxConsoleInput {
+		in := &sandboxConsoleInput{}
+		cmd.Flags().StringVar(&in.Shell, "shell", in.Shell, "Shell to use (default: sandbox default, usually /bin/bash)")
+		cmd.Flags().BoolVar(&in.ForwardSSHAgent, "forward-ssh-agent", in.ForwardSSHAgent, "Forward the local SSH agent (SSH_AUTH_SOCK) into the sandbox")
+		return in
+	},
+	CustomOutput: true,
+	Action: func(ctx context.Context, cmd *cobra.Command, in *sandboxConsoleInput, args []string) (any, error) {
+		return nil, runConsole(args[0], in.Shell, in.ForwardSSHAgent)
+	},
+}
 
-	cmd.Flags().String("shell", "", "Shell to use (default: sandbox default, usually /bin/bash)")
-	cmd.Flags().Bool("forward-ssh-agent", false, "Forward the local SSH agent (SSH_AUTH_SOCK) into the sandbox")
-
-	return cmd
+func newSandboxConsoleCmd() *cobra.Command {
+	return sandboxConsoleCommand.Cobra()
 }
 
 func runConsole(name, shell string, forwardSSHAgent bool) error {

--- a/internal/cmd/sandbox_console_windows.go
+++ b/internal/cmd/sandbox_console_windows.go
@@ -1,18 +1,23 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/langchain-ai/langsmith-cli/internal/structured"
 	"github.com/spf13/cobra"
 )
 
+var sandboxConsoleCommand = structured.Command[struct{}]{
+	Use:          "console <name>",
+	Short:        "Open an interactive shell inside a sandbox (not supported on Windows)",
+	Args:         cobra.ExactArgs(1),
+	CustomOutput: true,
+	Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+		return nil, fmt.Errorf("sandbox console is not supported on Windows; use SSH instead: langsmith sandbox ssh-setup %s", args[0])
+	},
+}
+
 func newSandboxConsoleCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "console <name>",
-		Short: "Open an interactive shell inside a sandbox (not supported on Windows)",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("sandbox console is not supported on Windows; use SSH instead: langsmith sandbox ssh-setup %s", args[0])
-		},
-	}
+	return sandboxConsoleCommand.Cobra()
 }

--- a/internal/cmd/sandbox_ssh.go
+++ b/internal/cmd/sandbox_ssh.go
@@ -10,17 +10,19 @@ import (
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/cmdutil"
+	"github.com/langchain-ai/langsmith-cli/internal/structured"
 	"github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 
-func newSandboxSSHSetupCmd() *cobra.Command {
-	var identity string
+type sandboxSSHSetupInput struct {
+	Identity string
+}
 
-	cmd := &cobra.Command{
-		Use:   "ssh-setup <name>",
-		Short: "Upload your SSH public key and configure ~/.ssh/config for a sandbox",
-		Long: `Upload your SSH public key to a running sandbox so you can connect
+var sandboxSSHSetupCommand = structured.Command[*sandboxSSHSetupInput]{
+	Use:   "ssh-setup <name>",
+	Short: "Upload your SSH public key and configure ~/.ssh/config for a sandbox",
+	Long: `Upload your SSH public key to a running sandbox so you can connect
 with standard SSH tools (ssh, scp, rsync, sftp).
 
 This command uploads your key, fetches the host key, writes a
@@ -30,15 +32,20 @@ immediately connect with: ssh sandbox-<name>
 Examples:
   langsmith sandbox ssh-setup my-sandbox
   langsmith sandbox ssh-setup my-sandbox --identity ~/.ssh/id_ed25519.pub`,
-		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSSHSetup(cmd, args[0], identity)
-		},
-	}
+	Args: cobra.ExactArgs(1),
+	Input: func(cmd *cobra.Command) *sandboxSSHSetupInput {
+		in := &sandboxSSHSetupInput{}
+		cmd.Flags().StringVar(&in.Identity, "identity", in.Identity, "Path to SSH public key (default: auto-detect)")
+		return in
+	},
+	CustomOutput: true,
+	Action: func(ctx context.Context, cmd *cobra.Command, in *sandboxSSHSetupInput, args []string) (any, error) {
+		return nil, runSSHSetup(cmd, args[0], in.Identity)
+	},
+}
 
-	cmd.Flags().StringVar(&identity, "identity", "", "Path to SSH public key (default: auto-detect)")
-
-	return cmd
+func newSandboxSSHSetupCmd() *cobra.Command {
+	return sandboxSSHSetupCommand.Cobra()
 }
 
 func runSSHSetup(cmd *cobra.Command, name, identity string) error {

--- a/internal/cmd/sandbox_test.go
+++ b/internal/cmd/sandbox_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	langsmith "github.com/langchain-ai/langsmith-go"
@@ -204,9 +205,15 @@ func TestSandboxCustomOutputCommands_Flags(t *testing.T) {
 		cmd  *cobra.Command
 		want []string
 	}{
-		{"console", newSandboxConsoleCmd(), []string{"shell", "forward-ssh-agent"}},
 		{"tunnel", newSandboxTunnelCmd(), []string{"url", "name", "remote-port", "local-port", "stdio", "log-level"}},
 		{"ssh-setup", newSandboxSSHSetupCmd(), []string{"identity"}},
+	}
+	if runtime.GOOS != "windows" {
+		tests = append(tests, struct {
+			name string
+			cmd  *cobra.Command
+			want []string
+		}{"console", newSandboxConsoleCmd(), []string{"shell", "forward-ssh-agent"}})
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cmd/sandbox_test.go
+++ b/internal/cmd/sandbox_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	langsmith "github.com/langchain-ai/langsmith-go"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -155,6 +156,65 @@ func TestSandboxCreateCmd_AllowsNoArgs(t *testing.T) {
 	require.NotEmpty(t, out)
 	require.NotContains(t, body, "name")
 	require.NotContains(t, body, "snapshot_id")
+}
+
+func TestSandboxExecCmd_PositionalNameAndCommandSeparator(t *testing.T) {
+	cmd := newSandboxExecCmd()
+	require.NoError(t, cmd.Args(cmd, []string{"my-vm", "echo", "hi"}))
+	require.Error(t, cmd.Args(cmd, []string{}))
+}
+
+func TestSandboxExecCmd_WritesCommandOutputDirectly(t *testing.T) {
+	var body map[string]any
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes/boxes/my-vm":
+			_, err := w.Write([]byte(`{"id":"box-id","name":"my-vm","status":"ready","dataplane_url":"` + tsURL(t, r) + `"}`))
+			require.NoError(t, err)
+		case r.Method == http.MethodPost && r.URL.Path == "/execute":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			_, err := w.Write([]byte(`{"stdout":"hello\n","stderr":"","exit_code":0}`))
+			require.NoError(t, err)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	var out string
+	var err error
+	stdout := captureStdout(t, func() {
+		out, err = executeCommand(t, "--api-key", "test-key", "--api-url", ts.URL, "sandbox", "exec", "my-vm", "--", "echo", "hello")
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, out)
+	assert.Equal(t, "hello\n", stdout)
+	assert.Equal(t, "'echo' 'hello'", body["command"])
+}
+
+func tsURL(t *testing.T, r *http.Request) string {
+	t.Helper()
+	return "http://" + r.Host
+}
+
+func TestSandboxCustomOutputCommands_Flags(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+		want []string
+	}{
+		{"console", newSandboxConsoleCmd(), []string{"shell", "forward-ssh-agent"}},
+		{"tunnel", newSandboxTunnelCmd(), []string{"url", "name", "remote-port", "local-port", "stdio", "log-level"}},
+		{"ssh-setup", newSandboxSSHSetupCmd(), []string{"identity"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, name := range tc.want {
+				require.NotNil(t, tc.cmd.Flags().Lookup(name), "flag --%s not found", name)
+			}
+		})
+	}
 }
 
 func TestSandboxTunnelCmd_PositionalNameOrURL(t *testing.T) {

--- a/internal/cmd/sandbox_tunnel.go
+++ b/internal/cmd/sandbox_tunnel.go
@@ -65,7 +65,7 @@ Examples:
 			return nil, fmt.Errorf("provide a sandbox name or --url")
 		}
 		client := MustGetClient()
-		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+		ctx, cancel := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
 		defer cancel()
 		sandboxURL := in.SandboxURL
 		if sandboxURL == "" {

--- a/internal/cmd/sandbox_tunnel.go
+++ b/internal/cmd/sandbox_tunnel.go
@@ -10,24 +10,24 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/langchain-ai/langsmith-cli/internal/structured"
 	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 
-func newSandboxTunnelCmd() *cobra.Command {
-	var (
-		sandboxURL  string
-		sandboxName string
-		remotePort  int
-		localPort   int
-		logLevel    string
-		stdio       bool
-	)
+type sandboxTunnelInput struct {
+	SandboxURL  string
+	SandboxName string
+	RemotePort  int
+	LocalPort   int
+	LogLevel    string
+	Stdio       bool
+}
 
-	cmd := &cobra.Command{
-		Use:   "tunnel <name> --remote-port <port>",
-		Short: "Create a TCP tunnel to a service inside a sandbox",
-		Long: `Create a TCP tunnel from a local port to a port inside a remote sandbox.
+var sandboxTunnelCommand = structured.Command[*sandboxTunnelInput]{
+	Use:   "tunnel <name> --remote-port <port>",
+	Short: "Create a TCP tunnel to a service inside a sandbox",
+	Long: `Create a TCP tunnel from a local port to a port inside a remote sandbox.
 
 The tunnel multiplexes many TCP connections over a single WebSocket,
 so you can connect tools like psql, redis-cli, or curl to services
@@ -42,62 +42,66 @@ Examples:
   langsmith sandbox tunnel my-vm --remote-port 5432 --local-port 15432
   langsmith sandbox tunnel my-vm --remote-port 22 --stdio
   langsmith sandbox tunnel --url https://sandboxes.langsmith.com/my-sandbox --remote-port 5432`,
-		Args: cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// Resolve name: positional arg takes precedence over --name flag.
-			name := sandboxName
-			if len(args) > 0 {
-				name = args[0]
+	Args: cobra.MaximumNArgs(1),
+	Input: func(cmd *cobra.Command) *sandboxTunnelInput {
+		in := &sandboxTunnelInput{LogLevel: "info"}
+		cmd.Flags().StringVar(&in.SandboxURL, "url", in.SandboxURL, "Sandbox URL (override; skips name resolution)")
+		cmd.Flags().StringVar(&in.SandboxName, "name", in.SandboxName, "")
+		cmd.Flags().IntVar(&in.RemotePort, "remote-port", in.RemotePort, "Port inside the sandbox to tunnel to")
+		cmd.Flags().IntVar(&in.LocalPort, "local-port", in.LocalPort, "Local port to listen on (defaults to remote-port)")
+		cmd.Flags().StringVar(&in.LogLevel, "log-level", in.LogLevel, "Log level: debug, info, warn, error")
+		cmd.Flags().BoolVar(&in.Stdio, "stdio", in.Stdio, "Bridge stdin/stdout to the remote port (for use as SSH ProxyCommand)")
+		_ = cmd.Flags().MarkHidden("name")
+		_ = cmd.MarkFlagRequired("remote-port")
+		return in
+	},
+	CustomOutput: true,
+	Action: func(ctx context.Context, cmd *cobra.Command, in *sandboxTunnelInput, args []string) (any, error) {
+		name := in.SandboxName
+		if len(args) > 0 {
+			name = args[0]
+		}
+		if name == "" && in.SandboxURL == "" {
+			return nil, fmt.Errorf("provide a sandbox name or --url")
+		}
+		client := MustGetClient()
+		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+		defer cancel()
+		sandboxURL := in.SandboxURL
+		if sandboxURL == "" {
+			box, err := client.SDK.Sandboxes.Boxes.Get(ctx, name)
+			if err != nil {
+				return nil, fmt.Errorf("getting sandbox: %w", err)
 			}
-			if name == "" && sandboxURL == "" {
-				return fmt.Errorf("provide a sandbox name or --url")
+			if box.DataplaneURL == "" {
+				return nil, fmt.Errorf("sandbox %q has no dataplane URL", name)
 			}
-			client := MustGetClient()
-			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-			defer cancel()
-			if sandboxURL == "" {
-				box, err := client.SDK.Sandboxes.Boxes.Get(ctx, name)
-				if err != nil {
-					return fmt.Errorf("getting sandbox: %w", err)
-				}
-				if box.DataplaneURL == "" {
-					return fmt.Errorf("sandbox %q has no dataplane URL", name)
-				}
-				sandboxURL = box.DataplaneURL
-			}
-			if remotePort < 1 || remotePort > 65535 {
-				return fmt.Errorf("--remote-port must be between 1 and 65535 (got %d)", remotePort)
-			}
+			sandboxURL = box.DataplaneURL
+		}
+		if in.RemotePort < 1 || in.RemotePort > 65535 {
+			return nil, fmt.Errorf("--remote-port must be between 1 and 65535 (got %d)", in.RemotePort)
+		}
 
-			if stdio {
-				logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-				return runTunnelStdio(ctx, logger, client.SDK, sandboxURL, remotePort)
-			}
+		if in.Stdio {
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			return nil, runTunnelStdio(ctx, logger, client.SDK, sandboxURL, in.RemotePort)
+		}
 
-			if localPort == 0 {
-				localPort = remotePort
-			}
-			if localPort < 1 || localPort > 65535 {
-				return fmt.Errorf("--local-port must be between 1 and 65535 (got %d)", localPort)
-			}
+		localPort := in.LocalPort
+		if localPort == 0 {
+			localPort = in.RemotePort
+		}
+		if localPort < 1 || localPort > 65535 {
+			return nil, fmt.Errorf("--local-port must be between 1 and 65535 (got %d)", localPort)
+		}
 
-			logger := newTunnelLogger(logLevel)
+		logger := newTunnelLogger(in.LogLevel)
+		return nil, runTunnel(ctx, logger, client.SDK, sandboxURL, in.RemotePort, localPort)
+	},
+}
 
-			return runTunnel(ctx, logger, client.SDK, sandboxURL, remotePort, localPort)
-		},
-	}
-
-	cmd.Flags().StringVar(&sandboxURL, "url", "", "Sandbox URL (override; skips name resolution)")
-	cmd.Flags().StringVar(&sandboxName, "name", "", "")
-	cmd.Flags().IntVar(&remotePort, "remote-port", 0, "Port inside the sandbox to tunnel to")
-	cmd.Flags().IntVar(&localPort, "local-port", 0, "Local port to listen on (defaults to remote-port)")
-	cmd.Flags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
-	cmd.Flags().BoolVar(&stdio, "stdio", false, "Bridge stdin/stdout to the remote port (for use as SSH ProxyCommand)")
-
-	_ = cmd.Flags().MarkHidden("name")
-	_ = cmd.MarkFlagRequired("remote-port")
-
-	return cmd
+func newSandboxTunnelCmd() *cobra.Command {
+	return sandboxTunnelCommand.Cobra()
 }
 
 func newTunnelLogger(level string) *slog.Logger {
@@ -124,7 +128,7 @@ func runTunnel(ctx context.Context, logger *slog.Logger, client *langsmith.Clien
 	}
 	defer func() { _ = tunnel.Close() }()
 
-	logger.Info("tunnel ready",
+	logger.InfoContext(ctx, "tunnel ready",
 		"local", fmt.Sprintf("127.0.0.1:%d", tunnel.LocalPort),
 		"remote_port", remotePort,
 		"sandbox_url", sandboxURL,
@@ -143,6 +147,6 @@ func runTunnelStdio(ctx context.Context, logger *slog.Logger, client *langsmith.
 	}
 	defer func() { _ = stream.Close() }()
 
-	logger.Debug("tunnel stream established", "remote_port", remotePort, "sandbox_url", sandboxURL)
+	logger.DebugContext(ctx, "tunnel stream established", "remote_port", remotePort, "sandbox_url", sandboxURL)
 	return langsmith.BridgeSandboxTunnelIO(ctx, stream, os.Stdin, os.Stdout)
 }

--- a/internal/structured/command.go
+++ b/internal/structured/command.go
@@ -7,13 +7,14 @@ import (
 )
 
 type Command[I any] struct {
-	Use    string
-	Short  string
-	Long   string
-	Args   cobra.PositionalArgs
-	Input  func(*cobra.Command) I
-	Action func(context.Context, *cobra.Command, I, []string) (any, error)
-	Render Spec
+	Use          string
+	Short        string
+	Long         string
+	Args         cobra.PositionalArgs
+	Input        func(*cobra.Command) I
+	Action       func(context.Context, *cobra.Command, I, []string) (any, error)
+	Render       Spec
+	CustomOutput bool
 }
 
 func (c Command[I]) Cobra() *cobra.Command {
@@ -28,13 +29,18 @@ func (c Command[I]) Cobra() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if c.CustomOutput {
+				return nil
+			}
 			return Render(cmd, result, c.Render)
 		},
 	}
 	if c.Input != nil {
 		input = c.Input(cmd)
 	}
-	cmd.Flags().String("jq", "", "Filter JSON output using a jq expression")
+	if !c.CustomOutput {
+		cmd.Flags().String("jq", "", "Filter JSON output using a jq expression")
+	}
 	return cmd
 }
 

--- a/internal/structured/structured_test.go
+++ b/internal/structured/structured_test.go
@@ -28,6 +28,27 @@ func TestRenderJSONIgnoresTextSpec(t *testing.T) {
 	require.JSONEq(t, `{"name":"sandbox"}`, out.String())
 }
 
+func TestCommandCustomOutputSkipsRender(t *testing.T) {
+	var out bytes.Buffer
+	cmd := Command[struct{}]{
+		Use:          "custom",
+		CustomOutput: true,
+		Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
+			_, err := cmd.OutOrStdout().Write([]byte("raw\n"))
+			return map[string]string{"rendered": "no"}, err
+		},
+		Render: Template(`rendered`),
+	}.Cobra()
+	cmd.PersistentFlags().String("format", "json", "")
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	require.Nil(t, cmd.Flags().Lookup("jq"))
+	require.Equal(t, "raw\n", out.String())
+}
+
 func TestTemplateRenderText(t *testing.T) {
 	var out bytes.Buffer
 	cmd := testCmd("pretty", &out)


### PR DESCRIPTION
## Summary

Refactor the remaining sandbox subcommands onto the structured command framework.

- add CustomOutput support for commands that own stdout/stderr or terminal state
- convert sandbox exec, console, tunnel, and ssh-setup to structured.Command
- keep raw output commands out of structured rendering and jq handling

## Test Plan

- [x] go test ./...
