### PR TITLE
fix: --full run/trace output omits first_token_time and events

### DIFF
--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -183,12 +183,14 @@ func buildRunSelectV2(includeIO, includeFeedback bool) []langsmith.RunQueryV2Par
 		langsmith.RunQueryV2ParamsSelectTotalCost,
 		langsmith.RunQueryV2ParamsSelectLatencySeconds,
 		langsmith.RunQueryV2ParamsSelectAppPath,
+		langsmith.RunQueryV2ParamsSelectFirstTokenTime,
 	}
 	if includeIO {
 		fields = append(fields,
 			langsmith.RunQueryV2ParamsSelectInputs,
 			langsmith.RunQueryV2ParamsSelectOutputs,
 			langsmith.RunQueryV2ParamsSelectError,
+			langsmith.RunQueryV2ParamsSelectEvents,
 		)
 	}
 	if includeFeedback {
@@ -240,6 +242,7 @@ func runV2ToSchema(r langsmith.Run) langsmith.RunSchema {
 		Outputs:            asMap(r.Outputs),
 		Extra:              extra,
 		FeedbackStats:      convertFeedbackStats(r.FeedbackStats),
+		Events:             convertEvents(r.Events),
 	}
 	if len(r.ParentRunIDs) > 0 {
 		out.ParentRunIDs = r.ParentRunIDs
@@ -275,6 +278,24 @@ func convertFeedbackStats(stats map[string]langsmith.RunFeedbackStat) map[string
 	return m
 }
 
+// convertEvents round-trips the generated v2 event shape into the
+// loosely-typed maps the legacy RunSchema.Events field expects. Returns nil on
+// empty input or any marshalling error.
+func convertEvents(events []langsmith.RunEvent) []map[string]interface{} {
+	if len(events) == 0 {
+		return nil
+	}
+	raw, err := json.Marshal(events)
+	if err != nil {
+		return nil
+	}
+	var m []map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil
+	}
+	return m
+}
+
 // buildRunSelect returns the Select fields needed for the given include flags.
 // Returns nil when neither IO nor feedback is requested, letting the API use its defaults.
 // When set, includes all base/metadata fields so they aren't stripped from the response.
@@ -295,6 +316,7 @@ func buildRunSelect(includeIO, includeFeedback bool) []langsmith.RunQueryParamsS
 		langsmith.RunQueryParamsSelectStatus,
 		// Metadata fields
 		langsmith.RunQueryParamsSelectExtra,
+		langsmith.RunQueryParamsSelectFirstTokenTime,
 		langsmith.RunQueryParamsSelectPromptTokens,
 		langsmith.RunQueryParamsSelectCompletionTokens,
 		langsmith.RunQueryParamsSelectTotalTokens,
@@ -309,6 +331,7 @@ func buildRunSelect(includeIO, includeFeedback bool) []langsmith.RunQueryParamsS
 			langsmith.RunQueryParamsSelectInputs,
 			langsmith.RunQueryParamsSelectOutputs,
 			langsmith.RunQueryParamsSelectError,
+			langsmith.RunQueryParamsSelectEvents,
 		)
 	}
 

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -404,6 +404,19 @@ func TestBuildRunSelect_IncludesMetadataFields(t *testing.T) {
 	}
 }
 
