### PR TITLE
feat: prompt description cli read path [LSPE-673]

### DIFF
--- a/internal/cmd/prompt.go
+++ b/internal/cmd/prompt.go
@@ -326,6 +326,7 @@ func newPromptPullCmd() *cobra.Command {
 				"owner":       owner,
 				"repo":        repo,
 				"commit_hash": resp.CommitHash,
+				"description": resp.Description,
 				"manifest":    resp.Manifest,
 			}
 
@@ -454,7 +455,7 @@ func newPromptCommitsCmd() *cobra.Command {
 			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
-				columns := []string{"Hash", "Author", "Downloads", "Created"}
+				columns := []string{"Hash", "Author", "Description", "Downloads", "Created"}
 				var rows [][]string
 				for _, c := range commits {
 					hash := c.CommitHash
@@ -464,6 +465,7 @@ func newPromptCommitsCmd() *cobra.Command {
 					rows = append(rows, []string{
 						hash,
 						c.FullName,
+						truncate(c.Description, 40),
 						fmt.Sprintf("%d", c.NumDownloads),
 						formatTimeShort(c.CreatedAt),
 					})
@@ -476,6 +478,7 @@ func newPromptCommitsCmd() *cobra.Command {
 						"id":                 c.ID,
 						"commit_hash":        c.CommitHash,
 						"parent_commit_hash": nilStr(c.ParentCommitHash),
+						"description":        c.Description,
 						"full_name":          c.FullName,
 						"num_downloads":      c.NumDownloads,
 						"num_views":          c.NumViews,

--- a/internal/cmd/prompt_test.go
+++ b/internal/cmd/prompt_test.go
@@ -100,3 +100,50 @@ func TestPromptPush_OmitsDescriptionWhenUnset(t *testing.T) {
 		t.Fatalf("description should be omitted when --description is unset, body: %v", gotBody)
 	}
 }
+
+// TestPromptCommits_ShowsDescription verifies the commits read path surfaces
+// the per-commit description in JSON output.
+func TestPromptCommits_ShowsDescription(t *testing.T) {
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/commits/acme/my-prompt" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Return the commit only on the first page; an empty second page
+		// terminates the offset pager.
+		if off := r.URL.Query().Get("offset"); off != "" && off != "0" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"total": 1, "commits": []map[string]any{}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total": 1,
+			"commits": []map[string]any{
+				{
+					"id":          "11111111-1111-1111-1111-111111111111",
+					"commit_hash": "abc123",
+					"description": "first commit via CLI",
+					"created_at":  "2026-06-08T12:00:00Z",
+				},
+			},
+		})
+	})
+
+	out := captureStdout(t, func() {
+		if _, err := executeCommand(t, "--api-key", "test-key", "--api-url", ts.URL,
+			"prompt", "commits", "acme/my-prompt", "--format", "json"); err != nil {
+			t.Fatalf("commits command returned error: %v", err)
+		}
+	})
+
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing commits output %q: %v", out, err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 commit, got %d: %v", len(got), got)
+	}
+	if d := got[0]["description"]; d != "first commit via CLI" {
+		t.Fatalf("description in commits output = %v, want %q", d, "first commit via CLI")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds the commit `description` to the prompt read path so it's visible without raw API calls
- `prompt commits` — new `Description` column (pretty) and `description` field (JSON)
- `prompt pull` — includes `description` for the fetched commit

## Test plan

- [ ] `langsmith prompt commits <owner>/<repo>` shows the description column; commits pushed without `--description render blank`
- [ ] `--format json` includes a `description` field per commit
- [ ] `langsmith prompt pull <owner>/<repo>` output includes `description` for the latest commit