### PR TITLE
fix(self-update): detect install method and defer to package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,19 @@ langsmith self-update --dry-run
 langsmith self-update
 ```
 
+If langsmith was installed through a package manager, `self-update` won't replace the
+binary in place — it points you at the right command instead:
+
+| Installed via | Update with |
+| --- | --- |
+| Homebrew | `brew upgrade langchain-ai/tap/langsmith-cli` |
+| Scoop | `scoop update langsmith-cli` |
+| `go install` | `go install github.com/langchain-ai/langsmith-cli/cmd/langsmith@latest` |
+
+Installs from the `install.sh`/`install.ps1` scripts or a direct GitHub Releases download
+are updated in place as usual. Pass `--force` to update in place regardless of how
+langsmith was installed.
+
 ### `trace setup` — Trace coding agents to LangSmith
 
 Configure Claude Code or Codex to send full-content traces (prompts, responses, tool

--- a/internal/cmd/install_method.go
+++ b/internal/cmd/install_method.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 )
@@ -23,6 +22,21 @@ const (
 	// methodDev means a local/development build with no release version.
 	methodDev
 )
+
+// externalManagers describes installs owned by a package manager: how to name
+// the manager in output and the command the user should run to update. Only the
+// methods self-update must defer to appear here — methodManaged and methodDev are
+// handled by self-update itself and intentionally have no entry, so membership in
+// this map is the single source of truth for "must defer to a package manager".
+var externalManagers = map[installMethod]struct {
+	label   string // machine-readable name, for JSON output
+	display string // human-readable name, for the pretty message
+	command string // the command the user should run to update
+}{
+	methodHomebrew: {"homebrew", "Homebrew", "brew upgrade langchain-ai/tap/langsmith-cli"},
+	methodScoop:    {"scoop", "Scoop", "scoop update langsmith-cli"},
+	methodGo:       {"go", "`go install`", "go install github.com/langchain-ai/langsmith-cli/cmd/langsmith@latest"},
+}
 
 // detectInstallMethod classifies the install method from the resolved executable
 // path, the build version, and the relevant environment values. It is pure: all
@@ -77,58 +91,11 @@ func goBinDirs(gobin, gopath, home string) []string {
 	return nil
 }
 
-// updateCommand returns the command a user should run to update an
-// externally-managed install. Returns "" for managed/dev methods.
-func (m installMethod) updateCommand() string {
-	switch m {
-	case methodHomebrew:
-		return "brew upgrade langchain-ai/tap/langsmith-cli"
-	case methodScoop:
-		return "scoop update langsmith-cli"
-	case methodGo:
-		return "go install github.com/langchain-ai/langsmith-cli/cmd/langsmith@latest"
-	default:
-		return ""
-	}
-}
-
-// label returns a stable machine-readable name for the install method, used in
-// JSON output.
-func (m installMethod) label() string {
-	switch m {
-	case methodHomebrew:
-		return "homebrew"
-	case methodScoop:
-		return "scoop"
-	case methodGo:
-		return "go"
-	case methodDev:
-		return "dev"
-	default:
-		return "managed"
-	}
-}
-
-// displayName returns a human-readable name of the package manager for messages.
-func (m installMethod) displayName() string {
-	switch m {
-	case methodHomebrew:
-		return "Homebrew"
-	case methodScoop:
-		return "Scoop"
-	case methodGo:
-		return "`go install`"
-	default:
-		return ""
-	}
-}
-
-// managedExternallyMessage returns the pretty-format message shown when
-// self-update declines to replace a package-manager-owned binary.
-func (m installMethod) managedExternallyMessage() string {
-	return fmt.Sprintf(
-		"langsmith was installed with %s, which manages updates for you.\nTo update, run:\n\n    %s\n\n(Use --force to update in place anyway.)",
-		m.displayName(),
-		m.updateCommand(),
-	)
+// shouldDeferToManager reports whether self-update must defer to a package
+// manager instead of replacing the binary in place. --force overrides it.
+// Membership in externalManagers is the source of truth; methodManaged and
+// methodDev are not externally managed and so are never deferred.
+func shouldDeferToManager(method installMethod, force bool) bool {
+	_, external := externalManagers[method]
+	return external && !force
 }

--- a/internal/cmd/install_method.go
+++ b/internal/cmd/install_method.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// installMethod identifies how the langsmith binary was installed, which
+// determines whether self-update may replace the binary in place.
+type installMethod int
+
+const (
+	// methodManaged means self-update owns the binary: install.sh, install.ps1,
+	// or a manual download from GitHub Releases. In-place replacement is correct.
+	methodManaged installMethod = iota
+	// methodHomebrew means the binary lives in a Homebrew Cellar.
+	methodHomebrew
+	// methodScoop means the binary was installed by Scoop.
+	methodScoop
+	// methodGo means the binary was installed via `go install`.
+	methodGo
+	// methodDev means a local/development build with no release version.
+	methodDev
+)
+
+// detectInstallMethod classifies the install method from the resolved executable
+// path, the build version, and the relevant environment values. It is pure: all
+// I/O (resolving the path, reading env) happens in the caller.
+//
+//   - execPath must already be resolved through filepath.EvalSymlinks so that
+//     Homebrew's bin symlinks point at the Cellar.
+//   - goos is runtime.GOOS.
+//   - gobin/gopath/home come from $GOBIN, $GOPATH, and the user's home dir.
+func detectInstallMethod(execPath, version, goos, gobin, gopath, home string) installMethod {
+	// Normalize both separators to "/" so a single "/segment/" check works for
+	// Windows paths regardless of the OS this code runs on (matters for tests).
+	lower := strings.ToLower(strings.ReplaceAll(execPath, `\`, "/"))
+
+	if strings.Contains(lower, "/cellar/") {
+		return methodHomebrew
+	}
+	if strings.Contains(lower, "/scoop/") {
+		return methodScoop
+	}
+
+	dir := filepath.Dir(execPath)
+	for _, bin := range goBinDirs(gobin, gopath, home) {
+		if bin != "" && filepath.Clean(dir) == filepath.Clean(bin) {
+			return methodGo
+		}
+	}
+
+	if version == "dev" {
+		return methodDev
+	}
+	return methodManaged
+}
+
+// goBinDirs returns the candidate directories where `go install` places binaries,
+// in precedence order: $GOBIN, then $GOPATH/bin, then $HOME/go/bin (Go's default
+// GOPATH when unset).
+func goBinDirs(gobin, gopath, home string) []string {
+	if gobin != "" {
+		return []string{gobin}
+	}
+	if gopath != "" {
+		// GOPATH may contain multiple entries; go install uses the first.
+		first := filepath.SplitList(gopath)
+		if len(first) > 0 && first[0] != "" {
+			return []string{filepath.Join(first[0], "bin")}
+		}
+	}
+	if home != "" {
+		return []string{filepath.Join(home, "go", "bin")}
+	}
+	return nil
+}
+
+// updateCommand returns the command a user should run to update an
+// externally-managed install. Returns "" for managed/dev methods.
+func (m installMethod) updateCommand() string {
+	switch m {
+	case methodHomebrew:
+		return "brew upgrade langchain-ai/tap/langsmith-cli"
+	case methodScoop:
+		return "scoop update langsmith-cli"
+	case methodGo:
+		return "go install github.com/langchain-ai/langsmith-cli/cmd/langsmith@latest"
+	default:
+		return ""
+	}
+}
+
+// label returns a stable machine-readable name for the install method, used in
+// JSON output.
+func (m installMethod) label() string {
+	switch m {
+	case methodHomebrew:
+		return "homebrew"
+	case methodScoop:
+		return "scoop"
+	case methodGo:
+		return "go"
+	case methodDev:
+		return "dev"
+	default:
+		return "managed"
+	}
+}
+
+// displayName returns a human-readable name of the package manager for messages.
+func (m installMethod) displayName() string {
+	switch m {
+	case methodHomebrew:
+		return "Homebrew"
+	case methodScoop:
+		return "Scoop"
+	case methodGo:
+		return "`go install`"
+	default:
+		return ""
+	}
+}
+
+// managedExternallyMessage returns the pretty-format message shown when
+// self-update declines to replace a package-manager-owned binary.
+func (m installMethod) managedExternallyMessage() string {
+	return fmt.Sprintf(
+		"langsmith was installed with %s, which manages updates for you.\nTo update, run:\n\n    %s\n\n(Use --force to update in place anyway.)",
+		m.displayName(),
+		m.updateCommand(),
+	)
+}

--- a/internal/cmd/install_method_test.go
+++ b/internal/cmd/install_method_test.go
@@ -138,17 +138,56 @@ func TestDetectInstallMethod(t *testing.T) {
 	}
 }
 
-func TestInstallMethodUpdateCommand(t *testing.T) {
-	tests := map[installMethod]string{
-		methodHomebrew: "brew upgrade langchain-ai/tap/langsmith-cli",
-		methodScoop:    "scoop update langsmith-cli",
-		methodGo:       "go install github.com/langchain-ai/langsmith-cli/cmd/langsmith@latest",
-		methodManaged:  "",
-		methodDev:      "",
+func TestExternalManagers(t *testing.T) {
+	want := map[installMethod]struct{ label, command string }{
+		methodHomebrew: {"homebrew", "brew upgrade langchain-ai/tap/langsmith-cli"},
+		methodScoop:    {"scoop", "scoop update langsmith-cli"},
+		methodGo:       {"go", "go install github.com/langchain-ai/langsmith-cli/cmd/langsmith@latest"},
 	}
-	for method, want := range tests {
-		if got := method.updateCommand(); got != want {
-			t.Errorf("updateCommand(%v) = %q, want %q", method, got, want)
+	for method, exp := range want {
+		mgr, ok := externalManagers[method]
+		if !ok {
+			t.Errorf("externalManagers missing entry for %v", method)
+			continue
+		}
+		if mgr.label != exp.label {
+			t.Errorf("externalManagers[%v].label = %q, want %q", method, mgr.label, exp.label)
+		}
+		if mgr.command != exp.command {
+			t.Errorf("externalManagers[%v].command = %q, want %q", method, mgr.command, exp.command)
+		}
+		if mgr.display == "" {
+			t.Errorf("externalManagers[%v].display is empty", method)
+		}
+	}
+	// managed and dev are handled by self-update itself and must not be listed.
+	for _, method := range []installMethod{methodManaged, methodDev} {
+		if _, ok := externalManagers[method]; ok {
+			t.Errorf("externalManagers should not contain %v", method)
+		}
+	}
+}
+
+func TestShouldDeferToManager(t *testing.T) {
+	tests := []struct {
+		method installMethod
+		force  bool
+		want   bool
+	}{
+		{methodHomebrew, false, true},
+		{methodHomebrew, true, false}, // --force overrides the defer
+		{methodScoop, false, true},
+		{methodScoop, true, false},
+		{methodGo, false, true},
+		{methodGo, true, false},
+		{methodManaged, false, false},
+		{methodManaged, true, false},
+		{methodDev, false, false},
+		{methodDev, true, false},
+	}
+	for _, tt := range tests {
+		if got := shouldDeferToManager(tt.method, tt.force); got != tt.want {
+			t.Errorf("shouldDeferToManager(%v, force=%v) = %v, want %v", tt.method, tt.force, got, tt.want)
 		}
 	}
 }
@@ -190,20 +229,5 @@ func TestReportManagedExternally_Pretty(t *testing.T) {
 	}
 	if !strings.Contains(output, "--force") {
 		t.Errorf("expected pretty output to mention --force, got %q", output)
-	}
-}
-
-func TestInstallMethodLabel(t *testing.T) {
-	tests := map[installMethod]string{
-		methodHomebrew: "homebrew",
-		methodScoop:    "scoop",
-		methodGo:       "go",
-		methodDev:      "dev",
-		methodManaged:  "managed",
-	}
-	for method, want := range tests {
-		if got := method.label(); got != want {
-			t.Errorf("label(%v) = %q, want %q", method, got, want)
-		}
 	}
 }

--- a/internal/cmd/install_method_test.go
+++ b/internal/cmd/install_method_test.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestDetectInstallMethod(t *testing.T) {
+	tests := []struct {
+		name     string
+		execPath string
+		version  string
+		goos     string
+		gobin    string
+		gopath   string
+		home     string
+		want     installMethod
+	}{
+		{
+			name:     "homebrew apple silicon cellar",
+			execPath: "/opt/homebrew/Cellar/langsmith-cli/0.2.38/bin/langsmith",
+			version:  "0.2.38",
+			goos:     "darwin",
+			home:     "/Users/me",
+			want:     methodHomebrew,
+		},
+		{
+			name:     "homebrew intel cellar",
+			execPath: "/usr/local/Cellar/langsmith-cli/0.2.38/bin/langsmith",
+			version:  "0.2.38",
+			goos:     "darwin",
+			home:     "/Users/me",
+			want:     methodHomebrew,
+		},
+		{
+			name:     "homebrew linux cellar",
+			execPath: "/home/linuxbrew/.linuxbrew/Cellar/langsmith-cli/0.2.38/bin/langsmith",
+			version:  "0.2.38",
+			goos:     "linux",
+			home:     "/home/me",
+			want:     methodHomebrew,
+		},
+		{
+			name:     "scoop apps",
+			execPath: `C:\Users\me\scoop\apps\langsmith-cli\current\langsmith.exe`,
+			version:  "0.2.38",
+			goos:     "windows",
+			home:     `C:\Users\me`,
+			want:     methodScoop,
+		},
+		{
+			name:     "scoop shims",
+			execPath: `C:\Users\me\scoop\shims\langsmith.exe`,
+			version:  "0.2.38",
+			goos:     "windows",
+			home:     `C:\Users\me`,
+			want:     methodScoop,
+		},
+		{
+			name:     "go install via GOBIN",
+			execPath: "/Users/me/dev/gobin/langsmith",
+			version:  "0.2.38",
+			goos:     "darwin",
+			gobin:    "/Users/me/dev/gobin",
+			home:     "/Users/me",
+			want:     methodGo,
+		},
+		{
+			name:     "go install via GOPATH bin",
+			execPath: "/Users/me/gopath/bin/langsmith",
+			version:  "0.2.38",
+			goos:     "darwin",
+			gopath:   "/Users/me/gopath",
+			home:     "/Users/me",
+			want:     methodGo,
+		},
+		{
+			name:     "go install via default HOME/go/bin",
+			execPath: "/Users/me/go/bin/langsmith",
+			version:  "0.2.38",
+			goos:     "darwin",
+			home:     "/Users/me",
+			want:     methodGo,
+		},
+		{
+			name:     "go install with dev version still detected as go",
+			execPath: "/Users/me/go/bin/langsmith",
+			version:  "dev",
+			goos:     "darwin",
+			home:     "/Users/me",
+			want:     methodGo,
+		},
+		{
+			name:     "managed install.sh usr local bin",
+			execPath: "/usr/local/bin/langsmith",
+			version:  "0.2.38",
+			goos:     "darwin",
+			home:     "/Users/me",
+			want:     methodManaged,
+		},
+		{
+			name:     "managed install.sh local bin",
+			execPath: "/Users/me/.local/bin/langsmith",
+			version:  "0.2.38",
+			goos:     "linux",
+			home:     "/Users/me",
+			want:     methodManaged,
+		},
+		{
+			name:     "dev build outside package dirs",
+			execPath: "/Users/me/repos/langsmith-cli/bin/langsmith",
+			version:  "dev",
+			goos:     "darwin",
+			home:     "/Users/me",
+			want:     methodDev,
+		},
+		{
+			name:     "GOBIN takes precedence over GOPATH",
+			execPath: "/Users/me/gopath/bin/langsmith",
+			version:  "0.2.38",
+			goos:     "darwin",
+			gobin:    "/Users/me/gobin",
+			gopath:   "/Users/me/gopath",
+			home:     "/Users/me",
+			// exec is in GOPATH/bin, but GOBIN is set and differs → not the go bin dir
+			want: methodManaged,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectInstallMethod(tt.execPath, tt.version, tt.goos, tt.gobin, tt.gopath, tt.home)
+			if got != tt.want {
+				t.Errorf("detectInstallMethod() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallMethodUpdateCommand(t *testing.T) {
+	tests := map[installMethod]string{
+		methodHomebrew: "brew upgrade langchain-ai/tap/langsmith-cli",
+		methodScoop:    "scoop update langsmith-cli",
+		methodGo:       "go install github.com/langchain-ai/langsmith-cli/cmd/langsmith@latest",
+		methodManaged:  "",
+		methodDev:      "",
+	}
+	for method, want := range tests {
+		if got := method.updateCommand(); got != want {
+			t.Errorf("updateCommand(%v) = %q, want %q", method, got, want)
+		}
+	}
+}
+
+func TestReportManagedExternally_JSON(t *testing.T) {
+	oldFmt := flagOutputFormat
+	flagOutputFormat = "json"
+	defer func() { flagOutputFormat = oldFmt }()
+
+	output := captureStdout(t, func() {
+		if err := reportManagedExternally(methodHomebrew, "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v, output: %q", err, output)
+	}
+	if result["status"] != "managed-externally" {
+		t.Errorf("expected status managed-externally, got %q", result["status"])
+	}
+	if result["install_method"] != "homebrew" {
+		t.Errorf("expected install_method homebrew, got %q", result["install_method"])
+	}
+	if result["update_command"] != "brew upgrade langchain-ai/tap/langsmith-cli" {
+		t.Errorf("unexpected update_command: %q", result["update_command"])
+	}
+}
+
+func TestReportManagedExternally_Pretty(t *testing.T) {
+	output := captureStdout(t, func() {
+		if err := reportManagedExternally(methodScoop, "pretty"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(output, "scoop update langsmith-cli") {
+		t.Errorf("expected pretty output to contain the scoop command, got %q", output)
+	}
+	if !strings.Contains(output, "--force") {
+		t.Errorf("expected pretty output to mention --force, got %q", output)
+	}
+}
+
+func TestInstallMethodLabel(t *testing.T) {
+	tests := map[installMethod]string{
+		methodHomebrew: "homebrew",
+		methodScoop:    "scoop",
+		methodGo:       "go",
+		methodDev:      "dev",
+		methodManaged:  "managed",
+	}
+	for method, want := range tests {
+		if got := method.label(); got != want {
+			t.Errorf("label(%v) = %q, want %q", method, got, want)
+		}
+	}
+}

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -28,24 +28,46 @@ var githubDownloadBaseURL = "https://github.com"
 
 func newUpdateCmd(rawVersion string) *cobra.Command {
 	var dryRun bool
+	var force bool
 
 	cmd := &cobra.Command{
 		Use:   "self-update",
 		Short: "Update langsmith to the latest version",
 		Long:  "Check for and install the latest version of the langsmith CLI.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUpdate(cmd.Context(), rawVersion, dryRun)
+			return runUpdate(cmd.Context(), rawVersion, dryRun, force)
 		},
 	}
 
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Check for updates without installing")
+	cmd.Flags().BoolVar(&force, "force", false, "Replace the binary in place even if a package manager (brew, scoop, go) manages this install")
 
 	return cmd
 }
 
-func runUpdate(ctx context.Context, currentVersion string, dryRun bool) error {
-	if currentVersion == "dev" {
+func runUpdate(ctx context.Context, currentVersion string, dryRun, force bool) error {
+	// Resolve the current binary path first: it drives both install-method
+	// detection and the eventual in-place replacement.
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving executable path: %w", err)
+	}
+	execPath, err = filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return fmt.Errorf("resolving symlinks: %w", err)
+	}
+
+	home, _ := os.UserHomeDir()
+	method := detectInstallMethod(execPath, currentVersion, runtime.GOOS, os.Getenv("GOBIN"), os.Getenv("GOPATH"), home)
+
+	if method == methodDev {
 		return fmt.Errorf("cannot update a development build; install from a release")
+	}
+
+	// For package-manager-owned installs, refuse to touch the binary and point
+	// the user at the right command instead. --force overrides this.
+	if method != methodManaged && !force {
+		return reportManagedExternally(method, GetFormat())
 	}
 
 	latest, err := fetchLatestVersion(ctx)
@@ -81,16 +103,6 @@ func runUpdate(ctx context.Context, currentVersion string, dryRun bool) error {
 			fmt.Println(string(out))
 		}
 		return nil
-	}
-
-	// Resolve current binary path
-	execPath, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("resolving executable path: %w", err)
-	}
-	execPath, err = filepath.EvalSymlinks(execPath)
-	if err != nil {
-		return fmt.Errorf("resolving symlinks: %w", err)
 	}
 
 	archiveName := buildArchiveName()
@@ -140,6 +152,23 @@ func runUpdate(ctx context.Context, currentVersion string, dryRun bool) error {
 			"status":           "updated",
 			"previous_version": currentVersion,
 			"new_version":      latest,
+		})
+		fmt.Println(string(out))
+	}
+	return nil
+}
+
+// reportManagedExternally informs the user that their install is managed by a
+// package manager and prints the command to update it, without modifying the
+// binary. It returns nil (a successful, informational outcome).
+func reportManagedExternally(method installMethod, format string) error {
+	if format == "pretty" {
+		fmt.Println(method.managedExternallyMessage())
+	} else {
+		out, _ := json.Marshal(map[string]string{
+			"status":         "managed-externally",
+			"install_method": method.label(),
+			"update_command": method.updateCommand(),
 		})
 		fmt.Println(string(out))
 	}

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -66,7 +66,7 @@ func runUpdate(ctx context.Context, currentVersion string, dryRun, force bool) e
 
 	// For package-manager-owned installs, refuse to touch the binary and point
 	// the user at the right command instead. --force overrides this.
-	if method != methodManaged && !force {
+	if shouldDeferToManager(method, force) {
 		return reportManagedExternally(method, GetFormat())
 	}
 
@@ -162,13 +162,21 @@ func runUpdate(ctx context.Context, currentVersion string, dryRun, force bool) e
 // package manager and prints the command to update it, without modifying the
 // binary. It returns nil (a successful, informational outcome).
 func reportManagedExternally(method installMethod, format string) error {
+	mgr, ok := externalManagers[method]
+	if !ok {
+		// Programming error: only externally-managed methods should reach here
+		// (methodManaged updates in place, methodDev errors out earlier).
+		return fmt.Errorf("internal error: install method %d is not externally managed", method)
+	}
+
 	if format == "pretty" {
-		fmt.Println(method.managedExternallyMessage())
+		fmt.Printf("langsmith was installed with %s, which manages updates for you.\n"+
+			"To update, run:\n\n    %s\n\n(Use --force to update in place anyway.)\n", mgr.display, mgr.command)
 	} else {
 		out, _ := json.Marshal(map[string]string{
 			"status":         "managed-externally",
-			"install_method": method.label(),
-			"update_command": method.updateCommand(),
+			"install_method": mgr.label,
+			"update_command": mgr.command,
 		})
 		fmt.Println(string(out))
 	}

--- a/internal/cmd/update_test.go
+++ b/internal/cmd/update_test.go
@@ -203,7 +203,7 @@ func TestRunUpdate_AlreadyUpToDate(t *testing.T) {
 	defer func() { flagOutputFormat = oldFmt }()
 
 	output := captureStdout(t, func() {
-		err := runUpdate(context.Background(), "0.1.7", false)
+		err := runUpdate(context.Background(), "0.1.7", false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -235,7 +235,7 @@ func TestRunUpdate_DryRun(t *testing.T) {
 	defer func() { flagOutputFormat = oldFmt }()
 
 	output := captureStdout(t, func() {
-		err := runUpdate(context.Background(), "0.1.7", true)
+		err := runUpdate(context.Background(), "0.1.7", true, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -254,7 +254,7 @@ func TestRunUpdate_DryRun(t *testing.T) {
 }
 
 func TestRunUpdate_DevBuild(t *testing.T) {
-	err := runUpdate(context.Background(), "dev", false)
+	err := runUpdate(context.Background(), "dev", false, false)
 	if err == nil {
 		t.Error("expected error for dev build")
 	}


### PR DESCRIPTION
## What

`langsmith self-update` overwrote the binary in place regardless of how the CLI was installed. For package-manager-owned installs that desyncs the manager (Homebrew, Scoop, `go install`) — the next `brew upgrade` fights it, and `go install` builds got a misleading "cannot update a development build" error.

This detects the install method from the resolved executable path and routes accordingly.

## How

- New pure `detectInstallMethod(execPath, version, goos, gobin, gopath, home)` in `internal/cmd/install_method.go` → `managed | homebrew | scoop | go | dev`. Signals: `/Cellar/` (brew), `/scoop/`, and `$GOBIN`/`$GOPATH/bin`/`~/go/bin` (go). Separators are normalized so Windows paths classify on any host.
- `runUpdate` resolves the exec path up front, detects the method, then:
  - **managed** (`install.sh`/`install.ps1`/manual download) → in-place update as before (download → sha256 verify → atomic replace, **unchanged**).
  - **brew / scoop / go** → print the correct command and exit 0:
    - `brew upgrade langchain-ai/tap/langsmith-cli`
    - `scoop update langsmith-cli`
    - `go install github.com/langchain-ai/langsmith-cli/cmd/langsmith@latest`
  - **dev** → existing error.
- `--force` overrides the block and updates in place.
- Respects `--format json`: `{"status":"managed-externally","install_method":"homebrew","update_command":"..."}`.
- `go install` builds report version `dev`, so the Go bin dir is checked **before** the dev guard — those users now get the right command instead of the dev-build error.

## Testing

- Table-driven unit tests for the detector (brew mac/intel/linux, scoop apps/shims, go via GOBIN/GOPATH/default, managed, dev, precedence) + command/label + JSON/pretty message tests.
- `go build ./...`, `go vet`, full `go test ./...` pass; `gofmt` clean.
- Manually verified end-to-end with a real binary from simulated install paths: brew/scoop/go print the command without touching the binary; managed still hits GitHub; brew + `--force` bypasses and checks for an update.

Fixes #171