### PR TITLE
fix(filters): use eq for --name so run/trace list name filtering works

### DIFF
--- a/internal/cmd/filters.go
+++ b/internal/cmd/filters.go
@@ -161,9 +161,11 @@ func buildFilterDSL(f *FilterFlags) string {
 		}
 	}
 
-	// Name filter (substring search)
+	// Name filter (exact match). The backend runs/query validator rejects the
+	// SEARCH comparator on the `name` attribute with a 400, and the --name flag
+	// is documented as an exact-match filter, so use eq rather than search.
 	if f.Name != "" {
-		parts = append(parts, fmt.Sprintf("search(name, %q)", f.Name))
+		parts = append(parts, fmt.Sprintf("eq(name, %q)", f.Name))
 	}
 
 	// Latency filters

--- a/internal/cmd/filters_test.go
+++ b/internal/cmd/filters_test.go
@@ -16,7 +16,7 @@ func TestBuildFilterDSL_Empty(t *testing.T) {
 func TestBuildFilterDSL_SingleName(t *testing.T) {
 	f := &FilterFlags{Name: "ChatOpenAI"}
 	result := buildFilterDSL(f)
-	expected := `search(name, "ChatOpenAI")`
+	expected := `eq(name, "ChatOpenAI")`
 	if result != expected {
 		t.Errorf("expected %q, got %q", expected, result)
 	}
@@ -92,7 +92,7 @@ func TestBuildFilterDSL_Combined(t *testing.T) {
 		Tags:       "prod",
 	}
 	result := buildFilterDSL(f)
-	expected := `and(search(name, "ChatOpenAI"), gte(latency, 2.5), has(tags, "prod"))`
+	expected := `and(eq(name, "ChatOpenAI"), gte(latency, 2.5), has(tags, "prod"))`
 	if result != expected {
 		t.Errorf("expected %q, got %q", expected, result)
 	}
@@ -265,7 +265,7 @@ func TestBuildRunQueryParams_FilterDSLWithName(t *testing.T) {
 	if !params.Filter.Present {
 		t.Fatal("expected Filter to be set")
 	}
-	expected := `search(name, "ChatOpenAI")`
+	expected := `eq(name, "ChatOpenAI")`
 	if params.Filter.Value != expected {
 		t.Errorf("expected %q, got %q", expected, params.Filter.Value)
 	}


### PR DESCRIPTION
## Problem

`langsmith run list --name <x>` (and `trace list --name <x>`, which shares the same filter flags) returns **HTTP 400** for any value:

```
querying runs: POST .../api/v1/runs/query: 400 Bad Request
{"detail":"Comparison comparator=<Comparator.SEARCH: 'search'> attribute='name' value='...' multi=False not accepted."}
```

`internal/cmd/filters.go` built the clause as `search(name, %q)`, but the backend runs/query validator does not accept the `SEARCH` comparator on the `name` attribute — only `eq`. So the `--name` filter is completely non-functional. It also contradicts the flag's own help, which documents it as **exact match**.

## Fix

One-line comparator change: emit `eq(name, %q)` instead of `search(name, %q)`. `eq` is both what the backend accepts and what the flag already promises. Value interpolation (`%q` quoting) is unchanged. Updated the two tests that asserted the old `search(name, …)` output.

## Verification

- `go build ./...` + `go test ./internal/cmd/` pass.
- Built the binary and ran it against a live project:
  - **before:** `run list --name ChatAnthropicWithOpenAIFallback` → HTTP 400
  - **after:** returns the matching runs, all named exactly `ChatAnthropicWithOpenAIFallback` (exact match, no 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)