### PR TITLE
feat(trace): enrich trajectory with normalized content (digest)

### DIFF
--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -16,42 +16,78 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Char caps for the normalized trajectory fields. Bounded so a single huge
-// message or tool payload can't blow up the trajectory view (and the context
-// of any agent reading it). The full untruncated content is still available in
-// the trace's `groups`.
+// Char caps for the per-trace digest fields. Bounded so a single huge message
+// or tool payload can't blow up the digest (and the context of any agent
+// reading it). The full untruncated content is still available in `groups`.
 const (
-	trajTextMax   = 600
-	trajArgsMax   = 200
-	trajResultMax = 200
+	digestTextMax   = 600
+	digestArgsMax   = 200
+	digestResultMax = 200
 )
 
-// errorishPattern flags a tool result whose content looks like an error, so a
-// reader can spot failed tool calls without opening every result.
-var errorishPattern = regexp.MustCompile(`(?i)error|not found|unauthorized|timeout|exception|denied|forbidden|traceback|http 5`)
+// errorishPattern is a heuristic flag for a tool result whose content looks
+// like an *error response* (not merely text that mentions the word "error" —
+// technical docs and search results say "error" constantly). It requires
+// error-shaped context: an error/exception token with `:`/`=`, a quoted
+// `"error":` key, an HTTP/status 4xx-5xx, a 4xx-5xx code next to a failure
+// word, a traceback, or a common shell/tool failure string. Advisory, not
+// authoritative — a reader still confirms by looking at the result.
+var errorishPattern = regexp.MustCompile(`(?i)<tool_use_error>|traceback|command not found|permission denied|no such file|\b(error|exception)\b\s*[:=]|"error"\s*[:=]|\bhttp[ /]?[45]\d\d\b|\b[45]\d\d\b\s+\w*\s*(error|not found|forbidden|unauthorized|internal server)`)
 
