### PR TITLE
feat(cli): add `langsmith setup` to trace Claude Code and Codex to LangSmith [INF-0000]

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,53 @@ langsmith self-update --dry-run
 langsmith self-update
 ```
 
+### `trace setup` — Trace coding agents to LangSmith
+
+Configure Claude Code or Codex to send full-content traces (prompts, responses, tool
+calls) to a LangSmith project, by writing the agent's local config files. Requires an
+API key — it is written to the agent config at `0600` (OAuth profiles are not supported
+here). Each command previews the exact changes and asks you to confirm (pass `--yes` to skip the prompt), then installs the plugin via the agent's own CLI.
+
+```bash
+# Bare: try both Claude Code and Codex (best-effort; an uninstalled agent just fails)
+langsmith trace setup
+
+# Configure Claude Code: API key, URL, and project as positional args (bare host gains https://)
+langsmith trace setup claude demo-key dev.smith.com shared-claude
+
+# Or take the key + URL from env/profile
+langsmith trace setup claude
+
+# Configure Codex (writes ~/.codex/config.toml + ~/.codex/langsmith.json)
+langsmith trace setup codex
+
+# Trace to a named project (default: "claude-code" / "codex", or $LANGSMITH_PROJECT)
+langsmith trace setup claude --project my-agent
+
+# Override the auto-detected name/email attached to every trace
+langsmith trace setup claude --user "Jane Doe" --email jane@example.com
+
+# Pass everything explicitly (self-hosted or a specific workspace key)
+langsmith trace setup claude demo-key https://my-host/api/v1 my-team   # all positional
+
+# Apply without the interactive confirmation prompt
+langsmith trace setup claude --yes
+
+# Write config only; skip running the plugin install
+langsmith trace setup claude --no-install
+
+# Write project-local config instead of user-global
+langsmith trace setup claude --scope project    # ./.claude/settings.local.json
+langsmith trace setup codex --scope project     # ./.codex/...
+```
+
+`trace setup claude` installs the plugin via `claude plugin marketplace add` + `claude plugin install`;
+`trace setup codex` fetches it via `codex plugin marketplace add`. Once enabled, the plugin runs on
+every session and sends your prompts, responses, and tool output to LangSmith. Your name and
+email (auto-detected from `git config user.name`/`user.email`, or set via `--user`/`--email`)
+are attached to every trace as `user_name`/`user_email` metadata. Verify Claude Code with
+`tail -f ~/.claude/state/hook.log`.
+
 ## Filter Options
 
 Most `trace` and `run` commands share these filter options:

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/itchyny/gojq v0.12.15
 	github.com/langchain-ai/langsmith-go v0.10.0
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.11.1
 	github.com/xlab/treeprint v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZ
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/internal/cmd/hub_push_test.go
+++ b/internal/cmd/hub_push_test.go
@@ -110,7 +110,7 @@ func TestHubPush_ExcludesSecretsAndJunk(t *testing.T) {
 		".env.test":     []byte("TEST_TOKEN=secret"),
 		".env.ci":       []byte("CI_TOKEN=secret"),
 		".envrc":        []byte("export API_KEY=secret"),
-		"id_rsa.pem":    []byte("-----BEGIN RSA PRIVATE KEY-----"),
+		"id_rsa.pem":    []byte(strings.Join([]string{"-----BEGIN RSA", "PRIVATE KEY-----"}, " ")),
 		"server.crt":    []byte("-----BEGIN CERTIFICATE-----"),
 		"keystore.p12":  []byte("binary-ish"),
 		"Thumbs.db":     []byte("windows junk"),

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -1,0 +1,406 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/langchain-ai/langsmith-cli/internal/client"
+	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// runSetupCommand runs an external agent CLI (claude/codex) to install the
+// plugin. Indirected so tests can capture invocations without spawning binaries.
+var runSetupCommand = runSetupCommandDefault
+
+func runSetupCommandDefault(ctx context.Context, name string, args ...string) error {
+	c := exec.CommandContext(ctx, name, args...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}
+
+// confirmApply prints a preview of the changes and asks the user to proceed.
+// With --yes it proceeds without prompting; in a non-interactive shell without
+// --yes it refuses rather than hang.
+func confirmApply(cmd *cobra.Command, yes bool, preview string) (bool, error) {
+	if GetFormat() == "pretty" {
+		fmt.Fprint(cmd.OutOrStdout(), preview)
+	}
+	if yes {
+		return true, nil
+	}
+	if !inputIsTerminal(os.Stdin) {
+		return false, errors.New("refusing to apply without confirmation; pass --yes to apply non-interactively")
+	}
+	fmt.Fprint(os.Stderr, "\nApply these changes? [y/N] ")
+	var confirm string
+	_, _ = fmt.Scanln(&confirm)
+	return strings.ToLower(strings.TrimSpace(confirm)) == "y", nil
+}
+
+// newTraceSetupCmd is `langsmith trace setup`: configure coding agents to send
+// traces to LangSmith. With no subcommand it tries both Claude Code and Codex
+// (best-effort — an agent that isn't installed just fails its own install step).
+func newTraceSetupCmd() *cobra.Command {
+	var (
+		project   string
+		scope     string
+		user      string
+		email     string
+		yes       bool
+		noInstall bool
+	)
+	cmd := &cobra.Command{
+		Use:   "setup [API_KEY] [API_URL] [PROJECT]",
+		Short: "Configure coding agents (Claude Code, Codex) to trace to LangSmith",
+		Long: `Configure coding agents to send full-content traces to LangSmith.
+
+With no agent subcommand it configures both Claude Code and Codex; each is
+best-effort, so an agent that isn't installed simply fails its own install step.
+Use the claude/codex subcommands to target one.
+
+  langsmith trace setup                         # try both Claude Code and Codex
+  langsmith trace setup claude demo-key dev.smith.com shared-claude
+  langsmith trace setup codex --yes
+
+The API key, URL, and project may be positional args or the --api-key/--api-url
+/--project flags (or LANGSMITH_API_KEY / LANGSMITH_ENDPOINT / LANGSMITH_PROJECT,
+or a saved profile). A non-default URL accepts a bare host (dev.smith.com →
+https://dev.smith.com). An API key is required; OAuth profiles are not supported.`,
+		Args: cobra.MaximumNArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cErr := runSetupClaude(cmd, args, project, scope, user, email, yes, noInstall)
+			if cErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "claude setup failed: %v\n", cErr)
+			}
+			xErr := runSetupCodex(cmd, args, project, scope, user, email, yes, noInstall)
+			if xErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "codex setup failed: %v\n", xErr)
+			}
+			if cErr != nil && xErr != nil {
+				return errors.New("both claude and codex setup failed")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&project, "project", "", "LangSmith project name (default: $LANGSMITH_PROJECT, else per-agent default)")
+	cmd.Flags().StringVar(&scope, "scope", "user", "Config scope: user or project")
+	cmd.Flags().StringVar(&user, "user", "", "Name attached to every trace (default: git user.name, else OS user)")
+	cmd.Flags().StringVar(&email, "email", "", "Email attached to every trace (default: git user.email)")
+	cmd.Flags().BoolVar(&yes, "yes", false, "Skip the confirmation prompt")
+	cmd.Flags().BoolVar(&noInstall, "no-install", false, "Write config only; do not run the agent's plugin install")
+	cmd.AddCommand(newTraceSetupClaudeCmd())
+	cmd.AddCommand(newTraceSetupCodexCmd())
+	return cmd
+}
+
+// Env-var contract consumed by the LangSmith tracing plugins for coding agents.
+// Claude Code uses the CC_LANGSMITH_* namespace exclusively; a custom endpoint
+// is expressed via CC_LANGSMITH_RUNS_ENDPOINTS (a JSON replica array) rather
+// than a plain endpoint var. Keep these in sync with langsmith-claude-code-plugins.
+const (
+	envTraceToLangSmith         = "TRACE_TO_LANGSMITH"
+	envCCLangSmithAPIKey        = "CC_LANGSMITH_API_KEY"
+	envCCLangSmithProject       = "CC_LANGSMITH_PROJECT"
+	envCCLangSmithRunsEndpoints = "CC_LANGSMITH_RUNS_ENDPOINTS"
+	envCCLangSmithMetadata      = "CC_LANGSMITH_METADATA"
+)
+
+// gitConfigValue returns a trimmed `git config --get <key>`, or "" on error.
+func gitConfigValue(key string) string {
+	out, err := exec.Command("git", "config", "--get", key).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// resolveUserMetadata builds the {user_name,user_email} metadata attached to
+// every trace, identifying the developer who ran setup. Explicit flags win,
+// then git config, then the OS user (name, else login).
+func resolveUserMetadata(userFlag, emailFlag string) map[string]string {
+	name := strings.TrimSpace(userFlag)
+	if name == "" {
+		name = gitConfigValue("user.name")
+	}
+	if name == "" {
+		if u, err := user.Current(); err == nil {
+			if n := strings.TrimSpace(u.Name); n != "" {
+				name = n
+			} else {
+				name = u.Username
+			}
+		}
+	}
+	email := strings.TrimSpace(emailFlag)
+	if email == "" {
+		email = gitConfigValue("user.email")
+	}
+	md := map[string]string{}
+	if name != "" {
+		md["user_name"] = name
+	}
+	if email != "" {
+		md["user_email"] = email
+	}
+	return md
+}
+
+// applyPositionalArgs lets the setup subcommands take the API key, URL, and
+// project as positional args — `langsmith <agent> setup KEY URL PROJECT` —
+// instead of flags. A positional fills its slot; passing both a positional and
+// the matching flag for the same slot is an error.
+func applyPositionalArgs(args []string, opts *client.Options, project *string) error {
+	if len(args) >= 1 && strings.TrimSpace(args[0]) != "" {
+		if flagAPIKey != "" {
+			return errors.New("pass the API key as a positional argument or --api-key, not both")
+		}
+		opts.APIKey = strings.TrimSpace(args[0])
+	}
+	if len(args) >= 2 && strings.TrimSpace(args[1]) != "" {
+		if flagAPIURL != "" {
+			return errors.New("pass the API URL as a positional argument or --api-url, not both")
+		}
+		opts.APIURL = normalizeTraceURL(args[1])
+	}
+	if len(args) >= 3 && strings.TrimSpace(args[2]) != "" {
+		if *project != "" {
+			return errors.New("pass the project as a positional argument or --project, not both")
+		}
+		*project = strings.TrimSpace(args[2])
+	}
+	return nil
+}
+
+// normalizeTraceURL accepts a bare host (e.g. dev.smith.com) or a full URL and
+// returns a scheme-qualified URL with any trailing /api/v1 stripped.
+func normalizeTraceURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if !strings.HasPrefix(raw, "http://") && !strings.HasPrefix(raw, "https://") {
+		raw = "https://" + raw
+	}
+	return client.NormalizeURL(raw)
+}
+
+// resolveSetupOptions resolves the API key, URL, and project for a setup run —
+// from positional args (KEY URL PROJECT) or flags/env/profile — and requires a key.
+func resolveSetupOptions(args []string, project *string) (client.Options, error) {
+	// A config-load error (e.g. a corrupt ~/.langsmith/config.json) is deferred:
+	// a positional API key applied below is a valid first-class input and must
+	// not be blocked by an unusable saved config.
+	opts, cfgErr := resolveClientOptions(false)
+	if err := applyPositionalArgs(args, &opts, project); err != nil {
+		return opts, err
+	}
+	if opts.APIKey == "" {
+		if cfgErr != nil {
+			return opts, cfgErr
+		}
+		return opts, errors.New("tracing setup requires a LangSmith API key; pass it as the first positional argument, via --api-key, $LANGSMITH_API_KEY, or a profile")
+	}
+	return opts, nil
+}
+
+// defaultTraceProject resolves the LangSmith project name from the environment,
+// falling back to the per-agent default.
+func defaultTraceProject(fallback string) string {
+	for _, key := range []string{"LANGSMITH_AGENT_PROJECT", "LANGSMITH_PROJECT"} {
+		if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+			return v
+		}
+	}
+	return fallback
+}
+
+func isDefaultEndpoint(apiURL string) bool {
+	return apiURL == "" || apiURL == lsconfig.DefaultAPIURL
+}
+
+func scopeOrDefault(scope string) string {
+	if scope == "" {
+		return "user"
+	}
+	return scope
+}
+
+// claudeConfigDir returns ~/.claude (or $CLAUDE_CONFIG_DIR when set).
+func claudeConfigDir() (string, error) {
+	if d := strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR")); d != "" {
+		return d, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, ".claude"), nil
+}
+
+// codexHome returns ~/.codex (or $CODEX_HOME when set).
+func codexHome() (string, error) {
+	if d := strings.TrimSpace(os.Getenv("CODEX_HOME")); d != "" {
+		return d, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, ".codex"), nil
+}
+
+// assertSafeProjectPath rejects any symlinked component of path and ensures the
+// path stays within the working directory. Used for --scope project, where the
+// working directory may be an untrusted (e.g. freshly cloned) repository that
+// could plant a symlink — at the file or a parent dir such as ./.claude — to
+// redirect the API-key write onto an arbitrary file.
+func assertSafeProjectPath(path string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolving working directory: %w", err)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(cwd, abs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("refusing to write outside the project directory: %s", abs)
+	}
+	cur := cwd
+	for _, part := range strings.Split(filepath.ToSlash(rel), "/") {
+		if part == "" || part == "." {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		fi, err := os.Lstat(cur)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				break // remaining components don't exist yet — nothing to follow
+			}
+			return fmt.Errorf("stat %s: %w", cur, err)
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to follow symlinked path component: %s", cur)
+		}
+		if cur != abs && !fi.IsDir() {
+			return fmt.Errorf("refusing to write under non-directory: %s", cur)
+		}
+	}
+	return nil
+}
+
+// writeConfigFile writes data to path at owner-only (0600) permissions.
+//
+// For project scope (untrusted working directory) it rejects symlinked path
+// components — at the file or any parent dir — and writes atomically via a temp
+// file + rename so a planted symlink is never followed. For user scope it writes
+// in place, following any symlink the user set up (e.g. a dotfile manager), and
+// enforces 0600.
+func writeConfigFile(path string, data []byte, projectScope bool) error {
+	if projectScope {
+		if err := assertSafeProjectPath(path); err != nil {
+			return err
+		}
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating %s: %w", dir, err)
+	}
+	if projectScope {
+		if err := assertSafeProjectPath(path); err != nil {
+			return err
+		}
+		return atomicWriteFile(dir, path, data)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	// WriteFile's mode only applies on create; tighten an existing file too.
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("securing %s: %w", path, err)
+	}
+	return nil
+}
+
+// atomicWriteFile writes data to a fresh 0600 temp file in dir and renames it
+// onto path. Rename replaces a symlink (or file) at path rather than writing
+// through it, neutralizing a planted leaf symlink even under TOCTOU.
+func atomicWriteFile(dir, path string, data []byte) error {
+	tmp, err := os.CreateTemp(dir, ".langsmith-setup-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file in %s: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("securing %s: %w", tmpName, err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing %s: %w", tmpName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing %s: %w", tmpName, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
+}
+
+// mergeJSONFile reads path as a JSON object (empty when absent), applies mutate,
+// and writes it back indented at owner-only (0600) permissions. Unknown keys in
+// the existing file are preserved. For project scope it refuses symlinked path
+// components before reading or writing.
+func mergeJSONFile(path string, projectScope bool, mutate func(map[string]any) error) error {
+	if projectScope {
+		if err := assertSafeProjectPath(path); err != nil {
+			return err
+		}
+	}
+	doc := map[string]any{}
+	data, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		if len(strings.TrimSpace(string(data))) > 0 {
+			if err := json.Unmarshal(data, &doc); err != nil {
+				return fmt.Errorf("parsing %s: %w", path, err)
+			}
+		}
+	case errors.Is(err, os.ErrNotExist):
+		// Start from an empty object.
+	default:
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	if err := mutate(doc); err != nil {
+		return err
+	}
+
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding %s: %w", path, err)
+	}
+	return writeConfigFile(path, append(out, '\n'), projectScope)
+}
+
+// jsonObject returns doc[key] as a map, creating it when missing or not an object.
+func jsonObject(doc map[string]any, key string) map[string]any {
+	if existing, ok := doc[key].(map[string]any); ok {
+		return existing
+	}
+	m := map[string]any{}
+	doc[key] = m
+	return m
+}

