### PR TITLE
feat(trace): add --project-id flag to all trace commands

### DIFF
--- a/internal/cmd/filters.go
+++ b/internal/cmd/filters.go
@@ -15,6 +15,7 @@ type FilterFlags struct {
 	TraceIDs     string
 	Limit        int
 	Project      string
+	ProjectID    string
 	LastNMinutes int
 	Since        string
 	Before       string

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -13,15 +13,34 @@ import (
 	"github.com/google/uuid"
 )
 
-// queryRuns queries runs with the given params and optional session resolution.
-// minTokens > 0 enables client-side filtering by total_tokens (not supported server-side).
-func queryRuns(ctx context.Context, c *client.Client, params langsmith.RunQueryParams, projectName string, limit int, minTokens int) ([]langsmith.RunSchema, error) {
-	// Resolve project name → session ID
-	if projectName != "" {
-		sessionID, err := c.ResolveSessionID(ctx, projectName)
-		if err != nil {
-			return nil, err
+// resolveSessionID resolves the target session (project) UUID for a command from
+// either an explicit project ID or a project name. Precedence:
+//
+//	--project-id (an explicit session UUID; takes precedence) →
+//	--project / $LANGSMITH_PROJECT (a project name, looked up via the API).
+//
+// projectID, when set, must be a well-formed UUID and is returned as-is without a
+// name lookup (saving a Sessions.List round-trip). cmdName is used only to build
+// the "required" error message.
+func resolveSessionID(ctx context.Context, c *client.Client, projectName, projectID, cmdName string) (string, error) {
+	if projectID != "" {
+		if _, err := uuid.Parse(projectID); err != nil {
+			return "", fmt.Errorf("invalid --project-id %q: must be a project (session) UUID", projectID)
 		}
+		return projectID, nil
+	}
+	name := ResolveProject(projectName)
+	if name == "" {
+		return "", fmt.Errorf("--project or --project-id is required for %s (or set LANGSMITH_PROJECT)", cmdName)
+	}
+	return c.ResolveSessionID(ctx, name)
+}
+
+// queryRuns queries runs with the given params, scoped to sessionID when non-empty.
+// The caller is responsible for resolving sessionID (see resolveSessionID).
+// minTokens > 0 enables client-side filtering by total_tokens (not supported server-side).
+func queryRuns(ctx context.Context, c *client.Client, params langsmith.RunQueryParams, sessionID string, limit int, minTokens int) ([]langsmith.RunSchema, error) {
+	if sessionID != "" {
 		params.Session = langsmith.F([]string{sessionID})
 	}
 

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -1,12 +1,56 @@
 package cmd
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/langchain-ai/langsmith-cli/internal/output"
 	langsmith "github.com/langchain-ai/langsmith-go"
 )
+
+// ---------- resolveSessionID ----------
+//
+// These cases all resolve (or error) before any API call, so a nil client is
+// safe. The project-name → session-ID lookup path is exercised via the
+// command-level tests that stub the client.
+
+func TestResolveSessionID_ProjectIDTakesPrecedence(t *testing.T) {
+	// A valid --project-id is returned as-is, even when a project name is set
+	// via --project / $LANGSMITH_PROJECT — without any name lookup.
+	t.Setenv("LANGSMITH_PROJECT", "some-project-name")
+	const id = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+
+	got, err := resolveSessionID(context.Background(), nil, "another-name", id, "trace get")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != id {
+		t.Errorf("expected session id %q returned verbatim, got %q", id, got)
+	}
+}
+
+func TestResolveSessionID_InvalidProjectID(t *testing.T) {
+	_, err := resolveSessionID(context.Background(), nil, "", "not-a-uuid", "trace get")
+	if err == nil {
+		t.Fatal("expected error for malformed --project-id")
+	}
+	if !strings.Contains(err.Error(), "--project-id") {
+		t.Errorf("error should mention --project-id, got %q", err.Error())
+	}
+}
+
+func TestResolveSessionID_NeitherProvided(t *testing.T) {
+	t.Setenv("LANGSMITH_PROJECT", "")
+	_, err := resolveSessionID(context.Background(), nil, "", "", "trace stats")
+	if err == nil {
+		t.Fatal("expected error when neither --project nor --project-id is provided")
+	}
+	if !strings.Contains(err.Error(), "trace stats") {
+		t.Errorf("error should name the command, got %q", err.Error())
+	}
+}
 
 // ---------- formatTimedelta ----------
 

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -73,12 +73,7 @@ Examples:
 
 			c := MustGetClient()
 			ctx := context.Background()
-			projectName := ResolveProject(ff.Project)
-			if projectName == "" {
-				ExitError("--project is required for trace messages (or set LANGSMITH_PROJECT)")
-			}
-
-			sessionID, err := c.ResolveSessionID(ctx, projectName)
+			sessionID, err := resolveSessionID(ctx, c, ff.Project, ff.ProjectID, "trace messages")
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -220,7 +215,9 @@ Examples:
 	}
 
 	addCommonFilterFlags(cmd, &ff, true)
+	cmd.Flags().StringVar(&ff.ProjectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
+	cmd.MarkFlagsMutuallyExclusive("project", "project-id")
 
 	return cmd
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -60,16 +60,16 @@ func newRunListCmd() *cobra.Command {
 
 			c := MustGetClient()
 			ctx := context.Background()
-			projectName := ResolveProject(ff.Project)
-			if projectName == "" {
-				ExitError("--project is required for run list (or set LANGSMITH_PROJECT)")
+			sessionID, err := resolveSessionID(ctx, c, ff.Project, "", "run list")
+			if err != nil {
+				ExitErrorf("%v", err)
 			}
 
 			params := BuildRunQueryParams(&ff, false, ff.Limit)
 			if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
 				params.Select = langsmith.F(sel)
 			}
-			runs, err := queryRuns(ctx, c, params, projectName, ff.Limit, ff.MinTokens)
+			runs, err := queryRuns(ctx, c, params, sessionID, ff.Limit, ff.MinTokens)
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -123,9 +123,9 @@ func newRunGetCmd() *cobra.Command {
 
 			c := MustGetClient()
 			ctx := context.Background()
-			projectName := ResolveProject(project)
-			if projectName == "" {
-				ExitError("--project is required for run get (or set LANGSMITH_PROJECT)")
+			sessionID, err := resolveSessionID(ctx, c, project, "", "run get")
+			if err != nil {
+				ExitErrorf("%v", err)
 			}
 
 			params := langsmith.RunQueryParams{
@@ -137,7 +137,7 @@ func newRunGetCmd() *cobra.Command {
 				params.Select = langsmith.F(sel)
 			}
 
-			runs, err := queryRuns(ctx, c, params, projectName, 1, 0)
+			runs, err := queryRuns(ctx, c, params, sessionID, 1, 0)
 			if err != nil {
 				ExitErrorf("fetching run: %v", err)
 			}
@@ -196,16 +196,16 @@ func newRunExportCmd() *cobra.Command {
 
 			c := MustGetClient()
 			ctx := context.Background()
-			projectName := ResolveProject(ff.Project)
-			if projectName == "" {
-				ExitError("--project is required for run export (or set LANGSMITH_PROJECT)")
+			sessionID, err := resolveSessionID(ctx, c, ff.Project, "", "run export")
+			if err != nil {
+				ExitErrorf("%v", err)
 			}
 
 			params := BuildRunQueryParams(&ff, false, ff.Limit)
 			if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
 				params.Select = langsmith.F(sel)
 			}
-			runs, err := queryRuns(ctx, c, params, projectName, ff.Limit, ff.MinTokens)
+			runs, err := queryRuns(ctx, c, params, sessionID, ff.Limit, ff.MinTokens)
 			if err != nil {
 				ExitErrorf("%v", err)
 			}

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -68,26 +68,22 @@ func newTraceListCmd() *cobra.Command {
 
 			c := MustGetClient()
 			ctx := context.Background()
-			projectName := ResolveProject(ff.Project)
-			if projectName == "" {
-				ExitError("--project is required for trace list (or set LANGSMITH_PROJECT)")
+			sessionID, err := resolveSessionID(ctx, c, ff.Project, ff.ProjectID, "trace list")
+			if err != nil {
+				ExitErrorf("%v", err)
 			}
 
 			params := BuildRunQueryParams(&ff, true, ff.Limit)
 			if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
 				params.Select = langsmith.F(sel)
 			}
-			runs, err := queryRuns(ctx, c, params, projectName, ff.Limit, ff.MinTokens)
+			runs, err := queryRuns(ctx, c, params, sessionID, ff.Limit, ff.MinTokens)
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
 
 			var flaggedByTrace map[string]string
 			if includeFlagged {
-				sessionID, err := c.ResolveSessionID(ctx, projectName)
-				if err != nil {
-					ExitErrorf("%v", err)
-				}
 				flagged := FetchFlaggedTraces(ctx, c, sessionID, ff.LastNMinutes)
 				flaggedByTrace = make(map[string]string, len(flagged))
 				for _, ft := range flagged {
@@ -103,7 +99,7 @@ func newTraceListCmd() *cobra.Command {
 						allRuns, err := queryRuns(ctx, c, langsmith.RunQueryParams{
 							Trace: langsmith.F(run.TraceID),
 							Order: langsmith.F(langsmith.RunQueryParamsOrderAsc),
-						}, projectName, 1000, 0)
+						}, sessionID, 1000, 0)
 						if err != nil {
 							ExitErrorf("%v", err)
 						}
@@ -124,7 +120,7 @@ func newTraceListCmd() *cobra.Command {
 					var result []map[string]any
 					for _, run := range runs {
 						childParams.Trace = langsmith.F(run.TraceID)
-						allRuns, err := queryRuns(ctx, c, childParams, projectName, 1000, 0)
+						allRuns, err := queryRuns(ctx, c, childParams, sessionID, 1000, 0)
 						if err != nil {
 							ExitErrorf("%v", err)
 						}
@@ -147,6 +143,7 @@ func newTraceListCmd() *cobra.Command {
 	}
 
 	addCommonFilterFlags(cmd, &ff, false)
+	cmd.Flags().StringVar(&ff.ProjectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, token_usage, costs, tags, custom_metadata (incl. revision_id)")
 	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, and error fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
@@ -154,6 +151,7 @@ func newTraceListCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io --include-feedback")
 	cmd.Flags().BoolVar(&showHierarchy, "show-hierarchy", false, "Fetch the full run tree for each trace")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
+	cmd.MarkFlagsMutuallyExclusive("project", "project-id")
 
 	return cmd
 }
@@ -161,6 +159,7 @@ func newTraceListCmd() *cobra.Command {
 func newTraceGetCmd() *cobra.Command {
 	var (
 		project         string
+		projectID       string
 		since           string
 		lastNMinutes    int
 		includeMetadata bool
@@ -185,9 +184,9 @@ func newTraceGetCmd() *cobra.Command {
 
 			c := MustGetClient()
 			ctx := context.Background()
-			projectName := ResolveProject(project)
-			if projectName == "" {
-				ExitError("--project is required for trace get (or set LANGSMITH_PROJECT)")
+			sessionID, err := resolveSessionID(ctx, c, project, projectID, "trace get")
+			if err != nil {
+				ExitErrorf("%v", err)
 			}
 
 			params := langsmith.RunQueryParams{
@@ -199,7 +198,7 @@ func newTraceGetCmd() *cobra.Command {
 				params.Select = langsmith.F(sel)
 			}
 
-			runs, err := queryRuns(ctx, c, params, projectName, 1000, 0)
+			runs, err := queryRuns(ctx, c, params, sessionID, 1000, 0)
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -220,6 +219,7 @@ func newTraceGetCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
+	cmd.Flags().StringVar(&projectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
 	cmd.Flags().StringVar(&since, "since", "", "Only include runs after this timestamp, e.g. 2024-01-15T00:00:00Z (overrides 7-day default)")
 	cmd.Flags().IntVar(&lastNMinutes, "last-n-minutes", 0, "Only include runs from the last N minutes, e.g. 60 (overrides 7-day default)")
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, token_usage, costs, tags, custom_metadata (incl. revision_id)")
@@ -227,6 +227,7 @@ func newTraceGetCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io --include-feedback")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
+	cmd.MarkFlagsMutuallyExclusive("project", "project-id")
 
 	return cmd
 }
@@ -264,9 +265,9 @@ func newTraceExportCmd() *cobra.Command {
 
 			c := MustGetClient()
 			ctx := context.Background()
-			projectName := ResolveProject(ff.Project)
-			if projectName == "" {
-				ExitError("--project is required for trace export (or set LANGSMITH_PROJECT)")
+			sessionID, err := resolveSessionID(ctx, c, ff.Project, ff.ProjectID, "trace export")
+			if err != nil {
+				ExitErrorf("%v", err)
 			}
 
 			params := BuildRunQueryParams(&ff, true, ff.Limit)
@@ -274,7 +275,7 @@ func newTraceExportCmd() *cobra.Command {
 			if sel != nil {
 				params.Select = langsmith.F(sel)
 			}
-			rootRuns, err := queryRuns(ctx, c, params, projectName, ff.Limit, ff.MinTokens)
+			rootRuns, err := queryRuns(ctx, c, params, sessionID, ff.Limit, ff.MinTokens)
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -290,7 +291,7 @@ func newTraceExportCmd() *cobra.Command {
 				if sel != nil {
 					childParams.Select = langsmith.F(sel)
 				}
-				allRuns, err := queryRuns(ctx, c, childParams, projectName, 1000, 0)
+				allRuns, err := queryRuns(ctx, c, childParams, sessionID, 1000, 0)
 				if err != nil {
 					ExitErrorf("%v", err)
 				}
@@ -330,12 +331,14 @@ func newTraceExportCmd() *cobra.Command {
 	}
 
 	addCommonFilterFlags(cmd, &ff, false)
+	cmd.Flags().StringVar(&ff.ProjectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, token_usage, costs, tags, custom_metadata (incl. revision_id)")
 	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, and error fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io --include-feedback")
 	cmd.Flags().StringVar(&filenamePattern, "filename-pattern", "{trace_id}.jsonl",
 		"Filename pattern. Supports {trace_id} and {name} placeholders.")
+	cmd.MarkFlagsMutuallyExclusive("project", "project-id")
 
 	return cmd
 }

--- a/internal/cmd/trace_stats.go
+++ b/internal/cmd/trace_stats.go
@@ -31,6 +31,7 @@ type runStats struct {
 func newTraceStatsCmd() *cobra.Command {
 	var (
 		project     string
+		projectID   string
 		since       string
 		before      string
 		lastNMin    int
@@ -63,14 +64,9 @@ Examples:
 			c := MustGetClient()
 			ctx := context.Background()
 
-			projectName := ResolveProject(project)
-			if projectName == "" {
-				return fmt.Errorf("--project is required (or set LANGSMITH_PROJECT)")
-			}
-
-			sessionID, err := c.ResolveSessionID(ctx, projectName)
+			sessionID, err := resolveSessionID(ctx, c, project, projectID, "trace stats")
 			if err != nil {
-				return fmt.Errorf("resolving project %q: %w", projectName, err)
+				return err
 			}
 
 			primary, err := fetchRunStats(ctx, c, sessionID, since, before, lastNMin, filter)
@@ -103,6 +99,7 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
+	cmd.Flags().StringVar(&projectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
 	cmd.Flags().StringVar(&since, "since", "", "Start of time window (RFC3339 or YYYY-MM-DD; default: 7 days ago)")
 	cmd.Flags().StringVar(&before, "before", "", "End of time window (RFC3339 or YYYY-MM-DD; default: now)")
 	cmd.Flags().IntVar(&lastNMin, "last-n-minutes", 0, "Shorthand: window = last N minutes (overrides --since)")
@@ -111,6 +108,7 @@ Examples:
 	cmd.Flags().IntVar(&cmpLastNMin, "compare-last-n-minutes", 0, "Shorthand: comparison window = N minutes before the primary window starts")
 	cmd.Flags().StringVar(&filter, "filter", "", "LangSmith filter DSL (applied to both windows if comparing)")
 	cmd.Flags().StringVar(&outputFile, "output", "", "Write JSON output to file instead of stdout")
+	cmd.MarkFlagsMutuallyExclusive("project", "project-id")
 	return cmd
 }
 


### PR DESCRIPTION
Add a --project-id flag to trace list/get/export/messages/stats so users can specify the LangSmith session (project) UUID directly, skipping the project-name -> session-ID lookup.

Introduce resolveSessionID helper with precedence: --project-id (validated UUID) -> --project / $LANGSMITH_PROJECT (name lookup). queryRuns now takes an already-resolved session ID; trace.go and run.go call sites updated accordingly (run commands keep current behavior, passing an empty id).