-// trajectoryStep is a compact single-step view of one message/tool-call in a trace.
+// trajectoryStep is a compact single-step view of one message/tool-call. It is
+// deliberately THIN: the trajectory is scanned across *all* traces in a batch
+// (triage), so per-trace content lives in the separate `digest` field, read
+// per-trace — not crammed into the bulk-scanned trajectory.
 type trajectoryStep struct {
 	Role      string `json:"role"`
 	ToolName  string `json:"tool_name,omitempty"`
 	Tokens    *int64 `json:"tokens,omitempty"`
 	LatencyMS *int64 `json:"latency_ms,omitempty"`
 	Chars     int    `json:"chars,omitempty"`
-	// Normalized content so a reader can verdict straight off the trajectory
-	// without re-parsing `groups` (whose content is heterogeneously shaped —
-	// a string, a list of blocks, or null).
-	Text       string `json:"text,omitempty"`        // coerced message content, ≤trajTextMax
-	ToolArgs   string `json:"tool_args,omitempty"`   // JSON of the tool call args, ≤trajArgsMax
-	ToolResult string `json:"tool_result,omitempty"` // coerced tool result content, ≤trajResultMax
-	Errorish   bool   `json:"errorish,omitempty"`    // tool result content looks like an error
 }
 
 // traceTrajectory is the compact trajectory for a single trace.
 type traceTrajectory struct {
-	TraceID       string           `json:"trace_id"`
-	InputMessage  string           `json:"input_message,omitempty"`
-	OutputMessage string           `json:"output_message,omitempty"`
-	Steps         []trajectoryStep `json:"steps"`
+	TraceID string           `json:"trace_id"`
+	Steps   []trajectoryStep `json:"steps"`
+}
+
+// digestToolArg is one tool call's name and its (bounded) JSON args.
+type digestToolArg struct {
+	Name string `json:"name"`
+	Args string `json:"args"`
+}
+
+// digestGroup is one normalized group in a trace's digest — enough to verdict
+// the group without re-parsing the heterogeneously-shaped raw `groups`.
+type digestGroup struct {
+	I          int             `json:"i"`
+	Kind       string          `json:"kind"`
+	Role       string          `json:"role,omitempty"`
+	Chars      int             `json:"chars"`
+	Text       string          `json:"text,omitempty"`        // coerced content, ≤digestTextMax
+	Tools      []string        `json:"tools,omitempty"`       // tool-call names in this group
+	ToolArgs   []digestToolArg `json:"tool_args,omitempty"`   // per call: name + ≤digestArgsMax JSON args
+	ToolResult []string        `json:"tool_result,omitempty"` // per call: coerced result, ≤digestResultMax
+	Errorish   bool            `json:"errorish,omitempty"`    // any tool result looks like an error
+}
+
+// traceDigest is the detailed per-trace view a screener reads for the ONE trace
+// it is judging. It is emitted as its own field (NOT folded into the trajectory)
+// so this bulk detail is read per-trace, never scanned across the whole batch.
+type traceDigest struct {
+	FirstHuman string        `json:"first_human,omitempty"`
+	FinalAI    string        `json:"final_ai,omitempty"`
+	NGroups    int           `json:"n_groups"`
+	GroupIndex []digestGroup `json:"group_index"`
+}
+
+// attachTrajectory attaches the thin trajectory and the per-trace digest to a
+// trace map for JSON output. The trajectory is scanned across all traces; the
+// digest is read per-trace.
+func attachTrajectory(trace map[string]any, traj traceTrajectory, digest traceDigest) {
+	trace["trajectory"] = traj.Steps
+	trace["digest"] = digest
 }
 
 func newTraceMessagesCmd() *cobra.Command {
@@ -160,7 +196,7 @@ Examples:
 				for _, t := range traces {
 					trace, _ := t.(map[string]any)
 					traj := buildTraceTrajectory(trace)
-					trace["trajectory"] = traj.Steps
+					attachTrajectory(trace, traj, buildTraceDigest(trace))
 				}
 
 				nextCursor, _ := result["next_cursor"].(string)
@@ -221,7 +257,7 @@ Examples:
 			for _, t := range allTraces {
 				trace, _ := t.(map[string]any)
 				traj := buildTraceTrajectory(trace)
-				trace["trajectory"] = traj.Steps
+				attachTrajectory(trace, traj, buildTraceDigest(trace))
 			}
 
 			combined := map[string]any{
@@ -382,20 +418,19 @@ func printTraceMessages(result map[string]any) {
 	}
 }
 
-// buildTraceTrajectory converts a raw trace map into a compact trajectory.
+// buildTraceTrajectory converts a raw trace map into a compact, THIN trajectory
+// (role/tool/tokens/latency/chars per step). It carries no message content —
+// the trajectory is scanned across all traces for triage, so detail lives in
+// buildTraceDigest and is read per-trace.
 func buildTraceTrajectory(trace map[string]any) traceTrajectory {
 	traceID, _ := trace["trace_id"].(string)
-	inputsPreview, _ := trace["root_inputs_preview"].(string)
-	outputsPreview, _ := trace["root_outputs_preview"].(string)
 	groups, _ := trace["groups"].([]any)
 
 	var steps []trajectoryStep
-	var firstHuman, finalAI string
 	for _, g := range groups {
 		group, _ := g.(map[string]any)
 		gType, _ := group["type"].(string)
 		meta, _ := group["metadata"].(map[string]any)
-
 		tokens := trajTokens(meta)
 		latency := trajLatency(meta)
 
@@ -403,71 +438,113 @@ func buildTraceTrajectory(trace map[string]any) traceTrajectory {
 		case "message":
 			msg, _ := group["message"].(map[string]any)
 			role, _ := msg["role"].(string)
-			text := msgText(msg)
-			step := trajectoryStep{Role: role, Chars: msgChars(msg), Text: truncateHard(text, trajTextMax)}
+			step := trajectoryStep{Role: role, Chars: msgChars(msg)}
 			if role == "ai" {
 				step.Tokens = tokens
 				step.LatencyMS = latency
-			}
-			if role == "human" && firstHuman == "" {
-				firstHuman = text
-			}
-			if role == "ai" && text != "" {
-				finalAI = text
 			}
 			steps = append(steps, step)
 		case "tool_interaction":
 			aiMsg, _ := group["aiMessage"].(map[string]any)
 			role, _ := aiMsg["role"].(string)
-			aiText := msgText(aiMsg)
-			if aiText != "" {
-				finalAI = aiText
-			}
 			steps = append(steps, trajectoryStep{
 				Role:      role,
 				Tokens:    tokens,
 				LatencyMS: latency,
 				Chars:     msgChars(aiMsg),
-				Text:      truncateHard(aiText, trajTextMax),
 			})
 			toolCalls, _ := group["toolCalls"].([]any)
 			for _, tc := range toolCalls {
 				call, _ := tc.(map[string]any)
 				name, _ := call["name"].(string)
 				result, _ := call["result"].(map[string]any)
-				resultText := ""
-				if result != nil {
-					resultText = coerceContent(result["content"])
-				}
 				steps = append(steps, trajectoryStep{
-					Role:       "tool",
-					ToolName:   name,
-					Chars:      msgChars(result),
-					ToolArgs:   truncateHard(marshalArgs(call["args"]), trajArgsMax),
-					ToolResult: truncateHard(resultText, trajResultMax),
-					Errorish:   resultText != "" && errorishPattern.MatchString(resultText),
+					Role:     "tool",
+					ToolName: name,
+					Chars:    msgChars(result),
 				})
 			}
 		}
 	}
+	return traceTrajectory{TraceID: traceID, Steps: steps}
+}
 
-	// Prefer the full message from groups (untruncated) over the ~150-char
-	// API preview, which is clipped and sometimes shows a tool message instead
-	// of the answer. Fall back to the preview when groups don't carry it.
-	inputMessage := firstHuman
-	if inputMessage == "" {
-		inputMessage = inputsPreview
-	}
-	outputMessage := finalAI
-	if outputMessage == "" {
-		outputMessage = outputsPreview
+// buildTraceDigest builds the detailed per-trace digest: the full first-human /
+// final-AI messages plus a normalized per-group index (content coerced to
+// strings, fields length-bounded). Read per-trace by a screener — kept OUT of
+// the bulk-scanned trajectory on purpose. Mirrors the fetch-time digest the
+// issues-agent screeners verdict from.
+func buildTraceDigest(trace map[string]any) traceDigest {
+	inputsPreview, _ := trace["root_inputs_preview"].(string)
+	outputsPreview, _ := trace["root_outputs_preview"].(string)
+	groups, _ := trace["groups"].([]any)
+
+	var firstHuman, finalAI string
+	index := make([]digestGroup, 0, len(groups))
+	for i, g := range groups {
+		group, _ := g.(map[string]any)
+		gType, _ := group["type"].(string)
+		dg := digestGroup{I: i, Kind: gType}
+		if dg.Kind == "" {
+			dg.Kind = "message"
+		}
+
+		var text string
+		switch gType {
+		case "message":
+			msg, _ := group["message"].(map[string]any)
+			dg.Role, _ = msg["role"].(string)
+			text = msgText(msg)
+			if dg.Role == "human" && firstHuman == "" {
+				firstHuman = text
+			}
+			if dg.Role == "ai" && text != "" {
+				finalAI = text
+			}
+		case "tool_interaction":
+			aiMsg, _ := group["aiMessage"].(map[string]any)
+			text = msgText(aiMsg)
+			if text != "" {
+				finalAI = text
+			}
+			toolCalls, _ := group["toolCalls"].([]any)
+			for _, tc := range toolCalls {
+				call, _ := tc.(map[string]any)
+				name, _ := call["name"].(string)
+				dg.Tools = append(dg.Tools, name)
+				dg.ToolArgs = append(dg.ToolArgs, digestToolArg{
+					Name: name,
+					Args: truncateHard(marshalArgs(call["args"]), digestArgsMax),
+				})
+				result, _ := call["result"].(map[string]any)
+				resultText := ""
+				if result != nil {
+					resultText = coerceContent(result["content"])
+				}
+				dg.ToolResult = append(dg.ToolResult, truncateHard(resultText, digestResultMax))
+				if resultText != "" && errorishPattern.MatchString(resultText) {
+					dg.Errorish = true
+				}
+			}
+		}
+		dg.Chars = len(text)
+		dg.Text = truncateHard(text, digestTextMax)
+		index = append(index, dg)
 	}
 
-	return traceTrajectory{
-		TraceID:       traceID,
-		InputMessage:  inputMessage,
-		OutputMessage: outputMessage,
-		Steps:         steps,
+	// Prefer the full message from groups; fall back to the (~150-char) preview
+	// only when groups don't carry it.
+	if firstHuman == "" {
+		firstHuman = inputsPreview
+	}
+	if finalAI == "" {
+		finalAI = outputsPreview
+	}
+	return traceDigest{
+		FirstHuman: firstHuman,
+		FinalAI:    finalAI,
+		NGroups:    len(groups),
+		GroupIndex: index,
 	}
 }
 

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -615,7 +615,11 @@ func coerceContent(v any) string {
 					parts = append(parts, t)
 				} else if t, ok := b["content"].(string); ok {
 					parts = append(parts, t)
+				} else {
+					parts = append(parts, unrenderedContent(b))
 				}
+			default:
+				parts = append(parts, fmt.Sprintf("%v", b))
 			}
 		}
 		return strings.Join(parts, " ")
@@ -626,10 +630,27 @@ func coerceContent(v any) string {
 		if t, ok := c["content"].(string); ok {
 			return t
 		}
-		return ""
+		return unrenderedContent(c)
 	default:
 		return fmt.Sprintf("%v", c)
 	}
+}
+
+// unrenderedContent represents a non-null content block that carries no
+// plain-text `text`/`content` field (image, tool_use, or other structured
+// blocks) as a non-empty string. Collapsing these to "" makes structured
+// content indistinguishable from a genuinely empty turn, which misleads a
+// downstream reader (e.g. the engine screener) into treating the content as
+// absent. Prefer compact JSON (the downstream char caps truncate it); fall back
+// to a typed sentinel if the block can't be marshaled.
+func unrenderedContent(m map[string]any) string {
+	if b, err := json.Marshal(m); err == nil {
+		return string(b)
+	}
+	if t, ok := m["type"].(string); ok && t != "" {
+		return "[" + t + " content]"
+	}
+	return "[unrenderable content]"
 }
 
 // msgText returns a message's content coerced to a plain string.

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -2,8 +2,11 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	langsmith "github.com/langchain-ai/langsmith-go"
@@ -13,6 +16,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Char caps for the normalized trajectory fields. Bounded so a single huge
+// message or tool payload can't blow up the trajectory view (and the context
+// of any agent reading it). The full untruncated content is still available in
+// the trace's `groups`.
+const (
+	trajTextMax   = 600
+	trajArgsMax   = 200
+	trajResultMax = 200
+)
+
+// errorishPattern flags a tool result whose content looks like an error, so a
+// reader can spot failed tool calls without opening every result.
+var errorishPattern = regexp.MustCompile(`(?i)error|not found|unauthorized|timeout|exception|denied|forbidden|traceback|http 5`)
+
 // trajectoryStep is a compact single-step view of one message/tool-call in a trace.
 type trajectoryStep struct {
 	Role      string `json:"role"`
@@ -20,6 +37,13 @@ type trajectoryStep struct {
 	Tokens    *int64 `json:"tokens,omitempty"`
 	LatencyMS *int64 `json:"latency_ms,omitempty"`
 	Chars     int    `json:"chars,omitempty"`
+	// Normalized content so a reader can verdict straight off the trajectory
+	// without re-parsing `groups` (whose content is heterogeneously shaped —
+	// a string, a list of blocks, or null).
+	Text       string `json:"text,omitempty"`        // coerced message content, ≤trajTextMax
+	ToolArgs   string `json:"tool_args,omitempty"`   // JSON of the tool call args, ≤trajArgsMax
+	ToolResult string `json:"tool_result,omitempty"` // coerced tool result content, ≤trajResultMax
+	Errorish   bool   `json:"errorish,omitempty"`    // tool result content looks like an error
 }
 
 // traceTrajectory is the compact trajectory for a single trace.
@@ -366,6 +390,7 @@ func buildTraceTrajectory(trace map[string]any) traceTrajectory {
 	groups, _ := trace["groups"].([]any)
 
 	var steps []trajectoryStep
+	var firstHuman, finalAI string
 	for _, g := range groups {
 		group, _ := g.(map[string]any)
 		gType, _ := group["type"].(string)
@@ -378,39 +403,70 @@ func buildTraceTrajectory(trace map[string]any) traceTrajectory {
 		case "message":
 			msg, _ := group["message"].(map[string]any)
 			role, _ := msg["role"].(string)
-			step := trajectoryStep{Role: role, Chars: msgChars(msg)}
+			text := msgText(msg)
+			step := trajectoryStep{Role: role, Chars: msgChars(msg), Text: truncateHard(text, trajTextMax)}
 			if role == "ai" {
 				step.Tokens = tokens
 				step.LatencyMS = latency
+			}
+			if role == "human" && firstHuman == "" {
+				firstHuman = text
+			}
+			if role == "ai" && text != "" {
+				finalAI = text
 			}
 			steps = append(steps, step)
 		case "tool_interaction":
 			aiMsg, _ := group["aiMessage"].(map[string]any)
 			role, _ := aiMsg["role"].(string)
+			aiText := msgText(aiMsg)
+			if aiText != "" {
+				finalAI = aiText
+			}
 			steps = append(steps, trajectoryStep{
 				Role:      role,
 				Tokens:    tokens,
 				LatencyMS: latency,
 				Chars:     msgChars(aiMsg),
+				Text:      truncateHard(aiText, trajTextMax),
 			})
 			toolCalls, _ := group["toolCalls"].([]any)
 			for _, tc := range toolCalls {
 				call, _ := tc.(map[string]any)
 				name, _ := call["name"].(string)
 				result, _ := call["result"].(map[string]any)
+				resultText := ""
+				if result != nil {
+					resultText = coerceContent(result["content"])
+				}
 				steps = append(steps, trajectoryStep{
-					Role:     "tool",
-					ToolName: name,
-					Chars:    msgChars(result),
+					Role:       "tool",
+					ToolName:   name,
+					Chars:      msgChars(result),
+					ToolArgs:   truncateHard(marshalArgs(call["args"]), trajArgsMax),
+					ToolResult: truncateHard(resultText, trajResultMax),
+					Errorish:   resultText != "" && errorishPattern.MatchString(resultText),
 				})
 			}
 		}
 	}
 
+	// Prefer the full message from groups (untruncated) over the ~150-char
+	// API preview, which is clipped and sometimes shows a tool message instead
+	// of the answer. Fall back to the preview when groups don't carry it.
+	inputMessage := firstHuman
+	if inputMessage == "" {
+		inputMessage = inputsPreview
+	}
+	outputMessage := finalAI
+	if outputMessage == "" {
+		outputMessage = outputsPreview
+	}
+
 	return traceTrajectory{
 		TraceID:       traceID,
-		InputMessage:  inputsPreview,
-		OutputMessage: outputsPreview,
+		InputMessage:  inputMessage,
+		OutputMessage: outputMessage,
 		Steps:         steps,
 	}
 }
@@ -459,6 +515,64 @@ func msgChars(msg map[string]any) int {
 		}
 	}
 	return total
