### PR TITLE
ci: auto-sync RC branches with upstream for runs-v2 engine integration

### DIFF
--- a/.github/workflows/sync-rc-branches.yml
+++ b/.github/workflows/sync-rc-branches.yml
@@ -1,0 +1,63 @@
+name: Sync RC branches with upstream
+
+# Keeps the engine-facing RC branches in sync with their upstream integration
+# branches while the v2 runs-query work is consumed pre-release:
+#   - langsmith-go  rc/runs-v2-engine  <- next   (custom code lives off `next`)
+#   - langsmith-cli rc/runs-v2-engine  <- main
+#
+# Merges (never rebases/force-pushes) so engine's go.mod pin to the RC HEAD
+# stays valid. On conflict it leaves the last-good RC untouched and opens a
+# single deduped issue for manual resolution.
+#
+# Requires a secret RC_SYNC_TOKEN with contents:write + issues:write on BOTH
+# repos. The default GITHUB_TOKEN is repo-scoped and cannot push cross-repo.
+
+on:
+  schedule:
+    - cron: '23 */4 * * *' # every 4 hours
+  workflow_dispatch: {}
+
+concurrency:
+  group: sync-rc-runs-v2-engine
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { repo: langchain-ai/langsmith-go, upstream: next, rc: rc/runs-v2-engine }
+          - { repo: langchain-ai/langsmith-cli, upstream: main, rc: rc/runs-v2-engine }
+    steps:
+      - name: Merge ${{ matrix.upstream }} into ${{ matrix.rc }} (${{ matrix.repo }})
+        env:
+          GH_TOKEN: ${{ secrets.RC_SYNC_TOKEN }}
+          REPO: ${{ matrix.repo }}
+          UPSTREAM: ${{ matrix.upstream }}
+          RC: ${{ matrix.rc }}
+        run: |
+          set -euo pipefail
+          git config --global user.name "langsmith-rc-sync[bot]"
+          git config --global user.email "rc-sync@users.noreply.github.com"
+
+          git clone --no-tags "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" repo
+          cd repo
+          git fetch origin "$UPSTREAM" "$RC"
+          git checkout "$RC"
+
+          if git merge --no-edit "origin/$UPSTREAM"; then
+            git push origin "HEAD:$RC"
+            echo "Synced $REPO: $UPSTREAM -> $RC"
+          else
+            git merge --abort
+            echo "::warning::Merge conflict syncing $UPSTREAM into $RC in $REPO"
+            TITLE="RC sync conflict: $UPSTREAM -> $RC"
+            BODY="Automated RC sync could not merge \`$UPSTREAM\` into \`$RC\`. Resolve manually: \`git checkout $RC && git merge origin/$UPSTREAM\`, then push."
+            EXISTING="$(gh issue list --repo "$REPO" --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')"
+            if [ -z "$EXISTING" ]; then
+              gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY"
+            fi
+            exit 1
+          fi

--- a/.github/workflows/sync-rc-branches.yml
+++ b/.github/workflows/sync-rc-branches.yml
@@ -12,6 +12,8 @@ name: Sync RC branches with upstream
 # Requires a secret RC_SYNC_TOKEN with contents:write + issues:write on BOTH
 # repos. The default GITHUB_TOKEN is repo-scoped and cannot push cross-repo.
 
+permissions: {}
+
 on:
   schedule:
     - cron: '23 */4 * * *' # every 4 hours


### PR DESCRIPTION
Adds a scheduled workflow that keeps the engine-facing `rc/runs-v2-engine` branches in both SDK repos current with their upstream integration branches while the v2 runs-query client is consumed pre-release.

## Why
Per the runs-v2 / SmithDB engine-integration decision, engine consumes the v2 runs-query client from RC branches rather than the published SDK/CLI — the SDK `main` branches are frozen for the Stainless→stlc migration and the v2 endpoints aren't ready for public exposure yet. The RC branches need to stay current with upstream so engine isn't building against stale code.

## What it does
- `langsmith-go` `rc/runs-v2-engine` ← `next` (custom code lives off `next`, not the frozen `main`)
- `langsmith-cli` `rc/runs-v2-engine` ← `main`
- Runs every 4h (and on manual dispatch). **Merges** upstream into the RC branch — never rebases or force-pushes — so engine's `go.mod` pin to the RC HEAD stays valid.
- On a merge conflict it aborts (leaving the last-good RC intact) and opens a single deduped issue for manual resolution.

## Prerequisite (inert until configured)
Requires a repo secret `RC_SYNC_TOKEN` with `contents:write` + `issues:write` on **both** `langsmith-go` and `langsmith-cli`. The default `GITHUB_TOKEN` is repo-scoped and cannot push cross-repo. The workflow no-ops/fails harmlessly until the secret is added.

## Test Plan
- [x] Add `RC_SYNC_TOKEN` secret, then trigger via `workflow_dispatch` and confirm both RC branches advance to include upstream commits
- [x] Verify a no-op run (RC already current) succeeds without an empty push
- [x] (optional) Simulate a conflict and confirm an issue is opened rather than a bad merge pushed

## Self-Hosted Release Note
none