### PR TITLE
refactor: rename console env helper

### DIFF
--- a/internal/cmd/sandbox_console.go
+++ b/internal/cmd/sandbox_console.go
@@ -68,7 +68,7 @@ func sandboxConsoleEnvFrom(environ []string, extra []string) (map[string]string,
 			continue
 		}
 		local[key] = value
-		if value != "" && sandboxConsoleEnvAllowed(key) {
+		if value != "" && sandboxConsoleEnvPropagated(key) {
 			env[key] = value
 		}
 	}
@@ -90,7 +90,7 @@ func sandboxConsoleEnvFrom(environ []string, extra []string) (map[string]string,
 	return env, nil
 }
 
-func sandboxConsoleEnvAllowed(key string) bool {
+func sandboxConsoleEnvPropagated(key string) bool {
 	switch key {
 	case "TERM", "COLORTERM", "LANG", "CLICOLOR", "CLICOLOR_FORCE", "FORCE_COLOR", "NO_COLOR":
 		return true


### PR DESCRIPTION
## Summary

Renames the sandbox console env helper to `sandboxConsoleEnvPropagated` so the name better reflects the default propagation check.

## Test Plan

- [x] `go test ./internal/cmd -run 'TestSandbox(ConsoleEnvFrom|CustomOutputCommands)'`