+}
+
+// coerceContent flattens a message/tool `content` value — which may be a
+// string, a list of content blocks, an object, or null — into a plain string.
+// Content shape is heterogeneous across integrations; normalizing here lets a
+// reader verdict off the trajectory without re-parsing each shape.
+func coerceContent(v any) string {
+	switch c := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return c
+	case []any:
+		var parts []string
+		for _, block := range c {
+			switch b := block.(type) {
+			case string:
+				parts = append(parts, b)
+			case map[string]any:
+				if t, ok := b["text"].(string); ok {
+					parts = append(parts, t)
+				} else if t, ok := b["content"].(string); ok {
+					parts = append(parts, t)
+				}
+			}
+		}
+		return strings.Join(parts, " ")
+	case map[string]any:
+		if t, ok := c["text"].(string); ok {
+			return t
+		}
+		if t, ok := c["content"].(string); ok {
+			return t
+		}
+		return ""
+	default:
+		return fmt.Sprintf("%v", c)
+	}
+}
+
+// msgText returns a message's content coerced to a plain string.
+func msgText(msg map[string]any) string {
+	if msg == nil {
+		return ""
+	}
+	return coerceContent(msg["content"])
+}
+
+// marshalArgs renders tool-call args as compact JSON, or "" if absent/unmarshalable.
+func marshalArgs(args any) string {
+	if args == nil {
+		return ""
+	}
+	b, err := json.Marshal(args)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 // printMessage prints a single message in a compact format.

--- a/internal/cmd/message_trajectory_test.go
+++ b/internal/cmd/message_trajectory_test.go
@@ -5,77 +5,79 @@ import (
 	"testing"
 )
 
-// buildTraceTrajectory should normalize heterogeneously-shaped group content
-// into the trajectory's text / tool_args / tool_result / errorish fields, and
-// source the full first-human / final-AI messages from groups (not the clipped
-// previews).
-func TestBuildTraceTrajectory_NormalizedFields(t *testing.T) {
+// The trajectory must stay THIN — no message content / tool args / results.
+// It is scanned across all traces, so per-trace detail belongs in the digest.
+func TestBuildTraceTrajectory_IsThin(t *testing.T) {
 	trace := map[string]any{
-		"trace_id":             "t1",
-		"root_inputs_preview":  "human: how do I use MCP?",
-		"root_outputs_preview": "tool: a truncated preview that is not the answer",
+		"trace_id": "t1",
 		"groups": []any{
+			map[string]any{"type": "message", "message": map[string]any{"role": "human", "content": "x" + strings.Repeat("y", 5000)}},
 			map[string]any{
-				"type":    "message",
-				"message": map[string]any{"role": "human", "content": "how do I use MCP?"},
-			},
-			map[string]any{
-				"type": "tool_interaction",
-				// aiMessage content as a list of blocks (must coerce to a string)
-				"aiMessage": map[string]any{
-					"role":    "ai",
-					"content": []any{map[string]any{"type": "text", "text": "searching the docs"}},
-				},
-				"toolCalls": []any{
-					map[string]any{
-						"name":   "search_docs",
-						"args":   map[string]any{"q": "mcp"},
-						"result": map[string]any{"content": "404 not found"},
-					},
-				},
-			},
-			map[string]any{
-				"type":    "message",
-				"message": map[string]any{"role": "ai", "content": "Use create_agent with the mcp arg."},
+				"type":      "tool_interaction",
+				"aiMessage": map[string]any{"role": "ai", "content": "thinking"},
+				"toolCalls": []any{map[string]any{"name": "search", "args": map[string]any{"q": "z"}, "result": map[string]any{"content": "404 not found"}}},
 			},
 		},
 	}
-
 	traj := buildTraceTrajectory(trace)
-
-	// first_human / final_ai come from groups (full), not the previews.
-	if traj.InputMessage != "how do I use MCP?" {
-		t.Errorf("InputMessage = %q, want full human message from groups", traj.InputMessage)
+	if len(traj.Steps) != 3 { // human, ai, tool
+		t.Fatalf("got %d steps, want 3", len(traj.Steps))
 	}
-	if traj.OutputMessage != "Use create_agent with the mcp arg." {
-		t.Errorf("OutputMessage = %q, want final ai message from groups", traj.OutputMessage)
+	// Steps carry only role/tool_name/chars — no content fields exist on the struct.
+	if traj.Steps[2].Role != "tool" || traj.Steps[2].ToolName != "search" {
+		t.Errorf("tool step = %+v", traj.Steps[2])
 	}
-
-	// steps: human, ai (tool_interaction), tool, ai (final message)
-	if len(traj.Steps) != 4 {
-		t.Fatalf("got %d steps, want 4", len(traj.Steps))
-	}
-	if traj.Steps[1].Text != "searching the docs" {
-		t.Errorf("ai step Text = %q, want list-of-blocks coerced to a string", traj.Steps[1].Text)
-	}
-	tool := traj.Steps[2]
-	if tool.Role != "tool" || tool.ToolName != "search_docs" {
-		t.Errorf("tool step = %+v, want role=tool name=search_docs", tool)
-	}
-	if !strings.Contains(tool.ToolArgs, `"q":"mcp"`) {
-		t.Errorf("tool_args = %q, want JSON of the call args", tool.ToolArgs)
-	}
-	if tool.ToolResult != "404 not found" {
-		t.Errorf("tool_result = %q, want coerced result content", tool.ToolResult)
-	}
-	if !tool.Errorish {
-		t.Errorf("errorish = false, want true for a '404 not found' result")
+	if traj.Steps[0].Chars != 5001 {
+		t.Errorf("human step chars = %d, want 5001 (count only, no content)", traj.Steps[0].Chars)
 	}
 }
 
-// Null / missing content must coerce to empty without panicking, and the
-// trajectory must fall back to previews when groups carry no human/ai message.
-func TestBuildTraceTrajectory_NullContentAndFallback(t *testing.T) {
+// buildTraceDigest carries the detail: full first/final messages + a normalized
+// per-group index with coerced content, tool args/results, and errorish flags.
+func TestBuildTraceDigest_NormalizedGroups(t *testing.T) {
+	trace := map[string]any{
+		"trace_id":             "t1",
+		"root_inputs_preview":  "human: how do I use MCP?",
+		"root_outputs_preview": "tool: clipped preview that isn't the answer",
+		"groups": []any{
+			map[string]any{"type": "message", "message": map[string]any{"role": "human", "content": "how do I use MCP?"}},
+			map[string]any{
+				"type":      "tool_interaction",
+				"aiMessage": map[string]any{"role": "ai", "content": []any{map[string]any{"type": "text", "text": "searching the docs"}}},
+				"toolCalls": []any{map[string]any{"name": "search_docs", "args": map[string]any{"q": "mcp"}, "result": map[string]any{"content": "404 not found"}}},
+			},
+			map[string]any{"type": "message", "message": map[string]any{"role": "ai", "content": "Use create_agent with the mcp arg."}},
+		},
+	}
+	d := buildTraceDigest(trace)
+
+	if d.FirstHuman != "how do I use MCP?" {
+		t.Errorf("first_human = %q, want full human message from groups", d.FirstHuman)
+	}
+	if d.FinalAI != "Use create_agent with the mcp arg." {
+		t.Errorf("final_ai = %q, want final ai message from groups", d.FinalAI)
+	}
+	if d.NGroups != 3 || len(d.GroupIndex) != 3 {
+		t.Fatalf("n_groups=%d group_index=%d, want 3/3", d.NGroups, len(d.GroupIndex))
+	}
+	// tool_interaction group: content coerced from list-of-blocks, tool fields present.
+	tg := d.GroupIndex[1]
+	if tg.Kind != "tool_interaction" || tg.Text != "searching the docs" {
+		t.Errorf("group[1] kind/text = %q/%q", tg.Kind, tg.Text)
+	}
+	if len(tg.Tools) != 1 || tg.Tools[0] != "search_docs" {
+		t.Errorf("group[1] tools = %v", tg.Tools)
+	}
+	if len(tg.ToolArgs) != 1 || tg.ToolArgs[0].Name != "search_docs" || !strings.Contains(tg.ToolArgs[0].Args, `"q":"mcp"`) {
+		t.Errorf("group[1] tool_args = %+v", tg.ToolArgs)
+	}
+	if len(tg.ToolResult) != 1 || tg.ToolResult[0] != "404 not found" {
+		t.Errorf("group[1] tool_result = %v", tg.ToolResult)
+	}
+}
+
+// Null/missing content coerces to empty (no panic); first/final fall back to previews.
+func TestBuildTraceDigest_NullAndFallback(t *testing.T) {
 	trace := map[string]any{
 		"trace_id":             "t2",
 		"root_inputs_preview":  "human: hi",
@@ -83,51 +85,69 @@ func TestBuildTraceTrajectory_NullContentAndFallback(t *testing.T) {
 		"groups": []any{
 			map[string]any{
 				"type":      "tool_interaction",
-				"aiMessage": map[string]any{"role": "ai", "content": nil}, // null content
-				"toolCalls": []any{
-					map[string]any{"name": "read_url", "result": map[string]any{"content": nil}}, // null result
-				},
+				"aiMessage": map[string]any{"role": "ai", "content": nil},
+				"toolCalls": []any{map[string]any{"name": "read_url", "result": map[string]any{"content": nil}}},
 			},
 		},
 	}
-
-	traj := buildTraceTrajectory(trace)
-
-	// No human msg and no non-empty ai content in groups → fall back to previews.
-	if traj.InputMessage != "human: hi" {
-		t.Errorf("InputMessage = %q, want preview fallback", traj.InputMessage)
+	d := buildTraceDigest(trace)
+	if d.FirstHuman != "human: hi" || d.FinalAI != "the answer" {
+		t.Errorf("fallbacks: first=%q final=%q", d.FirstHuman, d.FinalAI)
 	}
-	if traj.OutputMessage != "the answer" {
-		t.Errorf("OutputMessage = %q, want preview fallback", traj.OutputMessage)
-	}
-	tool := traj.Steps[len(traj.Steps)-1]
-	if tool.ToolResult != "" || tool.Errorish {
-		t.Errorf("null result should yield empty tool_result and errorish=false, got %+v", tool)
+	g := d.GroupIndex[0]
+	if g.Text != "" || g.ToolResult[0] != "" || g.Errorish {
+		t.Errorf("null content should be empty/non-errorish, got %+v", g)
 	}
 }
 
-// Long content is bounded to the trajectory caps.
-func TestBuildTraceTrajectory_Truncation(t *testing.T) {
-	big := strings.Repeat("x", 5000)
-	trace := map[string]any{
-		"trace_id": "t3",
-		"groups": []any{
-			map[string]any{"type": "message", "message": map[string]any{"role": "human", "content": big}},
-			map[string]any{
-				"type":      "tool_interaction",
-				"aiMessage": map[string]any{"role": "ai", "content": "ok"},
-				"toolCalls": []any{
-					map[string]any{"name": "f", "result": map[string]any{"content": big}},
-				},
-			},
-		},
+// errorish must flag error-SHAPED results, not text that merely mentions "error".
+func TestBuildTraceDigest_ErrorishPrecision(t *testing.T) {
+	cases := []struct {
+		content string
+		want    bool
+	}{
+		{"Error: connection refused", true},
+		{"404 not found", true},
+		{`{"error": "rate limited"}`, true},
+		{"HTTP 503 service unavailable", true},
+		{"Traceback (most recent call last):", true},
+		{"Evaluators help you catch error cases in your app.", false},
+		{"This guide covers error handling best practices.", false},
+		{`{"level": "error", "matched": 4}`, false},
 	}
+	for _, c := range cases {
+		trace := map[string]any{"groups": []any{map[string]any{
+			"type":      "tool_interaction",
+			"aiMessage": map[string]any{"role": "ai", "content": ""},
+			"toolCalls": []any{map[string]any{"name": "t", "result": map[string]any{"content": c.content}}},
+		}}}
+		got := buildTraceDigest(trace).GroupIndex[0].Errorish
+		if got != c.want {
+			t.Errorf("errorish(%q) = %v, want %v", c.content, got, c.want)
+		}
+	}
+}
 
-	traj := buildTraceTrajectory(trace)
-	if got := len(traj.Steps[0].Text); got != trajTextMax {
-		t.Errorf("human step Text len = %d, want %d", got, trajTextMax)
+// Long content is bounded to the digest caps.
+func TestBuildTraceDigest_Truncation(t *testing.T) {
+	big := strings.Repeat("x", 5000)
+	trace := map[string]any{"groups": []any{
+		map[string]any{"type": "message", "message": map[string]any{"role": "human", "content": big}},
+		map[string]any{
+			"type":      "tool_interaction",
+			"aiMessage": map[string]any{"role": "ai", "content": "ok"},
+			"toolCalls": []any{map[string]any{"name": "f", "args": map[string]any{"k": big}, "result": map[string]any{"content": big}}},
+		},
+	}}
+	d := buildTraceDigest(trace)
+	if got := len(d.GroupIndex[0].Text); got != digestTextMax {
+		t.Errorf("group text len = %d, want %d", got, digestTextMax)
 	}
-	if got := len(traj.Steps[2].ToolResult); got != trajResultMax {
-		t.Errorf("tool_result len = %d, want %d", got, trajResultMax)
+	tg := d.GroupIndex[1]
+	if got := len(tg.ToolResult[0]); got != digestResultMax {
+		t.Errorf("tool_result len = %d, want %d", got, digestResultMax)
+	}
+	if got := len(tg.ToolArgs[0].Args); got != digestArgsMax {
+		t.Errorf("tool_args len = %d, want %d", got, digestArgsMax)
 	}
 }

--- a/internal/cmd/message_trajectory_test.go
+++ b/internal/cmd/message_trajectory_test.go
@@ -100,6 +100,30 @@ func TestBuildTraceDigest_NullAndFallback(t *testing.T) {
 	}
 }
 
+// Non-null structured content (image / tool_use blocks, or a map with no
+// text/content field) must NOT collapse to "" — that is indistinguishable from
+// a genuinely empty turn and misleads a downstream reader into thinking the
+// content is absent. Only nil stays empty.
+func TestCoerceContent_UnrenderedStructuredContent(t *testing.T) {
+	if got := coerceContent(nil); got != "" {
+		t.Errorf("nil content = %q, want empty", got)
+	}
+	// A structured object with no text/content field (e.g. an image block).
+	img := map[string]any{"type": "image", "source": map[string]any{"url": "https://x/y.png"}}
+	if got := coerceContent(img); got == "" || !strings.Contains(got, "image") {
+		t.Errorf("image block coerced to %q, want non-empty mentioning its type", got)
+	}
+	// A list with a renderable text block and an unrenderable tool_use block:
+	// the tool_use must still contribute non-empty content, not be dropped.
+	blocks := []any{
+		map[string]any{"type": "text", "text": "calling a tool"},
+		map[string]any{"type": "tool_use", "name": "search", "input": map[string]any{"q": "mcp"}},
+	}
+	if got := coerceContent(blocks); !strings.Contains(got, "calling a tool") || !strings.Contains(got, "tool_use") {
+		t.Errorf("block list coerced to %q, want both the text and the tool_use block", got)
+	}
+}
+
 // errorish must flag error-SHAPED results, not text that merely mentions "error".
 func TestBuildTraceDigest_ErrorishPrecision(t *testing.T) {
 	cases := []struct {

--- a/internal/cmd/message_trajectory_test.go
+++ b/internal/cmd/message_trajectory_test.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildTraceTrajectory should normalize heterogeneously-shaped group content
+// into the trajectory's text / tool_args / tool_result / errorish fields, and
+// source the full first-human / final-AI messages from groups (not the clipped
+// previews).
+func TestBuildTraceTrajectory_NormalizedFields(t *testing.T) {
+	trace := map[string]any{
+		"trace_id":             "t1",
+		"root_inputs_preview":  "human: how do I use MCP?",
+		"root_outputs_preview": "tool: a truncated preview that is not the answer",
+		"groups": []any{
+			map[string]any{
+				"type":    "message",
+				"message": map[string]any{"role": "human", "content": "how do I use MCP?"},
+			},
+			map[string]any{
+				"type": "tool_interaction",
+				// aiMessage content as a list of blocks (must coerce to a string)
+				"aiMessage": map[string]any{
+					"role":    "ai",
+					"content": []any{map[string]any{"type": "text", "text": "searching the docs"}},
+				},
+				"toolCalls": []any{
+					map[string]any{
+						"name":   "search_docs",
+						"args":   map[string]any{"q": "mcp"},
+						"result": map[string]any{"content": "404 not found"},
+					},
+				},
+			},
+			map[string]any{
+				"type":    "message",
+				"message": map[string]any{"role": "ai", "content": "Use create_agent with the mcp arg."},
+			},
+		},
+	}
+
+	traj := buildTraceTrajectory(trace)
+
+	// first_human / final_ai come from groups (full), not the previews.
+	if traj.InputMessage != "how do I use MCP?" {
+		t.Errorf("InputMessage = %q, want full human message from groups", traj.InputMessage)
+	}
+	if traj.OutputMessage != "Use create_agent with the mcp arg." {
+		t.Errorf("OutputMessage = %q, want final ai message from groups", traj.OutputMessage)
+	}
+
+	// steps: human, ai (tool_interaction), tool, ai (final message)
+	if len(traj.Steps) != 4 {
+		t.Fatalf("got %d steps, want 4", len(traj.Steps))
+	}
+	if traj.Steps[1].Text != "searching the docs" {
+		t.Errorf("ai step Text = %q, want list-of-blocks coerced to a string", traj.Steps[1].Text)
+	}
+	tool := traj.Steps[2]
+	if tool.Role != "tool" || tool.ToolName != "search_docs" {
+		t.Errorf("tool step = %+v, want role=tool name=search_docs", tool)
+	}
+	if !strings.Contains(tool.ToolArgs, `"q":"mcp"`) {
+		t.Errorf("tool_args = %q, want JSON of the call args", tool.ToolArgs)
+	}
+	if tool.ToolResult != "404 not found" {
+		t.Errorf("tool_result = %q, want coerced result content", tool.ToolResult)
+	}
+	if !tool.Errorish {
+		t.Errorf("errorish = false, want true for a '404 not found' result")
+	}
+}
+
+// Null / missing content must coerce to empty without panicking, and the
+// trajectory must fall back to previews when groups carry no human/ai message.
+func TestBuildTraceTrajectory_NullContentAndFallback(t *testing.T) {
+	trace := map[string]any{
+		"trace_id":             "t2",
+		"root_inputs_preview":  "human: hi",
+		"root_outputs_preview": "the answer",
+		"groups": []any{
+			map[string]any{
+				"type":      "tool_interaction",
+				"aiMessage": map[string]any{"role": "ai", "content": nil}, // null content
+				"toolCalls": []any{
+					map[string]any{"name": "read_url", "result": map[string]any{"content": nil}}, // null result
+				},
+			},
+		},
+	}
+
+	traj := buildTraceTrajectory(trace)
+
+	// No human msg and no non-empty ai content in groups → fall back to previews.
+	if traj.InputMessage != "human: hi" {
+		t.Errorf("InputMessage = %q, want preview fallback", traj.InputMessage)
+	}
+	if traj.OutputMessage != "the answer" {
+		t.Errorf("OutputMessage = %q, want preview fallback", traj.OutputMessage)
+	}
+	tool := traj.Steps[len(traj.Steps)-1]
+	if tool.ToolResult != "" || tool.Errorish {
+		t.Errorf("null result should yield empty tool_result and errorish=false, got %+v", tool)
+	}
+}
+
+// Long content is bounded to the trajectory caps.
+func TestBuildTraceTrajectory_Truncation(t *testing.T) {
+	big := strings.Repeat("x", 5000)
+	trace := map[string]any{
+		"trace_id": "t3",
+		"groups": []any{
+			map[string]any{"type": "message", "message": map[string]any{"role": "human", "content": big}},
+			map[string]any{
+				"type":      "tool_interaction",
+				"aiMessage": map[string]any{"role": "ai", "content": "ok"},
+				"toolCalls": []any{
+					map[string]any{"name": "f", "result": map[string]any{"content": big}},
+				},
+			},
+		},
+	}
+
+	traj := buildTraceTrajectory(trace)
+	if got := len(traj.Steps[0].Text); got != trajTextMax {
+		t.Errorf("human step Text len = %d, want %d", got, trajTextMax)
+	}
+	if got := len(traj.Steps[2].ToolResult); got != trajResultMax {
+		t.Errorf("tool_result len = %d, want %d", got, trajResultMax)
+	}
+}


### PR DESCRIPTION
Folds the issues-agent "digest" into the `trace messages` trajectory view, so the normalization lives in the CLI/data layer rather than as a bespoke agent tool or a jq blob in a prompt.

## Motivation
The issues-agent screener was spending its first several turns running ad-hoc `jq` against each trace's `groups[]` to extract the question, the answer, and the tool sequence — `groups[]` content is heterogeneously shaped (a string, a list of content blocks, or null), so that jq was both slow and crash-prone. `trace messages` already builds a compact `trajectory` from the same groups; this adds the normalized content needed to verdict a trace directly off the trajectory.

## Changes
`buildTraceTrajectory` now emits, per step:
- `text` — message content coerced to a plain string, ≤600 chars
- `tool_args` — compact JSON of the tool-call args, ≤200 chars
- `tool_result` — coerced tool result content, ≤200 chars
- `errorish` — true when the result content matches an error pattern (`error|not found|unauthorized|timeout|...`)

And `input_message` / `output_message` are now sourced from the **full** first-human / final-AI messages in `groups` (untruncated), falling back to the previews — the API preview is ~150 chars and sometimes shows a tool message instead of the answer.

Content coercion handles `string | []block | object | null` defensively and every field is length-bounded, so malformed or huge trace payloads can't panic the CLI or blow up the trajectory. Full untruncated content is still available in `groups`.

## Test plan
- [x] New `message_trajectory_test.go`: list-of-blocks coercion, tool args/result/errorish, full first-human/final-AI from groups vs preview fallback, null-content safety, and the ≤600/≤200 truncation caps.
- [x] `go vet`, `gofmt`, and the full `internal/cmd` suite pass.

## Follow-up
Once released and the sandbox CLI is bumped, the issues-agent drops its `jq -f digest_filter.jq` fetch step and reads these fields directly from `trace messages` — removing the bespoke digest tool entirely.