### PR TITLE
feat(issues): add 'project issues overview' command

### DIFF
--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -50,10 +50,12 @@ func newProjectIssuesCmd() *cobra.Command {
 Examples:
   langsmith project issues list --project my-app
   langsmith project issues list --project my-app --status open --priority high
+  langsmith project issues overview --project my-app
   langsmith project issues events --project my-app`,
 	}
 
 	cmd.AddCommand(newProjectIssuesListCmd())
+	cmd.AddCommand(newProjectIssuesOverviewCmd())
 	cmd.AddCommand(newProjectIssuesEventsCmd())
 	cmd.AddCommand(newProjectIssuesUpdateCmd())
 	cmd.AddCommand(newProjectIssuesRunsCmd())
@@ -63,12 +65,11 @@ Examples:
 
 func newProjectIssuesListCmd() *cobra.Command {
 	var (
-		project         string
-		status          string
-		priority        string
-		limit           int
-		outputFile      string
-		includeOverview bool
+		project    string
+		status     string
+		priority   string
+		limit      int
+		outputFile string
 	)
 
 	cmd := &cobra.Command{
@@ -80,15 +81,13 @@ Fetches issues from the Issues Board for the specified project. Results
 can be filtered by status (open/closed) and priority (high/medium/low).
 Output is JSON by default; pass --format pretty for a human-readable table.
 
-Pass --include-overview to also fetch the project's Agent Overview (the
-markdown summary the issues agent maintains). With it, JSON output becomes
-an object {overview, issues:[...]} instead of a bare issues array.
+To fetch the project's Agent Overview (the markdown summary the issues
+agent maintains), use 'langsmith project issues overview'.
 
 Examples:
   langsmith project issues list --project my-app
   langsmith project issues list --project my-app --status open
   langsmith project issues list --project my-app --priority high --limit 10
-  langsmith project issues list --project my-app --include-overview
   langsmith project issues list --project my-app --format pretty`,
 		Run: func(cmd *cobra.Command, args []string) {
 			c := MustGetClient()
@@ -119,28 +118,9 @@ Examples:
 				issues = issues[:limit]
 			}
 
-			var overview string
-			var haveOverview bool
-			if includeOverview {
-				sessionID, err := c.ResolveSessionID(ctx, projectName)
-				if err != nil {
-					ExitErrorf("resolving project for overview: %v", err)
-				}
-				overview, haveOverview = fetchAgentOverview(ctx, c, sessionID)
-			}
-
 			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
-				if includeOverview {
-					fmt.Println("=== Agent Overview ===")
-					if haveOverview {
-						fmt.Println(overview)
-					} else {
-						fmt.Println("(no agent overview)")
-					}
-					fmt.Println()
-				}
 				columns := []string{"NAME", "SEVERITY", "STATUS", "TAGS", "CREATED"}
 				var rows [][]string
 				for _, issue := range issues {
@@ -162,18 +142,7 @@ Examples:
 				for _, issue := range issues {
 					data = append(data, issueToMap(issue))
 				}
-				if includeOverview {
-					var overviewVal any
-					if haveOverview {
-						overviewVal = overview
-					}
-					output.OutputJSON(map[string]any{
-						"overview": overviewVal,
-						"issues":   data,
-					}, outputFile)
-				} else {
-					output.OutputJSON(data, outputFile)
-				}
+				output.OutputJSON(data, outputFile)
 			}
 		},
 	}
@@ -183,7 +152,67 @@ Examples:
 	cmd.Flags().StringVar(&priority, "priority", "", "Filter by priority: high, medium, or low")
 	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum number of issues to return")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
