### PR TITLE
claude plugin version update bump [LSEN-276]

### DIFF
--- a/internal/cmd/setup_claude.go
+++ b/internal/cmd/setup_claude.go
@@ -201,9 +201,11 @@ func claudeChangePreview(settingsPath, pluginRef string, opts client.Options, pr
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "Will update %s with:\n\n%s\n", settingsPath, b)
 	if !noInstall {
-		fmt.Fprintf(&sb, "\nThen run:\n")
+		fmt.Fprintf(&sb, "\nThen run (updating an existing install to the latest version):\n")
 		fmt.Fprintf(&sb, "  %s plugin marketplace add %s\n", claudeBinary(), claudeMarketplaceURL)
+		fmt.Fprintf(&sb, "  %s plugin marketplace update %s\n", claudeBinary(), claudeMarketplaceName)
 		fmt.Fprintf(&sb, "  %s plugin install %s --scope %s\n", claudeBinary(), pluginRef, scopeOrDefault(scope))
+		fmt.Fprintf(&sb, "  %s plugin update %s --scope %s\n", claudeBinary(), pluginRef, scopeOrDefault(scope))
 	}
 	fmt.Fprintf(&sb, "\nThe plugin runs on every Claude Code session and sends your prompts,\nresponses, and tool output to LangSmith.\n")
 	return sb.String()
@@ -216,13 +218,38 @@ func claudeBinary() string {
 	return "claude"
 }
 
