### PR TITLE
feat: add source filter to hub list

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ langsmith hub pull acme/my-skill:production --dir ./out
 
 # Discover, inspect, delete
 langsmith hub list --type skill --query foo
+langsmith hub list --type skill --source external
 langsmith hub get acme/my-skill
 langsmith hub delete acme/my-skill --yes
 ```

--- a/internal/cmd/hub.go
+++ b/internal/cmd/hub.go
@@ -54,6 +54,7 @@ type hubRepo struct {
 	Owner          *string  `json:"owner"`
 	RepoHandle     string   `json:"repo_handle"`
 	RepoType       string   `json:"repo_type"`
+	Source         *string  `json:"source"`
 	Description    *string  `json:"description"`
 	Readme         *string  `json:"readme"`
 	IsPublic       bool     `json:"is_public"`

--- a/internal/cmd/hub_list.go
+++ b/internal/cmd/hub_list.go
@@ -13,6 +13,7 @@ import (
 func newHubListCmd() *cobra.Command {
 	var (
 		repoType   string
+		source     string
 		query      string
 		publicOnly bool
 		limit      int
@@ -34,6 +35,12 @@ func newHubListCmd() *cobra.Command {
 					return fmt.Errorf("--type must be 'agent' or 'skill' when set (got %q)", repoType)
 				}
 				params.RepoType = langsmith.F(langsmith.RepoListParamsRepoType(repoType))
+			}
+			if source != "" {
+				if source != "internal" && source != "external" {
+					return fmt.Errorf("--source must be 'internal' or 'external' when set (got %q)", source)
+				}
+				params.Source = langsmith.F(langsmith.RepoListParamsSource(source))
 			}
 			if query != "" {
 				params.Query = langsmith.F(query)
@@ -88,6 +95,7 @@ func newHubListCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&repoType, "type", "", "Filter by repo type: agent or skill")
+	cmd.Flags().StringVar(&source, "source", "", "Filter by source: internal or external")
 	cmd.Flags().StringVar(&query, "query", "", "Filter by name substring")
 	cmd.Flags().BoolVar(&publicOnly, "public", false, "Filter by public/private")
 	cmd.Flags().IntVarP(&limit, "limit", "n", 100, "Maximum number of repos to return")

--- a/internal/cmd/hub_list_test.go
+++ b/internal/cmd/hub_list_test.go
@@ -19,7 +19,7 @@ func TestHubList_QueryParams(t *testing.T) {
 
 	captureStdout(t, func() {
 		cmd := newHubCmd()
-		cmd.SetArgs([]string{"list", "--type", "skill", "--query", "foo", "--public", "--limit", "10", "--offset", "5"})
+		cmd.SetArgs([]string{"list", "--type", "skill", "--source", "external", "--query", "foo", "--public", "--limit", "10", "--offset", "5"})
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("execute: %v", err)
 		}
@@ -27,6 +27,7 @@ func TestHubList_QueryParams(t *testing.T) {
 
 	checks := map[string]string{
 		"repo_type":    "skill",
+		"source":       "external",
 		"query":        "foo",
 		"match_prefix": "true",
 		"is_public":    "true",
@@ -50,6 +51,18 @@ func TestHubList_RejectsBadType(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "agent") {
 		t.Errorf("expected error mentioning valid types; got %v", err)
+	}
+}
+
+func TestHubList_RejectsBadSource(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {})
+	defer setupTestEnv(t, srv.URL)()
+
+	cmd := newHubCmd()
+	cmd.SetArgs([]string{"list", "--source", "unknown"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "internal") {
+		t.Errorf("expected error mentioning valid sources; got %v", err)
 	}
 }
 

--- a/internal/cmd/hub_repo_sdk.go
+++ b/internal/cmd/hub_repo_sdk.go
@@ -48,6 +48,7 @@ func sdkRepoToHubRepo(repo langsmith.RepoWithLookups) hubRepo {
 		Owner:          strPtrOrNil(repo.Owner),
 		RepoHandle:     repo.RepoHandle,
 		RepoType:       string(repo.RepoType),
+		Source:         strPtrOrNil(string(repo.Source)),
 		Description:    strPtrOrNil(repo.Description),
 		Readme:         strPtrOrNil(repo.Readme),
 		IsPublic:       repo.IsPublic,


### PR DESCRIPTION
## Summary

Adds a first-class `--source` filter to `langsmith hub list` so users can list internal or external hub repos without dropping to `langsmith api`.

The flag accepts the same source values supported by the underlying repo API and Go SDK: `internal` and `external`. JSON output now includes the repo `source` field when the API returns it.

## Self-Hosted Release Note

`langsmith hub list` now supports filtering hub repos with `--source internal|external`.

## Test Plan

- [x] `go test ./...`
- [x] `go run ./cmd/langsmith hub list --help`
- [x] `go run ./cmd/langsmith hub list --type skill --source bad --api-key dummy --api-url http://127.0.0.1`
- [x] Live API validation with `LANGSMITH_API_KEY` from local environment:
  - `hub list --type skill --source internal` returned only `source=internal` skill repos
  - `hub list --type skill --source external` returned only `source=external` skill repos
  - `hub list --type skill` still returned skill repos from both sources