-	cmd.Flags().BoolVar(&includeOverview, "include-overview", false, "Also fetch and include the project's Agent Overview")
+
+	return cmd
+}
+
+func newProjectIssuesOverviewCmd() *cobra.Command {
+	var (
+		project    string
+		outputFile string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "overview",
+		Short: "Fetch a tracing project's Agent Overview",
+		Long: `Fetch a tracing project's Agent Overview.
+
+The Agent Overview is the markdown summary the issues agent maintains for a
+project, derived from its traces and issues. It is stored as a Prompt Hub
+commit under the repo handle 'ao-<first 8 chars of session UUID>'.
+
+Output is JSON by default ({"overview": <markdown|null>}); pass
+--format pretty to print the markdown directly. If the project has no Agent
+Overview yet, "overview" is null (and pretty mode prints "(no agent overview)").
+
+Examples:
+  langsmith project issues overview --project my-app
+  langsmith project issues overview --project my-app --format pretty`,
+		Run: func(cmd *cobra.Command, args []string) {
+			c := MustGetClient()
+			ctx := context.Background()
+
+			projectName := ResolveProject(project)
+			if projectName == "" {
+				ExitError("--project is required (or set LANGSMITH_PROJECT)")
+			}
+
+			sessionID, err := c.ResolveSessionID(ctx, projectName)
+			if err != nil {
+				ExitErrorf("resolving project %q: %v", projectName, err)
+			}
+
+			overview, haveOverview := fetchAgentOverview(ctx, c, sessionID)
+
+			if GetFormat() == "pretty" {
+				if haveOverview {
+					fmt.Println(overview)
+				} else {
+					fmt.Println("(no agent overview)")
+				}
+				return
+			}
+
+			var overviewVal any
+			if haveOverview {
+				overviewVal = overview
+			}
+			output.OutputJSON(map[string]any{"overview": overviewVal}, outputFile)
+		},
+	}
+
+	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
+	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 
 	return cmd
 }

