### PR TITLE
fix(ci/cd): move the console-env tests into appropriate new testfile

### DIFF
--- a/internal/cmd/sandbox_console_test.go
+++ b/internal/cmd/sandbox_console_test.go
@@ -1,0 +1,65 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSandboxConsoleEnvFrom_AllowsTerminalEnvOnly(t *testing.T) {
+	env, err := sandboxConsoleEnvFrom([]string{
+		"TERM=xterm-256color",
+		"COLORTERM=truecolor",
+		"LANG=en_US.UTF-8",
+		"LC_ALL=en_US.UTF-8",
+		"CLICOLOR=1",
+		"CLICOLOR_FORCE=1",
+		"FORCE_COLOR=1",
+		"NO_COLOR=1",
+		"PATH=/usr/bin",
+		"LANGSMITH_API_KEY=secret",
+		"EMPTY=",
+		"malformed",
+	}, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"TERM":           "xterm-256color",
+		"COLORTERM":      "truecolor",
+		"LANG":           "en_US.UTF-8",
+		"LC_ALL":         "en_US.UTF-8",
+		"CLICOLOR":       "1",
+		"CLICOLOR_FORCE": "1",
+		"FORCE_COLOR":    "1",
+		"NO_COLOR":       "1",
+	}, env)
+}
+
+func TestSandboxConsoleEnvFrom_AddsExplicitEnv(t *testing.T) {
+	env, err := sandboxConsoleEnvFrom([]string{
+		"TERM=xterm",
+		"PATH=/usr/bin",
+		"LOCAL_ONLY=from-local",
+	}, []string{
+		"TERM=xterm-256color",
+		"PATH",
+		"EMPTY=",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"TERM":  "xterm-256color",
+		"PATH":  "/usr/bin",
+		"EMPTY": "",
+	}, env)
+}
+
+func TestSandboxConsoleEnvFrom_RejectsMissingForwardedEnv(t *testing.T) {
+	_, err := sandboxConsoleEnvFrom(nil, []string{"MISSING"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--env MISSING is not set")
+}

--- a/internal/cmd/sandbox_test.go
+++ b/internal/cmd/sandbox_test.go
@@ -194,61 +194,6 @@ func TestSandboxExecCmd_WritesCommandOutputDirectly(t *testing.T) {
 	assert.Equal(t, "'echo' 'hello'", body["command"])
 }
 
-func TestSandboxConsoleEnvFrom_AllowsTerminalEnvOnly(t *testing.T) {
-	env, err := sandboxConsoleEnvFrom([]string{
-		"TERM=xterm-256color",
-		"COLORTERM=truecolor",
-		"LANG=en_US.UTF-8",
-		"LC_ALL=en_US.UTF-8",
-		"CLICOLOR=1",
-		"CLICOLOR_FORCE=1",
-		"FORCE_COLOR=1",
-		"NO_COLOR=1",
-		"PATH=/usr/bin",
-		"LANGSMITH_API_KEY=secret",
-		"EMPTY=",
-		"malformed",
-	}, nil)
-
-	require.NoError(t, err)
-	assert.Equal(t, map[string]string{
-		"TERM":           "xterm-256color",
-		"COLORTERM":      "truecolor",
-		"LANG":           "en_US.UTF-8",
-		"LC_ALL":         "en_US.UTF-8",
-		"CLICOLOR":       "1",
-		"CLICOLOR_FORCE": "1",
-		"FORCE_COLOR":    "1",
-		"NO_COLOR":       "1",
-	}, env)
-}
-
-func TestSandboxConsoleEnvFrom_AddsExplicitEnv(t *testing.T) {
-	env, err := sandboxConsoleEnvFrom([]string{
-		"TERM=xterm",
-		"PATH=/usr/bin",
-		"LOCAL_ONLY=from-local",
-	}, []string{
-		"TERM=xterm-256color",
-		"PATH",
-		"EMPTY=",
-	})
-
-	require.NoError(t, err)
-	assert.Equal(t, map[string]string{
-		"TERM":  "xterm-256color",
-		"PATH":  "/usr/bin",
-		"EMPTY": "",
-	}, env)
-}
-
-func TestSandboxConsoleEnvFrom_RejectsMissingForwardedEnv(t *testing.T) {
-	_, err := sandboxConsoleEnvFrom(nil, []string{"MISSING"})
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--env MISSING is not set")
-}
-
 func tsURL(t *testing.T, r *http.Request) string {
 	t.Helper()
 	return "http://" + r.Host

--- a/internal/cmd/setup_test.go
+++ b/internal/cmd/setup_test.go
@@ -69,6 +69,11 @@ func assertPerm0600(t *testing.T, path string) {
 	if err != nil {
 		t.Fatalf("stat %s: %v", path, err)
 	}
+	// Windows does not implement Unix permission bits
+	// so we just have to check for Existence (above test)
+	if runtime.GOOS == "windows" {
+		return
+	}
 	if perm := fi.Mode().Perm(); perm != 0o600 {
 		t.Fatalf("expected %s to be 0600, got %o", path, perm)
 	}


### PR DESCRIPTION
sandboxConsoleEnvFrom is defined in sandbox_console.go, which is gated with //go:build !windows (Windows has a separate sandbox_console_windows.go that doesn't define that function). But the three TestSandboxConsoleEnvFrom_* tests lived in sandbox_test.go, which has no build tag - so on Windows it tried to compile against a symbol that doesn't exist there.

fix: Moved the three console-env tests into a new internal/cmd/sandbox_console_test.go gated with //go:build !windows, matching the file that defines the function.