+func TestBuildRunSelect_IncludesFirstTokenTimeAndEvents(t *testing.T) {
+	// first_token_time and events are native Run fields that --full is
+	// documented to return; a prior version of this select list silently
+	// dropped both even when --include-io/--include-metadata were requested.
+	has := selectSet(buildRunSelect(true, true))
+	if !has[langsmith.RunQueryParamsSelectFirstTokenTime] {
+		t.Error("missing first_token_time field")
+	}
+	if !has[langsmith.RunQueryParamsSelectEvents] {
+		t.Error("missing events field (should be requested alongside inputs/outputs/error)")
+	}
+}
+
 // selectSet converts a slice to a set for easy lookup.
 func selectSet(sel []langsmith.RunQueryParamsSelect) map[langsmith.RunQueryParamsSelect]bool {
 	m := make(map[langsmith.RunQueryParamsSelect]bool, len(sel))
@@ -482,5 +495,58 @@ func TestRunTreeData_AllFields(t *testing.T) {
 	if td.ID != "id" || td.ParentRunID != "pid" || td.Name != "name" ||
 		td.RunType != "chain" || *td.DurationMs != 100 || !td.HasError {
 		t.Error("unexpected RunTreeData field values")
+	}
+}
+
+// ---------- buildRunSelectV2 ----------
+
+func TestBuildRunSelectV2_IncludesFirstTokenTimeAndEvents(t *testing.T) {
+	// Mirrors TestBuildRunSelect_IncludesFirstTokenTimeAndEvents for the v2
+	// select builder: first_token_time is a base field always requested,
+	// events is requested alongside inputs/outputs/error under --include-io.
+	base := buildRunSelectV2(false, false)
+	baseHas := map[langsmith.RunQueryV2ParamsSelect]bool{}
+	for _, f := range base {
+		baseHas[f] = true
+	}
+	if !baseHas[langsmith.RunQueryV2ParamsSelectFirstTokenTime] {
+		t.Error("missing first_token_time field in base v2 select set")
+	}
+	if baseHas[langsmith.RunQueryV2ParamsSelectEvents] {
+		t.Error("events should not be requested without --include-io")
+	}
+
+	withIO := buildRunSelectV2(true, false)
+	ioHas := map[langsmith.RunQueryV2ParamsSelect]bool{}
+	for _, f := range withIO {
+		ioHas[f] = true
+	}
+	if !ioHas[langsmith.RunQueryV2ParamsSelectEvents] {
+		t.Error("missing events field when --include-io requested")
+	}
+}
+
+// ---------- runV2ToSchema ----------
+
+func TestRunV2ToSchema_MapsFirstTokenTimeAndEvents(t *testing.T) {
+	firstToken := time.Date(2026, 1, 15, 10, 30, 1, 0, time.UTC)
+	v2 := langsmith.Run{
+		ID:             "run-123",
+		FirstTokenTime: firstToken,
+		Events: []langsmith.RunEvent{
+			{Name: "new_token", Kwargs: map[string]interface{}{"token": "hi"}},
+		},
+	}
+
+	out := runV2ToSchema(v2)
+
+	if !out.FirstTokenTime.Equal(firstToken) {
+		t.Errorf("expected FirstTokenTime=%v, got %v", firstToken, out.FirstTokenTime)
+	}
+	if len(out.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(out.Events))
+	}
+	if out.Events[0]["name"] != "new_token" {
+		t.Errorf("expected event name=new_token, got %v", out.Events[0]["name"])
 	}
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -95,8 +95,8 @@ func newRunListCmd() *cobra.Command {
 
 	addCommonFilterFlags(cmd, &ff, true)
 	addVersionFlag(cmd, &ff)
-	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, token_usage, costs, tags, custom_metadata (incl. revision_id)")
-	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, and error fields")
+	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
+	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io --include-feedback")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
@@ -179,8 +179,8 @@ func newRunGetCmd() *cobra.Command {
 	cmd.Flags().StringVar(&since, "since", "", "Only include runs after this timestamp, e.g. 2024-01-15T00:00:00Z (overrides 7-day default)")
 	cmd.Flags().IntVar(&lastNMinutes, "last-n-minutes", 0, "Only include runs from the last N minutes, e.g. 60 (overrides 7-day default)")
 	cmd.Flags().StringVar(&version, "version", "", `Query API version: "" (v1, default) or "v2" (SmithDB)`)
-	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, token_usage, costs, tags, custom_metadata (incl. revision_id)")
-	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, and error fields")
+	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
+	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io --include-feedback")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
@@ -244,8 +244,8 @@ func newRunExportCmd() *cobra.Command {
 
 	addCommonFilterFlags(cmd, &ff, true)
 	addVersionFlag(cmd, &ff)
-	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, token_usage, costs, tags, custom_metadata (incl. revision_id)")
-	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, and error fields")
+	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
+	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io --include-feedback")
 

--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -267,8 +267,8 @@ func newThreadGetCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
-	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, token_usage, costs, tags, custom_metadata (incl. revision_id)")
-	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, and error fields")
+	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
+	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io --include-feedback")
 	cmd.Flags().IntVarP(&limit, "limit", "n", 0, "Maximum number of runs (turns) to return")

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -144,8 +144,8 @@ func newTraceListCmd() *cobra.Command {
 
 	addCommonFilterFlags(cmd, &ff, false)
 	cmd.Flags().StringVar(&ff.ProjectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
-	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, token_usage, costs, tags, custom_metadata (incl. revision_id)")
-	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, and error fields")
+	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
+	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
 	cmd.Flags().BoolVar(&includeFlagged, "include-flagged", false, "Add flagged_comment field populated from user-flagged trace feedback")
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io --include-feedback")
@@ -222,8 +222,8 @@ func newTraceGetCmd() *cobra.Command {
 	cmd.Flags().StringVar(&projectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
 	cmd.Flags().StringVar(&since, "since", "", "Only include runs after this timestamp, e.g. 2024-01-15T00:00:00Z (overrides 7-day default)")
 	cmd.Flags().IntVar(&lastNMinutes, "last-n-minutes", 0, "Only include runs from the last N minutes, e.g. 60 (overrides 7-day default)")
-	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, token_usage, costs, tags, custom_metadata (incl. revision_id)")
-	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, and error fields")
+	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
+	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io --include-feedback")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
@@ -332,8 +332,8 @@ func newTraceExportCmd() *cobra.Command {
 
 	addCommonFilterFlags(cmd, &ff, false)
 	cmd.Flags().StringVar(&ff.ProjectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
-	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, token_usage, costs, tags, custom_metadata (incl. revision_id)")
-	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, and error fields")
+	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
+	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io --include-feedback")
 	cmd.Flags().StringVar(&filenamePattern, "filename-pattern", "{trace_id}.jsonl",

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -70,6 +70,7 @@ func ExtractRun(run langsmith.RunSchema, includeMetadata, includeIO, includeFeed
 
 		result["status"] = run.Status
 		result["duration_ms"] = durationMs
+		result["first_token_time"] = formatTimeNullable(run.FirstTokenTime)
 		result["custom_metadata"] = customMetadata
 		result["token_usage"] = tokenUsage
 		result["costs"] = costs
@@ -80,6 +81,7 @@ func ExtractRun(run langsmith.RunSchema, includeMetadata, includeIO, includeFeed
 		result["inputs"] = nilIfEmptyMap(run.Inputs)
 		result["outputs"] = nilIfEmptyMap(run.Outputs)
 		result["error"] = nilIfEmpty(run.Error)
+		result["events"] = nilIfEmptyEvents(run.Events)
 	}
 
 	if includeFeedback {
@@ -127,6 +129,13 @@ func nilIfEmptyMap(m map[string]any) any {
 		return nil
 	}
 	return m
+}
+
+func nilIfEmptyEvents(events []map[string]any) any {
+	if len(events) == 0 {
+		return nil
+	}
+	return events
 }
 
 // FormatDurationHuman formats milliseconds as human-readable string.

--- a/internal/extract/extract_test.go
+++ b/internal/extract/extract_test.go
@@ -51,6 +51,7 @@ func TestExtractRunBase(t *testing.T) {
 func TestExtractRunWithMetadata(t *testing.T) {
 	start := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
 	end := time.Date(2024, 1, 15, 10, 30, 5, 0, time.UTC)
+	firstToken := time.Date(2024, 1, 15, 10, 30, 1, 0, time.UTC)
 
 	run := langsmith.RunSchema{
 		ID:               "run-123",
@@ -59,6 +60,7 @@ func TestExtractRunWithMetadata(t *testing.T) {
 		RunType:          "llm",
 		StartTime:        start,
 		EndTime:          end,
+		FirstTokenTime:   firstToken,
 		Status:           "success",
 		PromptTokens:     100,
 		CompletionTokens: 50,
@@ -74,6 +76,10 @@ func TestExtractRunWithMetadata(t *testing.T) {
 
 	if result["status"] != "success" {
 		t.Errorf("expected status=success, got %v", result["status"])
+	}
+
+	if result["first_token_time"] != firstToken.Format(time.RFC3339Nano) {
+		t.Errorf("expected first_token_time=%s, got %v", firstToken.Format(time.RFC3339Nano), result["first_token_time"])
 	}
 
 	durationMs, ok := result["duration_ms"].(int64)
@@ -115,6 +121,7 @@ func TestExtractRunWithIO(t *testing.T) {
 		Inputs:    map[string]any{"query": "hello"},
 		Outputs:   map[string]any{"response": "world"},
 		Error:     "some error",
+		Events:    []map[string]interface{}{{"name": "new_token", "kwargs": map[string]interface{}{"token": "hi"}}},
 	}
 
 	result := ExtractRun(run, false, true, false)
@@ -131,6 +138,30 @@ func TestExtractRunWithIO(t *testing.T) {
 
 	if result["error"] != "some error" {
 		t.Errorf("expected error='some error', got %v", result["error"])
+	}
+
+	events, ok := result["events"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected events to be []map[string]interface{}, got %T", result["events"])
+	}
+	if len(events) != 1 || events[0]["name"] != "new_token" {
+		t.Errorf("expected one new_token event, got %v", events)
+	}
+}
+
+func TestExtractRunWithIOEmptyEvents(t *testing.T) {
+	run := langsmith.RunSchema{
+		ID:        "run-123",
+		TraceID:   "trace-456",
+		Name:      "ChatOpenAI",
+		RunType:   "llm",
+		StartTime: time.Now(),
+	}
+
+	result := ExtractRun(run, false, true, false)
+
+	if result["events"] != nil {
+		t.Errorf("expected events=nil for run with no events, got %v", result["events"])
 	}
 }
 


### PR DESCRIPTION
## Summary

`run get --full` / `trace get --full` (v0.2.39) silently dropped `first_token_time` and `events`. Root cause: the select-field builders (v1 and v2) never requested either field, `ExtractRun` never copied them into the output map, and `runV2ToSchema` had no `Events` mapping at all.

## Changes

- Request `first_token_time`/`events` in the v1 and v2 select builders (`internal/cmd/helpers.go`)
- Map v2 `Events` onto `RunSchema` in `runV2ToSchema`
- Surface both fields in `extract.ExtractRun`'s output, update `--include-metadata`/`--include-io` help text
- Add regression tests for the select builders, `runV2ToSchema`, and `ExtractRun`

## Test plan

- [x] `go build`, `go vet`, `go test ./...` all pass
- [x] `gofmt -l .` clean
- [x] Manual smoke test against a live streaming run in prod (see Before/after below)

## Before / after

Reproduced against a real streaming run in prod (`chat-langchain-external`), comparing this branch against `main`:

```
$ langsmith run get 019f6aaa-f23b-7bb1-84b6-423ed0eddac8 --project chat-langchain-external --full \
  | jq '{start_time, first_token_time, end_time, events}'

# Before (main)
{
  "start_time": "2026-07-16T11:23:35.867978Z",
  "first_token_time": null,
  "end_time": "2026-07-16T11:23:36.333746Z",
  "events": null
}

# After (this branch)
{
  "start_time": "2026-07-16T11:23:35.867978Z",
  "first_token_time": "2026-07-16T11:23:36.320629Z",
  "end_time": "2026-07-16T11:23:36.333746Z",
  "events": [
    {
      "name": "start",
      "time": "2026-07-16T11:23:35.867978+00:00"
    },
    {
      "name": "new_token",
      "time": "2026-07-16T11:23:36.320629+00:00"
    },
    {
      "name": "end",
      "time": "2026-07-16T11:23:36.333746+00:00"
    }
  ]
}
```

