### PR TITLE
fix(issues): expose actions, proposed_examples, and traces in issues list --format json

### DIFF
--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -24,10 +24,11 @@ type forgeIssue struct {
 	FixPrompt   *string         `json:"fix_prompt"`
 	FixPRNumber *int            `json:"fix_pr_number"`
 	ProposedFix *string         `json:"proposed_fix"`
-	Actions     json.RawMessage `json:"actions"`
-	CreatedAt   time.Time       `json:"created_at"`
-	UpdatedAt   time.Time       `json:"updated_at"`
-	Traces      json.RawMessage `json:"traces"`
+	Actions          json.RawMessage `json:"actions"`
+	ProposedExamples json.RawMessage `json:"proposed_examples"`
+	CreatedAt        time.Time       `json:"created_at"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Traces           json.RawMessage `json:"traces"`
 }
 
 var severityLabels = map[int]string{
@@ -397,12 +398,18 @@ func issueToMap(issue forgeIssue) map[string]any {
 		"created_at":    formatTimeISO(issue.CreatedAt),
 		"updated_at":    formatTimeISO(issue.UpdatedAt),
 	}
-	// Include actions (evaluator spec) and traces so callers can read the
-	// existing evaluator and run it against new evidence traces.
+	// Include actions (evaluator spec), proposed_examples (per-trace
+	// assertions), and traces so callers can read and update all three.
 	if len(issue.Actions) > 0 {
 		var actions any
 		if err := json.Unmarshal(issue.Actions, &actions); err == nil {
 			m["actions"] = actions
+		}
+	}
+	if len(issue.ProposedExamples) > 0 {
+		var examples any
+		if err := json.Unmarshal(issue.ProposedExamples, &examples); err == nil {
+			m["proposed_examples"] = examples
 		}
 	}
 	if len(issue.Traces) > 0 {

--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -383,7 +383,7 @@ func priorityToSeverity(p string) int {
 }
 
 func issueToMap(issue forgeIssue) map[string]any {
-	return map[string]any{
+	m := map[string]any{
 		"id":            issue.ID,
 		"session_id":    issue.SessionID,
 		"name":          issue.Name,
@@ -397,6 +397,21 @@ func issueToMap(issue forgeIssue) map[string]any {
 		"created_at":    formatTimeISO(issue.CreatedAt),
 		"updated_at":    formatTimeISO(issue.UpdatedAt),
 	}
+	// Include actions (evaluator spec) and traces so callers can read the
+	// existing evaluator and run it against new evidence traces.
+	if len(issue.Actions) > 0 {
+		var actions any
+		if err := json.Unmarshal(issue.Actions, &actions); err == nil {
+			m["actions"] = actions
+		}
+	}
+	if len(issue.Traces) > 0 {
+		var traces any
+		if err := json.Unmarshal(issue.Traces, &traces); err == nil {
+			m["traces"] = traces
+		}
+	}
+	return m
 }
 
 // eventPayloadFields holds the fields we extract from an event payload.

--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -13,17 +13,17 @@ import (
 
 // forgeIssue mirrors the JSON shape returned by GET /v1/platform/issues.
 type forgeIssue struct {
-	ID          string          `json:"id"`
-	SessionID   string          `json:"session_id"`
-	Name        string          `json:"name"`
-	Description string          `json:"description"`
-	Severity    int             `json:"severity"`
-	Status      string          `json:"status"`
-	Tags        []string        `json:"tags"`
-	FixBranch   *string         `json:"fix_branch"`
-	FixPrompt   *string         `json:"fix_prompt"`
-	FixPRNumber *int            `json:"fix_pr_number"`
-	ProposedFix *string         `json:"proposed_fix"`
+	ID               string          `json:"id"`
+	SessionID        string          `json:"session_id"`
+	Name             string          `json:"name"`
+	Description      string          `json:"description"`
+	Severity         int             `json:"severity"`
+	Status           string          `json:"status"`
+	Tags             []string        `json:"tags"`
+	FixBranch        *string         `json:"fix_branch"`
+	FixPrompt        *string         `json:"fix_prompt"`
+	FixPRNumber      *int            `json:"fix_pr_number"`
+	ProposedFix      *string         `json:"proposed_fix"`
 	Actions          json.RawMessage `json:"actions"`
 	ProposedExamples json.RawMessage `json:"proposed_examples"`
 	CreatedAt        time.Time       `json:"created_at"`


### PR DESCRIPTION
## Summary

`issueToMap` was stripping three fields agents need to read and update issues effectively:

- **`actions`** — the evaluator spec; needed to test the existing evaluator against new traces and update it if the pattern has changed
- **`proposed_examples`** — per-trace regression example assertions; needed to see what assertions already exist and re-propose with better ground truth when available  
- **`traces`** — linked evidence runs; needed to sample existing traces for evaluator regression checks

All three are now included when non-empty, decoded from raw JSON so they appear as structured objects.

**Why this matters:** The companion langchainplus PRs teach the issues agent a read→test→update loop for both evaluators and regression examples, symmetric with how it already reads and updates issue descriptions. Without these fields in the CLI output, agents can't see what already exists before deciding whether to update.

Related langchainplus PRs:
- https://github.com/langchain-ai/langchainplus/pull/26060 (evaluator test/update on new traces)
- https://github.com/langchain-ai/langchainplus/pull/26085 (regression example upsert)

## Test Plan

- [x] `langsmith project issues list --project <name> --format json` includes `actions`, `proposed_examples`, and `traces` on issues that have them
- [x] Issues with no actions / proposed_examples / traces omit those keys (no empty arrays or nulls)

## Release Note

none