--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 
@@ -60,11 +63,12 @@ Examples:
 
 func newProjectIssuesListCmd() *cobra.Command {
 	var (
-		project    string
-		status     string
-		priority   string
-		limit      int
-		outputFile string
+		project         string
+		status          string
+		priority        string
+		limit           int
+		outputFile      string
+		includeOverview bool
 	)
 
 	cmd := &cobra.Command{
@@ -76,10 +80,15 @@ Fetches issues from the Issues Board for the specified project. Results
 can be filtered by status (open/closed) and priority (high/medium/low).
 Output is JSON by default; pass --format pretty for a human-readable table.
 
+Pass --include-overview to also fetch the project's Agent Overview (the
+markdown summary the issues agent maintains). With it, JSON output becomes
+an object {overview, issues:[...]} instead of a bare issues array.
+
 Examples:
   langsmith project issues list --project my-app
   langsmith project issues list --project my-app --status open
   langsmith project issues list --project my-app --priority high --limit 10
+  langsmith project issues list --project my-app --include-overview
   langsmith project issues list --project my-app --format pretty`,
 		Run: func(cmd *cobra.Command, args []string) {
 			c := MustGetClient()
@@ -110,9 +119,28 @@ Examples:
 				issues = issues[:limit]
 			}
 
+			var overview string
+			var haveOverview bool
+			if includeOverview {
+				sessionID, err := c.ResolveSessionID(ctx, projectName)
+				if err != nil {
+					ExitErrorf("resolving project for overview: %v", err)
+				}
+				overview, haveOverview = fetchAgentOverview(ctx, c, sessionID)
+			}
+
 			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
+				if includeOverview {
+					fmt.Println("=== Agent Overview ===")
+					if haveOverview {
+						fmt.Println(overview)
+					} else {
+						fmt.Println("(no agent overview)")
+					}
+					fmt.Println()
+				}
 				columns := []string{"NAME", "SEVERITY", "STATUS", "TAGS", "CREATED"}
 				var rows [][]string
 				for _, issue := range issues {
@@ -134,7 +162,18 @@ Examples:
 				for _, issue := range issues {
 					data = append(data, issueToMap(issue))
 				}
-				output.OutputJSON(data, outputFile)
+				if includeOverview {
+					var overviewVal any
+					if haveOverview {
+						overviewVal = overview
+					}
+					output.OutputJSON(map[string]any{
+						"overview": overviewVal,
+						"issues":   data,
+					}, outputFile)
+				} else {
+					output.OutputJSON(data, outputFile)
+				}
 			}
 		},
 	}
@@ -144,8 +183,47 @@ Examples:
 	cmd.Flags().StringVar(&priority, "priority", "", "Filter by priority: high, medium, or low")
 	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum number of issues to return")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
+	cmd.Flags().BoolVar(&includeOverview, "include-overview", false, "Also fetch and include the project's Agent Overview")
 
 	return cmd
+}
+
+// fetchAgentOverview returns the project's Agent Overview markdown, or ("", false)
+// if the project has no overview yet. The AO repo handle is derived from the
+// session UUID (ao-<first8>), mirroring smith-go's agentOverviewRepoHandle. Fetch
+// failures (no AO repo yet, or transient errors) degrade gracefully so the issues
+// list still renders.
+func fetchAgentOverview(ctx context.Context, c *client.Client, sessionID string) (string, bool) {
+	if len(sessionID) < 8 {
+		return "", false
+	}
+	handle := "ao-" + sessionID[:8]
+	resp, err := c.SDK.Commits.Get(ctx, "-", handle, "latest", langsmith.CommitGetParams{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not fetch agent overview: %v\n", err)
+		return "", false
+	}
+	return extractOverviewTemplate(resp.Manifest)
+}
+
+// extractOverviewTemplate pulls the AO markdown out of a PromptTemplate manifest
+// (content lives at kwargs.template). The SDK types Manifest as interface{}, so
+// it arrives as a map[string]any after JSON decoding. Returns ("", false) if the
+// manifest is not shaped as expected.
+func extractOverviewTemplate(manifest any) (string, bool) {
+	m, ok := manifest.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	kwargs, ok := m["kwargs"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	tmpl, ok := kwargs["template"].(string)
+	if !ok {
+		return "", false
+	}
+	return tmpl, true
 }
 
 // issueEvent mirrors the JSON shape returned by GET /v1/platform/sessions/{id}/issue-events.

--- a/internal/cmd/issues_test.go
+++ b/internal/cmd/issues_test.go
@@ -77,6 +77,75 @@ func TestProjectIssuesProposeExampleCmd_Flags(t *testing.T) {
 	}
 }
 
+// ==================== --include-overview flag ====================
+
+func TestProjectIssuesListCmd_IncludeOverviewFlag(t *testing.T) {
+	cmd := newProjectIssuesListCmd()
+	f := cmd.Flags().Lookup("include-overview")
+	if f == nil {
+		t.Fatal("flag --include-overview not found")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("flag --include-overview: expected default %q, got %q", "false", f.DefValue)
+	}
+}
+
+// ==================== extractOverviewTemplate ====================
+
+func TestExtractOverviewTemplate(t *testing.T) {
+	cases := []struct {
+		name     string
+		manifest any
+		wantTmpl string
+		wantOK   bool
+	}{
+		{
+			name: "valid",
+			manifest: map[string]any{
+				"kwargs": map[string]any{"template": "# Agent Overview\nbody"},
+			},
+			wantTmpl: "# Agent Overview\nbody",
+			wantOK:   true,
+		},
+		{
+			name:     "not a map",
+			manifest: "just a string",
+			wantOK:   false,
+		},
+		{
+			name:     "missing kwargs",
+			manifest: map[string]any{"id": []any{"langchain"}},
+			wantOK:   false,
+		},
+		{
+			name:     "kwargs wrong type",
+			manifest: map[string]any{"kwargs": "nope"},
+			wantOK:   false,
+		},
+		{
+			name:     "missing template",
+			manifest: map[string]any{"kwargs": map[string]any{"input_variables": []any{}}},
+			wantOK:   false,
+		},
+		{
+			name:     "template wrong type",
+			manifest: map[string]any{"kwargs": map[string]any{"template": 42}},
+			wantOK:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpl, ok := extractOverviewTemplate(tc.manifest)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if tmpl != tc.wantTmpl {
+				t.Errorf("template = %q, want %q", tmpl, tc.wantTmpl)
+			}
+		})
+	}
+}
+
 // ==================== parseAssertion ====================
 
 func TestParseAssertion_Valid(t *testing.T) {

--- a/internal/cmd/issues_test.go
+++ b/internal/cmd/issues_test.go
@@ -10,6 +10,7 @@ func TestProjectIssuesCmd_Subcommands(t *testing.T) {
 	cmd := newProjectIssuesCmd()
 	expected := map[string]bool{
 		"list":     false,
+		"overview": false,
 		"events":   false,
 		"update":   false,
 		"runs":     false,
@@ -77,16 +78,25 @@ func TestProjectIssuesProposeExampleCmd_Flags(t *testing.T) {
 	}
 }
 
-// ==================== --include-overview flag ====================
+// ==================== overview command ====================
 
-func TestProjectIssuesListCmd_IncludeOverviewFlag(t *testing.T) {
-	cmd := newProjectIssuesListCmd()
-	f := cmd.Flags().Lookup("include-overview")
-	if f == nil {
-		t.Fatal("flag --include-overview not found")
+func TestProjectIssuesOverviewCmd_UseField(t *testing.T) {
+	cmd := newProjectIssuesOverviewCmd()
+	if cmd.Use != "overview" {
+		t.Errorf("expected Use=%q, got %q", "overview", cmd.Use)
 	}
-	if f.DefValue != "false" {
-		t.Errorf("flag --include-overview: expected default %q, got %q", "false", f.DefValue)
+}
+
+func TestProjectIssuesOverviewCmd_Flags(t *testing.T) {
+	cmd := newProjectIssuesOverviewCmd()
+	for _, name := range []string{"project", "output"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("flag --%s not found", name)
+		}
+	}
+	// 'list' must no longer carry the overview flag — overview is its own command.
+	if newProjectIssuesListCmd().Flags().Lookup("include-overview") != nil {
+		t.Error("list should not have --include-overview flag anymore")
 	}
 }
 


### PR DESCRIPTION
## What

Adds a dedicated `langsmith project issues overview` command that fetches a project's **Agent Overview** — the markdown summary the issues agent maintains. It resolves the project name to its session UUID, derives the Agent Overview Prompt Hub repo handle (`ao-<first 8 chars of session UUID>`, mirroring smith-go's `agentOverviewRepoHandle`), and fetches the latest commit manifest via the SDK, surfacing the AO markdown (`manifest.kwargs.template`).

Previously the AO was only reachable through the generic `prompt` commands (if you already knew the internal repo-handle convention).

## Why its own command

Keeping the CLI as close to 1:1 with the API as possible: each command maps to a single API operation. An earlier revision bundled the AO fetch into `project issues list` via `--include-overview`, combining two API calls under one command and reshaping its output. This splits it back out so `list` is purely the issues endpoint and `overview` is purely the AO fetch.

## Behavior

- `langsmith project issues overview --project my-app` → JSON `{"overview": <markdown|null>}`.
- `--format pretty` → prints the AO markdown directly (`(no agent overview)` when absent).
- AO fetch failures (no AO repo yet / transient errors) degrade gracefully: a stderr warning and `overview: null`.
- `project issues list` is unchanged from main: bare issues array (JSON) / table (pretty), no extra API calls.

The full AO template markdown is returned (not split into user-visible/internal sections like the frontend does) since the CLI is an agent/dev tool.

## Test Plan

- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `go test ./internal/cmd/...` — table-driven tests for `extractOverviewTemplate`, `overview` subcommand presence + flags, and that `list` no longer carries `--include-overview`

## Release Note

Add `langsmith project issues overview` to fetch a project's Agent Overview.