+// installClaudePlugin registers the tracing marketplace and installs the
+// plugin, then refreshes both so a re-run bumps a stale install forward.
+//
+// Plugin installs are version-pinned and never auto-update, so a user who set
+// up on an old plugin keeps tracing with it indefinitely. That matters here:
+// per-user identity metadata (local_username / anthropic_user_id) only ships in
+// langsmith-tracing v0.1.3+, so installs older than that trace with no
+// attribution. The marketplace-update + plugin-update steps carry those stale
+// installs up to the latest release; both are no-ops when already current.
 func installClaudePlugin(ctx context.Context, scope, pluginRef string) error {
 	bin := claudeBinary()
-	if err := runSetupCommand(ctx, bin, "plugin", "marketplace", "add", claudeMarketplaceURL); err != nil {
-		return fmt.Errorf("%s plugin marketplace add: %w", bin, err)
+	sc := scopeOrDefault(scope)
+
+	// Best-effort: `marketplace add` errors when the marketplace is already
+	// known, which is the common case on re-run. A genuine failure (e.g. claude
+	// not installed) surfaces on the update below, which needs it to exist.
+	_ = runSetupCommand(ctx, bin, "plugin", "marketplace", "add", claudeMarketplaceURL)
+
+	// Refresh the marketplace so the latest published plugin version is visible
+	// to install/update.
+	if err := runSetupCommand(ctx, bin, "plugin", "marketplace", "update", claudeMarketplaceName); err != nil {
+		return fmt.Errorf("%s plugin marketplace update: %w", bin, err)
 	}
-	if err := runSetupCommand(ctx, bin, "plugin", "install", pluginRef, "--scope", scopeOrDefault(scope)); err != nil {
+
+	// Install if missing (no-op when already installed).
+	if err := runSetupCommand(ctx, bin, "plugin", "install", pluginRef, "--scope", sc); err != nil {
 		return fmt.Errorf("%s plugin install: %w", bin, err)
+	}
+
+	// Bump an existing/stale install to the latest version (no-op when current).
+	if err := runSetupCommand(ctx, bin, "plugin", "update", pluginRef, "--scope", sc); err != nil {
+		return fmt.Errorf("%s plugin update: %w", bin, err)
 	}
 	return nil
 }
@@ -240,14 +267,18 @@ func reportClaudeSetup(cmd *cobra.Command, settingsPath, project, apiURL, scope,
 		case noInstall:
 			fmt.Fprintf(out, "\nSkipped install. Run inside Claude Code (or rerun without --no-install):\n")
 			fmt.Fprintf(out, "  /plugin marketplace add %s\n", claudeMarketplaceURL)
+			fmt.Fprintf(out, "  /plugin marketplace update %s\n", claudeMarketplaceName)
 			fmt.Fprintf(out, "  /plugin install %s\n", pluginRef)
+			fmt.Fprintf(out, "  /plugin update %s\n", pluginRef)
 		case installed:
 			fmt.Fprintf(out, "  install:  done\n")
 		default:
 			fmt.Fprintf(out, "\nConfig written, but the plugin install failed (%v).\n", installErr)
 			fmt.Fprintf(out, "Claude Code will still install it on next launch from settings.json, or run:\n")
 			fmt.Fprintf(out, "  %s plugin marketplace add %s\n", claudeBinary(), claudeMarketplaceURL)
+			fmt.Fprintf(out, "  %s plugin marketplace update %s\n", claudeBinary(), claudeMarketplaceName)
 			fmt.Fprintf(out, "  %s plugin install %s --scope %s\n", claudeBinary(), pluginRef, scopeOrDefault(scope))
+			fmt.Fprintf(out, "  %s plugin update %s --scope %s\n", claudeBinary(), pluginRef, scopeOrDefault(scope))
 		}
 		fmt.Fprintf(out, "\nVerify with: tail -f ~/.claude/state/hook.log\n")
 		return nil

--- a/internal/cmd/setup_test.go
+++ b/internal/cmd/setup_test.go
@@ -165,15 +165,20 @@ func TestSetupClaudeWritesSettings(t *testing.T) {
 	}
 	assertPerm0600(t, settingsPath)
 
-	// The plugin install shelled out: marketplace add + install.
-	if len(*calls) != 2 {
-		t.Fatalf("expected 2 install commands, got %d: %+v", len(*calls), *calls)
+	// The update steps bump a stale install to the latest version on re-run
+	want := []string{
+		"claude plugin marketplace add " + claudeMarketplaceURL,
+		"claude plugin marketplace update " + claudeMarketplaceName,
+		"claude plugin install langsmith-tracing@langsmith-claude-code-plugins --scope user",
+		"claude plugin update langsmith-tracing@langsmith-claude-code-plugins --scope user",
 	}
-	if got := strings.Join((*calls)[0], " "); got != "claude plugin marketplace add "+claudeMarketplaceURL {
-		t.Fatalf("unexpected marketplace-add command: %s", got)
+	if len(*calls) != len(want) {
+		t.Fatalf("expected %d install commands, got %d: %+v", len(want), len(*calls), *calls)
 	}
-	if got := strings.Join((*calls)[1], " "); got != "claude plugin install langsmith-tracing@langsmith-claude-code-plugins --scope user" {
-		t.Fatalf("unexpected install command: %s", got)
+	for i, w := range want {
+		if got := strings.Join((*calls)[i], " "); got != w {
+			t.Fatalf("install command %d: got %q, want %q", i, got, w)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
The Claude Code trace setup flow (`langsmith trace setup claude`, `internal/cmd/setup_claude.go`) only ran `plugin marketplace add` + `plugin install`. Both are no-ops for an existing install, and Claude Code plugin installs are version-pinned and never auto-update - so a user who set up on an old plugin stays on it indefinitely. This matters because per-user identity metadata (`local_username` / `anthropic_user_id`) only ships in `langsmith-tracing` v0.1.3+; installs older than that trace into the shared project with no attribution.

Fix: `installClaudePlugin` now also runs `plugin marketplace update` (so the latest published version is visible) and `plugin update` (so a stale install is bumped forward). `marketplace add` becomes best-effort, since it errors on re-run when the marketplace already exists - a genuine failure still surfaces on the following `marketplace update`. Both update steps are no-ops when already current. Confirmation preview and the failure / `--no-install` hint text updated to match.

Also removes legacy-named installs (if-present) - which keyed marketplace by GitHub owner rather than manifest name.

## Self-Hosted Release Note
Claude Code trace setup now bumps an existing `langsmith-tracing` plugin install to the latest version on re-run, ensuring per-user trace attribution (`local_username` / `anthropic_user_id`).

## Test Plan
- [x] Existing `internal/cmd` setup tests pass; `TestSetupClaudeWritesSettings` updated to assert the 4-command sequence (marketplace add > marketplace update > install > update)
- [x] `go build` + `go vet ./internal/cmd/` clean
- [x] Live: faked a v0.1.0 install, ran `claude plugin marketplace update` + `claude plugin update`, verified "updated from 0.1.0 to 0.1.3"; `claude plugin list` confirmed 0.1.3
- [x] Live (legacy migration): ran the built CLI against a real langsmith-tracing@langchain-ai install → installed @langsmith-claude-code-plugins, uninstalled @langchain-ai; claude plugin list confirmed only the current-name plugin remains