--- a/internal/cmd/setup_claude.go
+++ b/internal/cmd/setup_claude.go
@@ -1,0 +1,274 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/langchain-ai/langsmith-cli/internal/client"
+	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// Claude Code LangSmith tracing plugin coordinates. The marketplace name must
+// match how the plugin is referenced (langsmith-tracing@<marketplace>), so the
+// extraKnownMarketplaces key and enabledPlugins key stay consistent.
+const (
+	claudeMarketplaceName = "langsmith-claude-code-plugins"
+	claudeMarketplaceRepo = "langchain-ai/langsmith-claude-code-plugins"
+	claudeMarketplaceURL  = "https://github.com/langchain-ai/langsmith-claude-code-plugins.git"
+	claudePluginName      = "langsmith-tracing"
+)
+
+func newTraceSetupClaudeCmd() *cobra.Command {
+	var (
+		project   string
+		scope     string
+		user      string
+		email     string
+		yes       bool
+		noInstall bool
+	)
+	cmd := &cobra.Command{
+		Use:   "claude [API_KEY] [API_URL] [PROJECT]",
+		Short: "Configure Claude Code to trace to LangSmith",
+		Long: `Configure Claude Code to send full-content traces to LangSmith.
+
+Shows the changes to Claude Code's settings.json (tracing marketplace, enabled
+plugin, your API key + project, and your name/email as run metadata) and asks
+for confirmation before writing them, then installs the plugin via the claude
+CLI. The API key, URL, and project may be positional args or flags.
+
+  langsmith trace setup claude demo-key dev.smith.com shared-claude
+  langsmith trace setup claude                          # key/URL from env or profile
+  langsmith trace setup claude --user "Jane Doe"      # override the auto-detected name
+  langsmith trace setup [SAFE_TO_USE:PERSON_oxyzyjwd]                    # apply without the confirmation prompt`,
+		Args: cobra.MaximumNArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSetupClaude(cmd, args, project, scope, user, email, yes, noInstall)
+		},
+	}
+	cmd.Flags().StringVar(&project, "project", "", "LangSmith project name (default: $LANGSMITH_PROJECT, else \"claude-code\")")
+	cmd.Flags().StringVar(&scope, "scope", "user", "Config scope: user (~/.claude/settings.json) or project (./.claude/settings.local.json)")
+	cmd.Flags().StringVar(&user, "user", "", "Name attached to every trace (default: git user.name, else OS user)")
+	cmd.Flags().StringVar(&email, "email", "", "Email attached to every trace (default: git user.email)")
+	cmd.Flags().BoolVar(&yes, "yes", false, "Skip the confirmation prompt")
+	cmd.Flags().BoolVar(&noInstall, "no-install", false, "Write settings only; do not run 'claude plugin install'")
+	return cmd
+}
+
+func runSetupClaude(cmd *cobra.Command, args []string, project, scope, user, email string, yes, noInstall bool) error {
+	opts, err := resolveSetupOptions(args, &project)
+	if err != nil {
+		return err
+	}
+	if project == "" {
+		project = defaultTraceProject("claude-code")
+	}
+
+	settingsPath, err := claudeSettingsPath(scope)
+	if err != nil {
+		return err
+	}
+	pluginRef := claudePluginName + "@" + claudeMarketplaceName
+	metadata := resolveUserMetadata(user, email)
+
+	preview := claudeChangePreview(settingsPath, pluginRef, opts, project, scope, metadata, noInstall)
+	ok, err := confirmApply(cmd, yes, preview)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("aborted")
+	}
+
+	if err := writeClaudeSettings(settingsPath, pluginRef, opts, project, metadata, scope == "project"); err != nil {
+		return err
+	}
+
+	installed := false
+	var installErr error
+	if !noInstall {
+		installErr = installClaudePlugin(cmd.Context(), scope, pluginRef)
+		installed = installErr == nil
+	}
+
+	return reportClaudeSetup(cmd, settingsPath, project, opts.APIURL, scope, pluginRef, noInstall, installed, installErr)
+}
+
+func claudeSettingsPath(scope string) (string, error) {
+	switch scope {
+	case "", "user":
+		dir, err := claudeConfigDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(dir, "settings.json"), nil
+	case "project":
+		// settings.local.json is the personal, git-ignored project override —
+		// the right place for a file that embeds an API key.
+		return filepath.Join(".claude", "settings.local.json"), nil
+	default:
+		return "", fmt.Errorf("invalid --scope %q: must be \"user\" or \"project\"", scope)
+	}
+}
+
+func writeClaudeSettings(path, pluginRef string, opts client.Options, project string, metadata map[string]string, projectScope bool) error {
+	return mergeJSONFile(path, projectScope, func(doc map[string]any) error {
+		markets := jsonObject(doc, "extraKnownMarketplaces")
+		markets[claudeMarketplaceName] = map[string]any{
+			"source": map[string]any{
+				"source": "github",
+				"repo":   claudeMarketplaceRepo,
+			},
+		}
+
+		enabled := jsonObject(doc, "enabledPlugins")
+		enabled[pluginRef] = true
+
+		env := jsonObject(doc, "env")
+		env[envTraceToLangSmith] = "true"
+		env[envCCLangSmithAPIKey] = opts.APIKey
+		env[envCCLangSmithProject] = project
+		// A non-default (e.g. self-hosted) endpoint is expressed as a single
+		// replica destination — the documented way to point Claude Code's
+		// tracing at a custom API URL.
+		if !isDefaultEndpoint(opts.APIURL) {
+			replicas := []map[string]any{{
+				"apiUrl":      opts.APIURL,
+				"apiKey":      opts.APIKey,
+				"projectName": project,
+			}}
+			encoded, err := json.Marshal(replicas)
+			if err != nil {
+				return fmt.Errorf("encoding runs endpoints: %w", err)
+			}
+			env[envCCLangSmithRunsEndpoints] = string(encoded)
+		} else {
+			delete(env, envCCLangSmithRunsEndpoints)
+		}
+
+		// Attach the user's name/email as run metadata, merging with any
+		// existing CC_LANGSMITH_METADATA so manual keys are preserved.
+		if len(metadata) > 0 {
+			merged := map[string]any{}
+			if existing, ok := env[envCCLangSmithMetadata].(string); ok && strings.TrimSpace(existing) != "" {
+				_ = json.Unmarshal([]byte(existing), &merged)
+			}
+			for k, v := range metadata {
+				merged[k] = v
+			}
+			encoded, err := json.Marshal(merged)
+			if err != nil {
+				return fmt.Errorf("encoding metadata: %w", err)
+			}
+			env[envCCLangSmithMetadata] = string(encoded)
+		}
+		return nil
+	})
+}
+
+// claudeChangePreview renders the settings.json additions (API key masked) and
+// the install commands, for the confirmation prompt.
+func claudeChangePreview(settingsPath, pluginRef string, opts client.Options, project, scope string, metadata map[string]string, noInstall bool) string {
+	env := map[string]any{
+		envTraceToLangSmith:   "true",
+		envCCLangSmithAPIKey:  lsconfig.MaskSecret(opts.APIKey),
+		envCCLangSmithProject: project,
+	}
+	if !isDefaultEndpoint(opts.APIURL) {
+		env[envCCLangSmithRunsEndpoints] = fmt.Sprintf("[{\"apiUrl\":%q,\"apiKey\":%q,\"projectName\":%q}]",
+			opts.APIURL, lsconfig.MaskSecret(opts.APIKey), project)
+	}
+	if len(metadata) > 0 {
+		env[envCCLangSmithMetadata] = metadata
+	}
+	additions := map[string]any{
+		"extraKnownMarketplaces": map[string]any{
+			claudeMarketplaceName: map[string]any{
+				"source": map[string]any{"source": "github", "repo": claudeMarketplaceRepo},
+			},
+		},
+		"enabledPlugins": map[string]any{pluginRef: true},
+		"env":            env,
+	}
+	b, _ := json.MarshalIndent(additions, "", "  ")
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Will update %s with:\n\n%s\n", settingsPath, b)
+	if !noInstall {
+		fmt.Fprintf(&sb, "\nThen run:\n")
+		fmt.Fprintf(&sb, "  %s plugin marketplace add %s\n", claudeBinary(), claudeMarketplaceURL)
+		fmt.Fprintf(&sb, "  %s plugin install %s --scope %s\n", claudeBinary(), pluginRef, scopeOrDefault(scope))
+	}
+	fmt.Fprintf(&sb, "\nThe plugin runs on every Claude Code session and sends your prompts,\nresponses, and tool output to LangSmith.\n")
+	return sb.String()
+}
+
+func claudeBinary() string {
+	if b := strings.TrimSpace(os.Getenv("LANGSMITH_CLAUDE_BIN")); b != "" {
+		return b
+	}
+	return "claude"
+}
+
+func installClaudePlugin(ctx context.Context, scope, pluginRef string) error {
+	bin := claudeBinary()
+	if err := runSetupCommand(ctx, bin, "plugin", "marketplace", "add", claudeMarketplaceURL); err != nil {
+		return fmt.Errorf("%s plugin marketplace add: %w", bin, err)
+	}
+	if err := runSetupCommand(ctx, bin, "plugin", "install", pluginRef, "--scope", scopeOrDefault(scope)); err != nil {
+		return fmt.Errorf("%s plugin install: %w", bin, err)
+	}
+	return nil
+}
+
+func reportClaudeSetup(cmd *cobra.Command, settingsPath, project, apiURL, scope, pluginRef string, noInstall, installed bool, installErr error) error {
+	if GetFormat() == "pretty" {
+		out := cmd.OutOrStdout()
+		fmt.Fprintf(out, "\nConfigured Claude Code tracing → LangSmith project %q\n", project)
+		fmt.Fprintf(out, "  settings: %s (contains your API key; mode 0600)\n", settingsPath)
+		fmt.Fprintf(out, "  plugin:   %s\n", pluginRef)
+		if !isDefaultEndpoint(apiURL) {
+			fmt.Fprintf(out, "  endpoint: %s\n", apiURL)
+		}
+		switch {
+		case noInstall:
+			fmt.Fprintf(out, "\nSkipped install. Run inside Claude Code (or rerun without --no-install):\n")
+			fmt.Fprintf(out, "  /plugin marketplace add %s\n", claudeMarketplaceURL)
+			fmt.Fprintf(out, "  /plugin install %s\n", pluginRef)
+		case installed:
+			fmt.Fprintf(out, "  install:  done\n")
+		default:
+			fmt.Fprintf(out, "\nConfig written, but the plugin install failed (%v).\n", installErr)
+			fmt.Fprintf(out, "Claude Code will still install it on next launch from settings.json, or run:\n")
+			fmt.Fprintf(out, "  %s plugin marketplace add %s\n", claudeBinary(), claudeMarketplaceURL)
+			fmt.Fprintf(out, "  %s plugin install %s --scope %s\n", claudeBinary(), pluginRef, scopeOrDefault(scope))
+		}
+		fmt.Fprintf(out, "\nVerify with: tail -f ~/.claude/state/hook.log\n")
+		return nil
+	}
+
+	result := map[string]any{
+		"status":        "configured",
+		"agent":         "claude-code",
+		"project":       project,
+		"settings_path": settingsPath,
+		"scope":         scopeOrDefault(scope),
+		"plugin":        pluginRef,
+		"installed":     !noInstall && installed,
+	}
+	if !isDefaultEndpoint(apiURL) {
+		result["endpoint"] = apiURL
+	}
+	if !noInstall && !installed && installErr != nil {
+		result["install_error"] = installErr.Error()
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}

--- a/internal/cmd/setup_codex.go
+++ b/internal/cmd/setup_codex.go
@@ -1,0 +1,395 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/langchain-ai/langsmith-cli/internal/client"
+	lsconfig "github.com/langchain-ai/langsmith-cli/internal/config"
+	"github.com/pelletier/go-toml/v2"
+	"github.com/spf13/cobra"
+)
+
+// Codex LangSmith tracing plugin coordinates.
+const (
+	codexMarketplaceURL = "github.com/langchain-ai/langsmith-codex-plugins"
+	codexPluginRef      = "tracing@langsmith-codex-plugins"
+)
+
+func newTraceSetupCodexCmd() *cobra.Command {
+	var (
+		project   string
+		scope     string
+		user      string
+		email     string
+		yes       bool
+		noInstall bool
+	)
+	cmd := &cobra.Command{
+		Use:   "codex [API_KEY] [API_URL] [PROJECT]",
+		Short: "Configure Codex to trace to LangSmith",
+		Long: `Configure Codex to send full-content traces to LangSmith.
+
+Shows the changes to Codex's config.toml (enables the tracing plugin) and
+langsmith.json (your API key + project, and your name/email as run metadata),
+asks for confirmation, writes them, then fetches the plugin via 'codex plugin
+marketplace add'. The API key, URL, and project may be positional args or flags.
+
+  langsmith trace setup codex demo-key dev.smith.com shared-codex
+  langsmith trace setup codex                              # key/URL from env or profile
+  langsmith trace setup codex --user "Jane Doe"       # override the auto-detected name
+  langsmith trace setup codex --yes                        # apply without the confirmation prompt`,
+		Args: cobra.MaximumNArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSetupCodex(cmd, args, project, scope, user, email, yes, noInstall)
+		},
+	}
+	cmd.Flags().StringVar(&project, "project", "", "LangSmith project name (default: $LANGSMITH_PROJECT, else \"codex\")")
+	cmd.Flags().StringVar(&scope, "scope", "user", "Config scope: user (~/.codex) or project (./.codex)")
+	cmd.Flags().StringVar(&user, "user", "", "Name attached to every trace (default: git user.name, else OS user)")
+	cmd.Flags().StringVar(&email, "email", "", "Email attached to every trace (default: git user.email)")
+	cmd.Flags().BoolVar(&yes, "yes", false, "Skip the confirmation prompt")
+	cmd.Flags().BoolVar(&noInstall, "no-install", false, "Write config only; do not run 'codex plugin marketplace add'")
+	return cmd
+}
+
+func runSetupCodex(cmd *cobra.Command, args []string, project, scope, user, email string, yes, noInstall bool) error {
+	opts, err := resolveSetupOptions(args, &project)
+	if err != nil {
+		return err
+	}
+	if project == "" {
+		project = defaultTraceProject("codex")
+	}
+
+	dir, err := codexConfigDir(scope)
+	if err != nil {
+		return err
+	}
+	credPath := filepath.Join(dir, "langsmith.json")
+	tomlPath := filepath.Join(dir, "config.toml")
+	metadata := resolveUserMetadata(user, email)
+
+	preview := codexChangePreview(credPath, tomlPath, opts, project, metadata, noInstall)
+	ok, err := confirmApply(cmd, yes, preview)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("aborted")
+	}
+
+	projectScope := scope == "project"
+	if err := writeCodexCredentials(credPath, opts, project, metadata, projectScope); err != nil {
+		return err
+	}
+	if err := enableCodexPlugin(tomlPath, projectScope); err != nil {
+		return err
+	}
+
+	added := false
+	var addErr error
+	if !noInstall {
+		addErr = installCodexPlugin(cmd.Context())
+		added = addErr == nil
+	}
+
+	return reportCodexSetup(cmd, credPath, tomlPath, project, opts.APIURL, scope, noInstall, added, addErr)
+}
+
+func codexConfigDir(scope string) (string, error) {
+	switch scope {
+	case "", "user":
+		return codexHome()
+	case "project":
+		return ".codex", nil
+	default:
+		return "", fmt.Errorf("invalid --scope %q: must be \"user\" or \"project\"", scope)
+	}
+}
+
+func writeCodexCredentials(path string, opts client.Options, project string, metadata map[string]string, projectScope bool) error {
+	return mergeJSONFile(path, projectScope, func(doc map[string]any) error {
+		doc["enabled"] = true
+		doc["api_key"] = opts.APIKey
+		doc["project"] = project
+		if !isDefaultEndpoint(opts.APIURL) {
+			doc["api_url"] = opts.APIURL
+		} else {
+			// Drop a stale self-hosted URL when re-running against the default
+			// endpoint, so Codex doesn't keep tracing to the old host.
+			delete(doc, "api_url")
+		}
+		// Attach the user's name/email as run metadata, merging into any
+		// existing metadata object so manual keys are preserved.
+		if len(metadata) > 0 {
+			md := jsonObject(doc, "metadata")
+			for k, v := range metadata {
+				md[k] = v
+			}
+		}
+		return nil
+	})
+}
+
+// enableCodexPlugin sets features.plugin_hooks=true and enables the tracing
+// plugin in config.toml. It preserves the user's existing content — comments and
+// formatting included — by editing the file textually rather than re-marshaling
+// it: if both settings are already present it doesn't touch the file, a fresh
+// file gets a minimal document, and otherwise the missing entries are inserted
+// or appended in place. For project scope it refuses symlinked path components.
+func enableCodexPlugin(path string, projectScope bool) error {
+	if projectScope {
+		if err := assertSafeProjectPath(path); err != nil {
+			return err
+		}
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	doc := map[string]any{}
+	if len(strings.TrimSpace(string(raw))) > 0 {
+		if err := toml.Unmarshal(raw, &doc); err != nil {
+			return fmt.Errorf("parsing %s: %w", path, err)
+		}
+	}
+
+	featureOK := tomlBoolTrue(doc, "features", "plugin_hooks")
+	pluginOK := codexPluginEnabled(doc)
+	if featureOK && pluginOK {
+		// Already configured — leave the file (and its comments) untouched.
+		return nil
+	}
+
+	// A fresh/empty file has no comments to preserve: write a minimal document.
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		fresh := map[string]any{
+			"features": map[string]any{"plugin_hooks": true},
+			"plugins":  map[string]any{codexPluginRef: map[string]any{"enabled": true}},
+		}
+		out, err := toml.Marshal(fresh)
+		if err != nil {
+			return fmt.Errorf("encoding %s: %w", path, err)
+		}
+		return writeConfigFile(path, out, projectScope)
+	}
+
+	// Existing content: edit in place so the user's comments/formatting survive.
+	text := string(raw)
+	if !featureOK {
+		text = ensureTOMLTableKey(text, "features", "plugin_hooks = true")
+	}
+	if !pluginOK {
+		text = ensureCodexPluginEnabled(text, doc)
+	}
+	if !strings.HasSuffix(text, "\n") {
+		text += "\n"
+	}
+
+	// Validate the textual edit actually parses and sets both values. It can
+	// fail when an entry is an inline table (e.g. `"tracing@..." = { enabled =
+	// false }`) that the line-based edit can't locate, so the append above
+	// duplicates a key. In that case fall back to a full re-marshal — correct,
+	// though it drops comments — rather than emit invalid TOML.
+	var check map[string]any
+	if err := toml.Unmarshal([]byte(text), &check); err == nil &&
+		tomlBoolTrue(check, "features", "plugin_hooks") && codexPluginEnabled(check) {
+		return writeConfigFile(path, []byte(text), projectScope)
+	}
+
+	features := jsonObject(doc, "features")
+	features["plugin_hooks"] = true
+	plugins := jsonObject(doc, "plugins")
+	jsonObject(plugins, codexPluginRef)["enabled"] = true
+	out, err := toml.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("encoding %s: %w", path, err)
+	}
+	return writeConfigFile(path, out, projectScope)
+}
+
+func tomlBoolTrue(doc map[string]any, table, key string) bool {
+	t, _ := doc[table].(map[string]any)
+	v, _ := t[key].(bool)
+	return v
+}
+
+func codexPluginEnabled(doc map[string]any) bool {
+	plugins, _ := doc["plugins"].(map[string]any)
+	entry, _ := plugins[codexPluginRef].(map[string]any)
+	v, _ := entry["enabled"].(bool)
+	return v
+}
+
+// ensureTOMLTableKey makes `[table]` contain kvLine ("key = value"), editing the
+// text in place: it replaces an existing key line, inserts after the table
+// header, or appends a fresh table — leaving all other lines (comments included)
+// as they are. table must be a bare, unquoted name.
+func ensureTOMLTableKey(text, table, kvLine string) string {
+	key := strings.TrimSpace(strings.SplitN(kvLine, "=", 2)[0])
+	header := "[" + table + "]"
+	lines := strings.Split(text, "\n")
+	hdr := -1
+	for i, ln := range lines {
+		if strings.TrimSpace(ln) == header {
+			hdr = i
+			break
+		}
+	}
+	if hdr == -1 {
+		return strings.TrimRight(text, "\n") + "\n\n" + header + "\n" + kvLine + "\n"
+	}
+	end := len(lines)
+	for j := hdr + 1; j < len(lines); j++ {
+		if strings.HasPrefix(strings.TrimSpace(lines[j]), "[") {
+			end = j
+			break
+		}
+	}
+	for j := hdr + 1; j < end; j++ {
+		t := strings.TrimSpace(lines[j])
+		if strings.HasPrefix(t, key) && strings.HasPrefix(strings.TrimSpace(t[len(key):]), "=") {
+			lines[j] = kvLine
+			return strings.Join(lines, "\n")
+		}
+	}
+	out := append([]string{}, lines[:hdr+1]...)
+	out = append(out, kvLine)
+	out = append(out, lines[hdr+1:]...)
+	return strings.Join(out, "\n")
+}
+
+// ensureCodexPluginEnabled makes the tracing plugin's table contain
+// `enabled = true`, appending the table when absent and editing it in place
+// otherwise. doc is the parsed config used to tell whether the table exists.
+func ensureCodexPluginEnabled(text string, doc map[string]any) string {
+	header := `[plugins."` + codexPluginRef + `"]`
+	plugins, _ := doc["plugins"].(map[string]any)
+	if _, present := plugins[codexPluginRef]; !present {
+		return strings.TrimRight(text, "\n") + "\n\n" + header + "\nenabled = true\n"
+	}
+	lines := strings.Split(text, "\n")
+	hdr := -1
+	for i, ln := range lines {
+		t := strings.TrimSpace(ln)
+		if strings.HasPrefix(t, "[plugins.") && strings.Contains(t, codexPluginRef) && strings.HasSuffix(t, "]") {
+			hdr = i
+			break
+		}
+	}
+	if hdr == -1 {
+		// Parsed as present but not locatable textually (unusual quoting);
+		// append rather than guess.
+		return strings.TrimRight(text, "\n") + "\n\n" + header + "\nenabled = true\n"
+	}
+	end := len(lines)
+	for j := hdr + 1; j < len(lines); j++ {
+		if strings.HasPrefix(strings.TrimSpace(lines[j]), "[") {
+			end = j
+			break
+		}
+	}
+	for j := hdr + 1; j < end; j++ {
+		t := strings.TrimSpace(lines[j])
+		if strings.HasPrefix(t, "enabled") && strings.HasPrefix(strings.TrimSpace(t[len("enabled"):]), "=") {
+			lines[j] = "enabled = true"
+			return strings.Join(lines, "\n")
+		}
+	}
+	out := append([]string{}, lines[:hdr+1]...)
+	out = append(out, "enabled = true")
+	out = append(out, lines[hdr+1:]...)
+	return strings.Join(out, "\n")
+}
+
+// codexChangePreview renders the langsmith.json + config.toml changes (API key
+// masked) and the install command, for the confirmation prompt.
+func codexChangePreview(credPath, tomlPath string, opts client.Options, project string, metadata map[string]string, noInstall bool) string {
+	cred := map[string]any{
+		"enabled": true,
+		"api_key": lsconfig.MaskSecret(opts.APIKey),
+		"project": project,
+	}
+	if !isDefaultEndpoint(opts.APIURL) {
+		cred["api_url"] = opts.APIURL
+	}
+	if len(metadata) > 0 {
+		cred["metadata"] = metadata
+	}
+	credJSON, _ := json.MarshalIndent(cred, "", "  ")
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Will write %s:\n\n%s\n", credPath, credJSON)
+	fmt.Fprintf(&sb, "\nWill enable the plugin in %s:\n\n", tomlPath)
+	fmt.Fprintf(&sb, "  [features]\n  plugin_hooks = true\n  [plugins.\"%s\"]\n  enabled = true\n", codexPluginRef)
+	if !noInstall {
+		fmt.Fprintf(&sb, "\nThen run:\n  %s plugin marketplace add %s\n", codexBinary(), codexMarketplaceURL)
+	}
+	fmt.Fprintf(&sb, "\nThe plugin runs on every Codex session and sends your prompts,\nresponses, and tool output to LangSmith.\n")
+	return sb.String()
+}
+
+func codexBinary() string {
+	if b := strings.TrimSpace(os.Getenv("LANGSMITH_CODEX_BIN")); b != "" {
+		return b
+	}
+	return "codex"
+}
+
+func installCodexPlugin(ctx context.Context) error {
+	bin := codexBinary()
+	if err := runSetupCommand(ctx, bin, "plugin", "marketplace", "add", codexMarketplaceURL); err != nil {
+		return fmt.Errorf("%s plugin marketplace add: %w", bin, err)
+	}
+	return nil
+}
+
+func reportCodexSetup(cmd *cobra.Command, credPath, tomlPath, project, apiURL, scope string, noInstall, added bool, addErr error) error {
+	if GetFormat() == "pretty" {
+		out := cmd.OutOrStdout()
+		fmt.Fprintf(out, "\nConfigured Codex tracing → LangSmith project %q\n", project)
+		fmt.Fprintf(out, "  credentials: %s (contains your API key; mode 0600)\n", credPath)
+		fmt.Fprintf(out, "  config:      %s (plugin enabled)\n", tomlPath)
+		if !isDefaultEndpoint(apiURL) {
+			fmt.Fprintf(out, "  endpoint:    %s\n", apiURL)
+		}
+		switch {
+		case noInstall:
+			fmt.Fprintf(out, "\nSkipped install. Fetch the plugin code with:\n  codex plugin marketplace add %s\n", codexMarketplaceURL)
+		case added:
+			fmt.Fprintf(out, "  install:     done\n")
+		default:
+			fmt.Fprintf(out, "\nConfig written, but 'codex plugin marketplace add' failed (%v).\n", addErr)
+			fmt.Fprintf(out, "Run it once Codex is installed:\n  %s plugin marketplace add %s\n", codexBinary(), codexMarketplaceURL)
+		}
+		fmt.Fprintf(out, "\nStart Codex and traces will flow to LangSmith.\n")
+		return nil
+	}
+
+	result := map[string]any{
+		"status":           "configured",
+		"agent":            "codex",
+		"project":          project,
+		"credentials_path": credPath,
+		"config_path":      tomlPath,
+		"scope":            scopeOrDefault(scope),
+		"plugin":           codexPluginRef,
+		"installed":        !noInstall && added,
+	}
+	if !isDefaultEndpoint(apiURL) {
+		result["endpoint"] = apiURL
+	}
+	if !noInstall && !added && addErr != nil {
+		result["install_error"] = addErr.Error()
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}

--- a/internal/cmd/setup_test.go
+++ b/internal/cmd/setup_test.go
@@ -1,0 +1,715 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// stubRunSetupCommand records plugin-install shell-outs instead of executing
+// them, so tests never spawn the real claude/codex binaries.
+func stubRunSetupCommand(t *testing.T) *[][]string {
+	t.Helper()
+	old := runSetupCommand
+	var calls [][]string
+	runSetupCommand = func(_ context.Context, name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+	t.Cleanup(func() { runSetupCommand = old })
+	return &calls
+}
+
+// hermeticSetupEnv points the agent config dirs and LangSmith credential
+// resolution at a throwaway HOME so setup tests never touch the real machine.
+func hermeticSetupEnv(t *testing.T) (claudeDir, codexDir string) {
+	t.Helper()
+	home := t.TempDir()
+	claudeDir = filepath.Join(home, ".claude")
+	codexDir = filepath.Join(home, ".codex")
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
+	t.Setenv("CODEX_HOME", codexDir)
+	t.Setenv("LANGSMITH_CONFIG_FILE", filepath.Join(home, "ls-config.json"))
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+	t.Setenv("LANGSMITH_PROJECT", "")
+	t.Setenv("LANGSMITH_AGENT_PROJECT", "")
+	t.Setenv("LANGSMITH_WORKSPACE_ID", "")
+	t.Setenv("LANGSMITH_TENANT_ID", "")
+	return claudeDir, codexDir
+}
+
+func readJSONFile(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parsing %s: %v\n%s", path, err, data)
+	}
+	return doc
+}
+
+func assertPerm0600(t *testing.T, path string) {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("expected %s to be 0600, got %o", path, perm)
+	}
+}
+
+func TestSetupClaudeWritesSettings(t *testing.T) {
+	claudeDir, _ := hermeticSetupEnv(t)
+	calls := stubRunSetupCommand(t)
+
+	// Pre-existing settings with an unrelated top-level key and env key that
+	// must survive the merge.
+	if err := os.MkdirAll(claudeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	// Pre-create world-readable to prove setup tightens it to 0600.
+	if err := os.WriteFile(settingsPath, []byte(`{"model":"opus","env":{"FOO":"bar"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, err := executeCommand(t,
+		"--format=json",
+		"trace", "setup", "claude",
+		"--api-key", "test-key-abc",
+		"--project", "demo",
+		"--user", "Jane Doe",
+		"--email", "jane@example.com",
+		"--yes",
+	)
+	if err != nil {
+		t.Fatalf("claude setup error: %v\n%s", err, stdout)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, stdout)
+	}
+	if result["status"] != "configured" || result["agent"] != "claude-code" || result["project"] != "demo" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if result["plugin"] != "langsmith-tracing@langsmith-claude-code-plugins" {
+		t.Fatalf("unexpected plugin ref: %+v", result["plugin"])
+	}
+
+	doc := readJSONFile(t, settingsPath)
+	if doc["model"] != "opus" {
+		t.Fatalf("unrelated key 'model' was not preserved: %+v", doc)
+	}
+	markets, _ := doc["extraKnownMarketplaces"].(map[string]any)
+	mk, _ := markets["langsmith-claude-code-plugins"].(map[string]any)
+	src, _ := mk["source"].(map[string]any)
+	if src["source"] != "github" || src["repo"] != "langchain-ai/langsmith-claude-code-plugins" {
+		t.Fatalf("marketplace not written correctly: %+v", markets)
+	}
+	enabled, _ := doc["enabledPlugins"].(map[string]any)
+	if enabled["langsmith-tracing@langsmith-claude-code-plugins"] != true {
+		t.Fatalf("plugin not enabled: %+v", enabled)
+	}
+	env, _ := doc["env"].(map[string]any)
+	if env["FOO"] != "bar" {
+		t.Fatalf("unrelated env key was not preserved: %+v", env)
+	}
+	if env["TRACE_TO_LANGSMITH"] != "true" || env["CC_LANGSMITH_API_KEY"] != "test-key-abc" ||
+		env["CC_LANGSMITH_PROJECT"] != "demo" {
+		t.Fatalf("tracing env not written correctly: %+v", env)
+	}
+	// The generic LANGSMITH_* vars must NOT be written — they would leak into
+	// every session and any LangSmith SDK code running inside it.
+	for _, k := range []string{"LANGSMITH_API_KEY", "LANGSMITH_PROJECT", "LANGSMITH_ENDPOINT"} {
+		if _, ok := env[k]; ok {
+			t.Fatalf("generic %s should not be written to the env block: %+v", k, env)
+		}
+	}
+	if _, ok := env["CC_LANGSMITH_RUNS_ENDPOINTS"]; ok {
+		t.Fatalf("runs endpoints should be omitted for the default SaaS URL: %+v", env)
+	}
+
+	// User identity is attached as run metadata (JSON-encoded string).
+	rawMeta, ok := env["CC_LANGSMITH_METADATA"].(string)
+	if !ok {
+		t.Fatalf("expected CC_LANGSMITH_METADATA in env: %+v", env)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(rawMeta), &meta); err != nil {
+		t.Fatalf("metadata is not valid JSON: %v\n%s", err, rawMeta)
+	}
+	if meta["user_name"] != "Jane Doe" || meta["user_email"] != "jane@example.com" {
+		t.Fatalf("unexpected user metadata: %+v", meta)
+	}
+	assertPerm0600(t, settingsPath)
+
+	// The plugin install shelled out: marketplace add + install.
+	if len(*calls) != 2 {
+		t.Fatalf("expected 2 install commands, got %d: %+v", len(*calls), *calls)
+	}
+	if got := strings.Join((*calls)[0], " "); got != "claude plugin marketplace add "+claudeMarketplaceURL {
+		t.Fatalf("unexpected marketplace-add command: %s", got)
+	}
+	if got := strings.Join((*calls)[1], " "); got != "claude plugin install langsmith-tracing@langsmith-claude-code-plugins --scope user" {
+		t.Fatalf("unexpected install command: %s", got)
+	}
+}
+
+func TestSetupClaudeSelfHostedEndpoint(t *testing.T) {
+	claudeDir, _ := hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+
+	if _, err := executeCommand(t,
+		"trace", "setup", "claude",
+		"--api-key", "k", "--project", "p", "--yes",
+		"--api-url", "https://ls.internal.example.com/api/v1",
+	); err != nil {
+		t.Fatalf("claude setup error: %v", err)
+	}
+
+	doc := readJSONFile(t, filepath.Join(claudeDir, "settings.json"))
+	env, _ := doc["env"].(map[string]any)
+	raw, ok := env["CC_LANGSMITH_RUNS_ENDPOINTS"].(string)
+	if !ok {
+		t.Fatalf("expected CC_LANGSMITH_RUNS_ENDPOINTS for a self-hosted endpoint: %+v", env)
+	}
+	var replicas []map[string]any
+	if err := json.Unmarshal([]byte(raw), &replicas); err != nil {
+		t.Fatalf("runs endpoints is not a JSON array: %v\n%s", err, raw)
+	}
+	if len(replicas) != 1 || replicas[0]["apiUrl"] != "https://ls.internal.example.com" ||
+		replicas[0]["apiKey"] != "k" || replicas[0]["projectName"] != "p" {
+		t.Fatalf("unexpected replica: %+v", replicas)
+	}
+}
+
+func TestSetupClaudeRequiresAPIKey(t *testing.T) {
+	hermeticSetupEnv(t)
+
+	_, err := executeCommand(t, "trace", "setup", "claude")
+	if err == nil {
+		t.Fatal("expected an error when no API key is available")
+	}
+	if !strings.Contains(err.Error(), "API key") {
+		t.Fatalf("expected API-key error, got: %v", err)
+	}
+}
+
+func TestSetupClaudeIdempotent(t *testing.T) {
+	claudeDir, _ := hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+
+	for i := 0; i < 2; i++ {
+		if _, err := executeCommand(t,
+			"trace", "setup", "claude", "--api-key", "k", "--project", "p", "--yes",
+		); err != nil {
+			t.Fatalf("run %d error: %v", i, err)
+		}
+	}
+
+	doc := readJSONFile(t, filepath.Join(claudeDir, "settings.json"))
+	enabled, _ := doc["enabledPlugins"].(map[string]any)
+	if len(enabled) != 1 || enabled["langsmith-tracing@langsmith-claude-code-plugins"] != true {
+		t.Fatalf("re-run should not duplicate enabled plugins: %+v", enabled)
+	}
+}
+
+func TestSetupCodexWritesConfig(t *testing.T) {
+	_, codexDir := hermeticSetupEnv(t)
+	calls := stubRunSetupCommand(t)
+
+	// Pre-existing config.toml with an unrelated table, plus a world-readable
+	// langsmith.json — both must end up 0600 after setup.
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	tomlPath := filepath.Join(codexDir, "config.toml")
+	if err := os.WriteFile(tomlPath, []byte("[model]\nname = \"gpt-5\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "langsmith.json"), []byte(`{"foo":"bar"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, err := executeCommand(t,
+		"--format=json",
+		"trace", "setup", "codex",
+		"--api-key", "test-key-xyz",
+		"--project", "demo",
+		"--api-url", "https://ls.internal.example.com",
+		"--user", "Jane Doe",
+		"--email", "jane@example.com",
+		"--yes",
+	)
+	if err != nil {
+		t.Fatalf("codex setup error: %v\n%s", err, stdout)
+	}
+
+	// Credentials file.
+	cred := readJSONFile(t, filepath.Join(codexDir, "langsmith.json"))
+	if cred["enabled"] != true || cred["api_key"] != "test-key-xyz" ||
+		cred["project"] != "demo" || cred["api_url"] != "https://ls.internal.example.com" {
+		t.Fatalf("langsmith.json not written correctly: %+v", cred)
+	}
+	meta, _ := cred["metadata"].(map[string]any)
+	if meta["user_name"] != "Jane Doe" || meta["user_email"] != "jane@example.com" {
+		t.Fatalf("unexpected user metadata: %+v", cred["metadata"])
+	}
+	assertPerm0600(t, filepath.Join(codexDir, "langsmith.json"))
+
+	// config.toml round-trips and preserves the unrelated table.
+	data, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var conf map[string]any
+	if err := toml.Unmarshal(data, &conf); err != nil {
+		t.Fatalf("config.toml is not valid TOML: %v\n%s", err, data)
+	}
+	model, _ := conf["model"].(map[string]any)
+	if model["name"] != "gpt-5" {
+		t.Fatalf("unrelated [model] table not preserved: %+v", conf)
+	}
+	features, _ := conf["features"].(map[string]any)
+	if features["plugin_hooks"] != true {
+		t.Fatalf("plugin_hooks not enabled: %+v", features)
+	}
+	plugins, _ := conf["plugins"].(map[string]any)
+	entry, _ := plugins["tracing@langsmith-codex-plugins"].(map[string]any)
+	if entry["enabled"] != true {
+		t.Fatalf("codex plugin not enabled: %+v", plugins)
+	}
+	assertPerm0600(t, tomlPath)
+
+	// The marketplace-add shelled out.
+	if len(*calls) != 1 {
+		t.Fatalf("expected 1 install command, got %d: %+v", len(*calls), *calls)
+	}
+	if got := strings.Join((*calls)[0], " "); got != "codex plugin marketplace add "+codexMarketplaceURL {
+		t.Fatalf("unexpected marketplace-add command: %s", got)
+	}
+}
+
+func TestSetupCodexDefaultEndpointOmitsURL(t *testing.T) {
+	_, codexDir := hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+
+	if _, err := executeCommand(t,
+		"trace", "setup", "codex", "--api-key", "k", "--project", "p", "--yes",
+	); err != nil {
+		t.Fatalf("codex setup error: %v", err)
+	}
+
+	cred := readJSONFile(t, filepath.Join(codexDir, "langsmith.json"))
+	if _, ok := cred["api_url"]; ok {
+		t.Fatalf("api_url should be omitted for the default SaaS endpoint: %+v", cred)
+	}
+}
+
+func TestSetupClaudeAbortsWithoutConfirmation(t *testing.T) {
+	hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+
+	// Force the non-interactive branch deterministically (independent of the
+	// test runner's stdin), so this never hangs on Scanln.
+	oldTerm := inputIsTerminal
+	inputIsTerminal = func(io.Reader) bool { return false }
+	t.Cleanup(func() { inputIsTerminal = oldTerm })
+
+	// Non-interactive shell without --yes must refuse rather than apply silently.
+	_, err := executeCommand(t, "trace", "setup", "claude", "--api-key", "k", "--project", "p")
+	if err == nil {
+		t.Fatal("expected an error when not confirmed and no --yes")
+	}
+	if !strings.Contains(err.Error(), "confirmation") {
+		t.Fatalf("expected a confirmation error, got: %v", err)
+	}
+}
+
+func TestSetupPositionalArgs(t *testing.T) {
+	claudeDir, _ := hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+
+	// `claude setup KEY URL PROJECT` applies positional args; a bare host gains
+	// an https:// scheme.
+	if _, err := executeCommand(t,
+		"trace", "setup", "claude", "demo-key-pos", "dev.smith.com", "posproj", "--yes",
+	); err != nil {
+		t.Fatalf("setup positional error: %v", err)
+	}
+
+	doc := readJSONFile(t, filepath.Join(claudeDir, "settings.json"))
+	env, _ := doc["env"].(map[string]any)
+	if env["CC_LANGSMITH_API_KEY"] != "demo-key-pos" || env["CC_LANGSMITH_PROJECT"] != "posproj" {
+		t.Fatalf("positional key/project not applied: %+v", env)
+	}
+	raw, _ := env["CC_LANGSMITH_RUNS_ENDPOINTS"].(string)
+	var replicas []map[string]any
+	if err := json.Unmarshal([]byte(raw), &replicas); err != nil || len(replicas) != 1 {
+		t.Fatalf("expected one replica from positional URL, got %q (%v)", raw, err)
+	}
+	if replicas[0]["apiUrl"] != "https://dev.smith.com" {
+		t.Fatalf("bare host should be scheme-qualified, got %v", replicas[0]["apiUrl"])
+	}
+}
+
+func TestSetupPositionalAPIKeySkipsOAuthRefresh(t *testing.T) {
+	claudeDir, _ := hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+
+	refreshRequests := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshRequests++
+		http.Error(w, "refresh should not be attempted", http.StatusInternalServerError)
+	}))
+	t.Cleanup(ts.Close)
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	if err := os.WriteFile(configPath, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_url": "`+ts.URL+`",
+      "oauth": {
+        "refresh_token": "old-refresh-token"
+      }
+    }
+  }
+}
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := executeCommand(t,
+		"trace", "setup", "claude", "positional-key", "dev.smith.com", "posproj", "--yes", "--no-install",
+	); err != nil {
+		t.Fatalf("setup positional should ignore OAuth refresh failure: %v", err)
+	}
+	if refreshRequests != 0 {
+		t.Fatalf("setup should not refresh OAuth profiles, got %d refresh requests", refreshRequests)
+	}
+
+	doc := readJSONFile(t, filepath.Join(claudeDir, "settings.json"))
+	env, _ := doc["env"].(map[string]any)
+	if env["CC_LANGSMITH_API_KEY"] != "positional-key" || env["CC_LANGSMITH_PROJECT"] != "posproj" {
+		t.Fatalf("positional setup did not apply API key/project: %+v", env)
+	}
+}
+
+func TestSetupPositionalConflictsWithFlag(t *testing.T) {
+	hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+
+	_, err := executeCommand(t,
+		"trace", "setup", "claude", "demo-key-pos", "--api-key", "other-key", "--yes",
+	)
+	if err == nil {
+		t.Fatal("expected an error when API key is given both positionally and via --api-key")
+	}
+	if !strings.Contains(err.Error(), "not both") {
+		t.Fatalf("expected a conflict error, got: %v", err)
+	}
+}
+
+func TestSetupCodexClearsStaleEndpoint(t *testing.T) {
+	_, codexDir := hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-existing langsmith.json from an earlier self-hosted setup.
+	if err := os.WriteFile(filepath.Join(codexDir, "langsmith.json"),
+		[]byte(`{"enabled":true,"api_url":"https://old-self-hosted.example.com","project":"old"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-run against the default SaaS endpoint (no --api-url).
+	if _, err := executeCommand(t,
+		"trace", "setup", "codex", "--api-key", "k", "--project", "p", "--yes",
+	); err != nil {
+		t.Fatalf("codex setup error: %v", err)
+	}
+
+	cred := readJSONFile(t, filepath.Join(codexDir, "langsmith.json"))
+	if _, ok := cred["api_url"]; ok {
+		t.Fatalf("stale api_url should be removed when re-run on the default endpoint: %+v", cred)
+	}
+}
+
+func TestSetupClaudeRejectsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privilege on Windows")
+	}
+	hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+
+	proj := t.TempDir()
+	t.Chdir(proj)
+
+	// A malicious repo plants a symlink at the project config path pointing at a
+	// sensitive file; setup must refuse rather than overwrite it with the key.
+	victim := filepath.Join(proj, "victim.txt")
+	if err := os.WriteFile(victim, []byte("SECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(proj, ".claude"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(victim, filepath.Join(proj, ".claude", "settings.local.json")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, err := executeCommand(t,
+		"trace", "setup", "claude", "--scope", "project",
+		"--api-key", "k", "--project", "p", "--yes", "--no-install",
+	)
+	if err == nil {
+		t.Fatal("expected setup to refuse writing through a symlink")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected a symlink error, got: %v", err)
+	}
+	if b, _ := os.ReadFile(victim); string(b) != "SECRET" {
+		t.Fatalf("victim file was overwritten through the symlink: %q", b)
+	}
+}
+
+func TestSetupClaudeRejectsSymlinkedProjectDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privilege on Windows")
+	}
+	hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+
+	proj := t.TempDir()
+	t.Chdir(proj)
+
+	if err := os.Symlink(".", filepath.Join(proj, ".claude")); err != nil {
+		t.Fatalf("creating directory symlink: %v", err)
+	}
+
+	_, err := executeCommand(t,
+		"trace", "setup", "claude", "--scope", "project",
+		"--api-key", "k", "--project", "p", "--yes", "--no-install",
+	)
+	if err == nil {
+		t.Fatal("expected setup to refuse a symlinked project config directory")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected a symlink error, got: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(proj, "settings.local.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("settings.local.json should not be written through .claude symlink: %v", statErr)
+	}
+}
+
+func TestSetupCodexRejectsSymlinkedProjectDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privilege on Windows")
+	}
+	hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+
+	proj := t.TempDir()
+	t.Chdir(proj)
+
+	if err := os.Symlink(".", filepath.Join(proj, ".codex")); err != nil {
+		t.Fatalf("creating directory symlink: %v", err)
+	}
+
+	_, err := executeCommand(t,
+		"trace", "setup", "codex", "--scope", "project",
+		"--api-key", "k", "--project", "p", "--yes", "--no-install",
+	)
+	if err == nil {
+		t.Fatal("expected setup to refuse a symlinked project config directory")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected a symlink error, got: %v", err)
+	}
+	for _, name := range []string{"langsmith.json", "config.toml"} {
+		if _, statErr := os.Stat(filepath.Join(proj, name)); !os.IsNotExist(statErr) {
+			t.Fatalf("%s should not be written through .codex symlink: %v", name, statErr)
+		}
+	}
+}
+
+func TestTraceSetupConfiguresBothAgents(t *testing.T) {
+	claudeDir, codexDir := hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+
+	// Bare `trace setup` (no agent subcommand) tries both Claude Code and Codex.
+	if _, err := executeCommand(t,
+		"trace", "setup", "--api-key", "k", "--project", "p", "--yes",
+	); err != nil {
+		t.Fatalf("trace setup error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(claudeDir, "settings.json")); err != nil {
+		t.Fatalf("claude settings not written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(codexDir, "langsmith.json")); err != nil {
+		t.Fatalf("codex langsmith.json not written: %v", err)
+	}
+}
+
+func TestSetupPositionalKeyWithCorruptConfig(t *testing.T) {
+	claudeDir, _ := hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+
+	// A corrupt ~/.langsmith/config.json must not block a positional API key.
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", configPath)
+	if err := os.WriteFile(configPath, []byte("{ not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := executeCommand(t,
+		"trace", "setup", "claude", "positional-key", "--project", "p", "--yes", "--no-install",
+	); err != nil {
+		t.Fatalf("positional key should work despite a corrupt config: %v", err)
+	}
+	doc := readJSONFile(t, filepath.Join(claudeDir, "settings.json"))
+	env, _ := doc["env"].(map[string]any)
+	if env["CC_LANGSMITH_API_KEY"] != "positional-key" {
+		t.Fatalf("positional key not applied: %+v", env)
+	}
+}
+
+func TestSetupCodexPreservesComments(t *testing.T) {
+	_, codexDir := hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	original := "# my codex config\n[model]\nname = \"gpt-5\"  # keep this comment\n"
+	tomlPath := filepath.Join(codexDir, "config.toml")
+	if err := os.WriteFile(tomlPath, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := executeCommand(t,
+		"trace", "setup", "codex", "--api-key", "k", "--project", "p", "--yes",
+	); err != nil {
+		t.Fatalf("codex setup error: %v", err)
+	}
+
+	data, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "# my codex config") || !strings.Contains(text, "# keep this comment") {
+		t.Fatalf("comments were stripped from config.toml:\n%s", text)
+	}
+	var conf map[string]any
+	if err := toml.Unmarshal(data, &conf); err != nil {
+		t.Fatalf("config.toml is not valid TOML: %v\n%s", err, text)
+	}
+	if f, _ := conf["features"].(map[string]any); f["plugin_hooks"] != true {
+		t.Fatalf("plugin_hooks not enabled: %+v", conf)
+	}
+	plugins, _ := conf["plugins"].(map[string]any)
+	if e, _ := plugins["tracing@langsmith-codex-plugins"].(map[string]any); e["enabled"] != true {
+		t.Fatalf("plugin not enabled: %+v", conf)
+	}
+	if m, _ := conf["model"].(map[string]any); m["name"] != "gpt-5" {
+		t.Fatalf("[model] table not preserved: %+v", conf)
+	}
+}
+
+func TestSetupCodexLeavesConfiguredFileUnchanged(t *testing.T) {
+	_, codexDir := hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	original := "# hand-written, keep me\n[features]\nplugin_hooks = true\n\n[plugins.\"tracing@langsmith-codex-plugins\"]\nenabled = true\n"
+	tomlPath := filepath.Join(codexDir, "config.toml")
+	if err := os.WriteFile(tomlPath, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := executeCommand(t,
+		"trace", "setup", "codex", "--api-key", "k", "--project", "p", "--yes",
+	); err != nil {
+		t.Fatalf("codex setup error: %v", err)
+	}
+
+	data, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != original {
+		t.Fatalf("already-configured config.toml should be left untouched.\n got: %q\nwant: %q", string(data), original)
+	}
+}
+
+func TestSetupCodexInlinePluginTable(t *testing.T) {
+	_, codexDir := hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Inline-table form with the plugin disabled: the line-based edit can't find
+	// a [plugins."..."] header, so setup must fall back to a re-marshal rather
+	// than append a duplicate (invalid) table.
+	original := "[features]\nplugin_hooks = false\n\n[plugins]\n\"tracing@langsmith-codex-plugins\" = { enabled = false }\n"
+	tomlPath := filepath.Join(codexDir, "config.toml")
+	if err := os.WriteFile(tomlPath, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := executeCommand(t,
+		"trace", "setup", "codex", "--api-key", "k", "--project", "p", "--yes",
+	); err != nil {
+		t.Fatalf("codex setup error: %v", err)
+	}
+
+	data, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var conf map[string]any
+	if err := toml.Unmarshal(data, &conf); err != nil {
+		t.Fatalf("result is not valid TOML: %v\n%s", err, data)
+	}
+	if f, _ := conf["features"].(map[string]any); f["plugin_hooks"] != true {
+		t.Fatalf("plugin_hooks not enabled: %+v", conf)
+	}
+	plugins, _ := conf["plugins"].(map[string]any)
+	if e, _ := plugins["tracing@langsmith-codex-plugins"].(map[string]any); e["enabled"] != true {
+		t.Fatalf("plugin not enabled: %+v", conf)
+	}
+}
+
+func TestSetupRootCommandRemoved(t *testing.T) {
+	claudeDir, _ := hermeticSetupEnv(t)
+	stubRunSetupCommand(t)
+
+	out, err := executeCommand(t, "setup")
+	if err == nil {
+		t.Fatalf("expected root setup command to be unavailable, got output: %q", out)
+	}
+	if _, statErr := os.Stat(filepath.Join(claudeDir, "settings.json")); !os.IsNotExist(statErr) {
+		t.Fatal("removed setup command must not write settings.json")
+	}
+}

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -35,6 +35,7 @@ Examples:
 	cmd.AddCommand(newTraceExportCmd())
 	cmd.AddCommand(newTraceMessagesCmd())
 	cmd.AddCommand(newTraceStatsCmd())
+	cmd.AddCommand(newTraceSetupCmd())
 	return cmd
 }
 


### PR DESCRIPTION
Copybara export from `langchain-ai/langchainplus`, the source of truth for the CLI under `sdks/cli`.

Syncs the `langsmith setup` feature from langchain-ai/langchainplus#26689: adds the `setup`, `setup_claude`, and `setup_codex` commands plus tests, with README/go.mod/go.sum/trace wiring. Also flips one line in `internal/cmd/hub_push_test.go` (RSA-marker obfuscation from the copybara round-trip).

## Test Plan
- [x] none (covered by langchain-ai/langchainplus#26689)