### PR TITLE
fix(ci): authenticate install script GitHub API call to avoid rate-limit flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - uses: actions/checkout@v4
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -39,9 +39,29 @@ fi
 
 # Get version
 if [ -z "$VERSION" ]; then
-  VERSION="$(curl -sSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
+  API_URL="https://api.github.com/repos/${REPO}/releases/latest"
+
+  fetch_latest() {
+    if [ -n "$GITHUB_TOKEN" ]; then
+      curl -fsSL -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer $GITHUB_TOKEN" "$API_URL"
+    else
+      curl -fsSL -H "Accept: application/vnd.github+json" "$API_URL"
+    fi
+  }
+
+  VERSION=""
+  i=1
+  while [ "$i" -le 3 ]; do
+    VERSION="$(fetch_latest | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
+    [ -n "$VERSION" ] && break
+    [ "$i" -lt 3 ] && sleep "$i"
+    i=$((i + 1))
+  done
+
   if [ -z "$VERSION" ]; then
-    echo "Failed to determine latest version" >&2
+    echo "Failed to determine latest version (GitHub API unreachable or rate-limited)." >&2
+    echo "Set GITHUB_TOKEN to raise the rate limit, or set VERSION to install a specific release." >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
## What

`install.sh` resolved the latest release tag via an **unauthenticated** GitHub API call — capped at 60 req/hour per IP, shared across Actions runners. When exhausted the response is empty and the `installer-smoke` job fails with `Failed to determine latest version` on unrelated changes.

## How

- **scripts/install.sh** — send `Authorization: Bearer $GITHUB_TOKEN` when the token is set (mirroring `install.ps1`), retry transient failures (3×, 1s/2s backoff), and fail with an actionable message naming the cause.
- **.github/workflows/ci.yml** — expose `GITHUB_TOKEN` to the `installer-smoke` job so both smoke steps authenticate, raising the limit to 1,000/hour.

## Testing

- Ran `install.sh` end-to-end to a temp dir: unauthenticated and authenticated paths both resolve, download, verify, and install (v0.2.38).
- Failure path (unreachable repo, no token): 3 attempts, ~3s backoff, friendly error, clean exit 1 — no hang, no `set -e` crash.
- `sh -n` clean; `ci.yml` valid YAML with `env` scoped to the job.

## Evidence

The flake that prompted this: https://github.com/langchain-ai/langsmith-cli/actions/runs/29037209171/job/86185056703 (a no-code re-run passed, confirming it was transient).

Closes LSDK-313