### PR TITLE
feat(custom-apps): dark/light theme support in apps dev

### DIFF
--- a/internal/cmd/apps_dev.go
+++ b/internal/cmd/apps_dev.go
@@ -348,7 +348,13 @@ func handleLsDevCall(w http.ResponseWriter, r *http.Request) {
 		bodyReader = bytes.NewReader(b)
 	}
 
-	c := MustGetClient()
+	c, err := getClient()
+	if err != nil {
+		// Not MustGetClient: that exits the process, so one unauthenticated
+		// app call would kill the whole dev server. Return 502 instead.
+		http.Error(w, "not authenticated: "+err.Error(), http.StatusBadGateway)
+		return
+	}
 	status, _, respHeaders, respBody, err := c.RawDo(r.Context(), method, path, bodyReader, nil)
 	if err != nil {
 		http.Error(w, "request failed: "+err.Error(), http.StatusBadGateway)
@@ -413,12 +419,9 @@ setInterval(function() {
 // LS_API forwarded to /__ls_dev/call, which is real network access the
 // iframe itself can never have.
 //
-// When showQueueSelector is set (the app is linked as context_type
-// annotation_queue), the page also gets a queue-picker bar — fetched live
-// from the real API via the same /__ls_dev/call proxy — mirroring the
-// queue picker CustomAppPreviewPanel.tsx already shows when previewing a
-// contextual app from the Custom Apps tab. Standalone apps get no context
-// to pick, so no bar.
+// Every app gets a config toolbar; its first control is a Light/Dark mode
+// toggle (posting LANGSMITH_METADATA). The queue-picker item is added only
+// when showQueueSelector is set (context_type annotation_queue).
 func renderDevHostHTML(files map[string]string, entrypoint string, data map[string]any, showQueueSelector bool) string {
 	filesJSON, _ := json.Marshal(files)
 	entrypointJSON, _ := json.Marshal(entrypoint)
@@ -444,7 +447,7 @@ func renderDevHostHTML(files map[string]string, entrypoint string, data map[stri
 	).Replace(devHostHTMLTemplate)
 }
 
-const queueSelectorBarHTML = `<div id="ls-dev-queue-bar">
+const queueSelectorBarHTML = `<div id="ls-dev-queue-bar" class="ls-dev-toolbar-item">
   <label for="ls-dev-queue-select">Annotation queue:</label>
   <select id="ls-dev-queue-select"><option value="">Loading queues…</option></select>
 </div>
@@ -515,32 +518,73 @@ const devHostHTMLTemplate = `<!doctype html>
   html, body { height: 100%; margin: 0; }
   body { display: flex; flex-direction: column; font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', system-ui, sans-serif; }
 
-  /* Mirrors CustomAppPreviewPanel.tsx's queue picker: a level-2 surface bar
-     with a subtle divider, a secondary-text label, and a Select-style
-     bordered control (see smith-frontend/STYLES.md and
-     design-system/components/Select). Hand-ported since this page is a
-     standalone Go-templated HTML string with no access to Tailwind/CSS
-     variables. */
-  #ls-dev-queue-bar {
+  /* Toolbar renders for every app; queue selector only when contextual.
+     ls-dev-dark mirrors the sandbox's html.dark onto the host chrome. */
+  :root {
+    --ls-dev-bar-bg: #f5f8fb;
+    --ls-dev-bar-border: #e2e8f0;
+    --ls-dev-bar-label: #334155;
+    --ls-dev-control-bg: #ffffff;
+    --ls-dev-control-border: #cbd5e1;
+    --ls-dev-control-border-hover: #94a3b8;
+    --ls-dev-control-text: #0f172a;
+    --ls-dev-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23475569' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  }
+  html.ls-dev-dark {
+    --ls-dev-bar-bg: #111521;
+    --ls-dev-bar-border: #282e42;
+    --ls-dev-bar-label: #e2e8f0;
+    --ls-dev-control-bg: #1b2030;
+    --ls-dev-control-border: #393f55;
+    --ls-dev-control-border-hover: #555d78;
+    --ls-dev-control-text: #f5f8fb;
+    --ls-dev-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%238790ab' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  }
+
+  #ls-dev-toolbar {
     flex: none;
     display: flex;
     align-items: center;
-    gap: 8px;
-    background: #f5f8fb;
-    border-bottom: 1px solid #e2e8f0;
+    gap: 20px;
+    background: var(--ls-dev-bar-bg);
+    border-bottom: 1px solid var(--ls-dev-bar-border);
     padding: 8px 16px;
     font-size: 13px;
   }
-  #ls-dev-queue-bar label { font-weight: 500; color: #334155; }
+  .ls-dev-toolbar-item { display: flex; align-items: center; gap: 8px; }
+  .ls-dev-toolbar-item > label,
+  .ls-dev-toolbar-label { font-weight: 500; color: var(--ls-dev-bar-label); }
+
+  #ls-dev-mode-toggle {
+    font-family: inherit;
+    font-size: 13px;
+    color: var(--ls-dev-control-text);
+    background-color: var(--ls-dev-control-bg);
+    border: 1px solid var(--ls-dev-control-border);
+    border-radius: 6px;
+    padding: 5px 12px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    transition: border-color 120ms ease;
+  }
+  #ls-dev-mode-toggle:hover { border-color: var(--ls-dev-control-border-hover); }
+  #ls-dev-mode-toggle:focus-visible {
+    outline: none;
+    border-color: #006ddd;
+    box-shadow: 0 0 0 2px rgba(0, 109, 221, 0.15);
+  }
+
   #ls-dev-queue-bar select {
     font-family: inherit;
     font-size: 13px;
-    color: #0f172a;
+    color: var(--ls-dev-control-text);
     padding: 5px 28px 5px 10px;
     border-radius: 6px;
-    border: 1px solid #cbd5e1;
-    background-color: #ffffff;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23475569' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+    border: 1px solid var(--ls-dev-control-border);
+    background-color: var(--ls-dev-control-bg);
+    background-image: var(--ls-dev-chevron);
     background-repeat: no-repeat;
     background-position: right 8px center;
     background-size: 14px;
@@ -550,25 +594,24 @@ const devHostHTMLTemplate = `<!doctype html>
     cursor: pointer;
     transition: border-color 120ms ease;
   }
-  #ls-dev-queue-bar select:hover { border-color: #94a3b8; }
+  #ls-dev-queue-bar select:hover { border-color: var(--ls-dev-control-border-hover); }
   #ls-dev-queue-bar select:focus-visible {
     outline: none;
     border-color: #006ddd;
     box-shadow: 0 0 0 2px rgba(0, 109, 221, 0.15);
   }
 
-  /* No prefers-color-scheme variant here on purpose: the sandboxed app
-     below never actually receives a real theme (renderDevHostHTML posts a
-     permanently empty LANGSMITH_THEME cssText), so it always renders with
-     its hardcoded light-mode fallback regardless of OS setting. A
-     dark-mode bar would mismatch that light content instead of matching
-     the real (currently light-only) rendered page. */
-
   iframe { display: block; width: 100%; border: none; flex: 1 1 auto; }
 </style>
 </head>
 <body>
-__QUEUE_BAR_HTML__<iframe id="ls-app" sandbox="allow-scripts" srcdoc="__SANDBOX_SRCDOC__"></iframe>
+<div id="ls-dev-toolbar">
+  <div class="ls-dev-toolbar-item">
+    <span class="ls-dev-toolbar-label">Appearance</span>
+    <button id="ls-dev-mode-toggle" type="button" aria-pressed="false"><span id="ls-dev-mode-label">Light</span></button>
+  </div>
+  __QUEUE_BAR_HTML__</div>
+<iframe id="ls-app" sandbox="allow-scripts" srcdoc="__SANDBOX_SRCDOC__"></iframe>
 <script>
 (function() {
   var iframe = document.getElementById('ls-app');
@@ -578,6 +621,41 @@ __QUEUE_BAR_HTML__<iframe id="ls-app" sandbox="allow-scripts" srcdoc="__SANDBOX_
     iframe.contentWindow.postMessage(msg, '*');
   }
 
+  // First config control. mode ("dark"|"light") defaults from the OS,
+  // persists to localStorage, and drives the sandbox (LANGSMITH_METADATA) and host chrome.
+  var MODE_STORAGE_KEY = 'langsmith:apps-dev:mode';
+  var modeToggle = document.getElementById('ls-dev-mode-toggle');
+  var modeLabel = document.getElementById('ls-dev-mode-label');
+
+  function initialMode() {
+    try {
+      var saved = localStorage.getItem(MODE_STORAGE_KEY);
+      if (saved === 'dark' || saved === 'light') return saved;
+    } catch (e) {}
+    return (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+  }
+  var mode = initialMode();
+
+  function applyModeToHost() {
+    document.documentElement.classList.toggle('ls-dev-dark', mode === 'dark');
+    if (modeToggle) modeToggle.setAttribute('aria-pressed', mode === 'dark' ? 'true' : 'false');
+    if (modeLabel) modeLabel.textContent = mode === 'dark' ? 'Dark' : 'Light';
+  }
+
+  function postMetadata() {
+    post({ type: 'LANGSMITH_METADATA', metadata: { mode: mode } });
+  }
+
+  applyModeToHost();
+  if (modeToggle) {
+    modeToggle.addEventListener('click', function() {
+      mode = mode === 'dark' ? 'light' : 'dark';
+      try { localStorage.setItem(MODE_STORAGE_KEY, mode); } catch (e) {}
+      applyModeToHost();
+      postMetadata();
+    });
+  }
+
   window.addEventListener('message', function(event) {
     if (event.source !== iframe.contentWindow) return;
     var msg = event.data;
@@ -585,6 +663,7 @@ __QUEUE_BAR_HTML__<iframe id="ls-app" sandbox="allow-scripts" srcdoc="__SANDBOX_
 
     if (msg.type === 'LANGSMITH_READY') {
       post({ type: 'LANGSMITH_THEME', cssText: ':root {}' });
+      postMetadata();
       post({ type: 'LANGSMITH_DATA', payload: data });
     }
 
@@ -668,6 +747,7 @@ pre, code {
 (function() {
   var themeReady = false;
   var currentData = null;
+  var currentMetadata = null;
 
   var FILES = __FILES_JSON__;
 
@@ -718,15 +798,28 @@ pre, code {
     if (msg.type === 'LANGSMITH_THEME') {
       document.getElementById('ls-theme').textContent = msg.cssText;
       themeReady = true;
-      if (currentData !== null) renderApp();
+      maybeRender();
+    }
+    if (msg.type === 'LANGSMITH_METADATA') {
+      // Load-bearing: the host can't set html.dark on this no-same-origin
+      // sandbox, so we do it here from this message.
+      currentMetadata = msg.metadata;
+      document.documentElement.classList.toggle('dark', currentMetadata && currentMetadata.mode === 'dark');
+      maybeRender();
     }
     if (msg.type === 'LANGSMITH_DATA') {
       if (JSON.stringify(msg.payload) !== JSON.stringify(currentData)) {
         currentData = msg.payload;
-        if (themeReady) renderApp();
+        maybeRender();
       }
     }
   });
+
+  // First render needs theme, metadata, and data all present; after that,
+  // any of the three changing re-renders.
+  function maybeRender() {
+    if (themeReady && currentMetadata !== null && currentData !== null) renderApp();
+  }
 
   function renderApp() {
     var root = document.getElementById('root');
@@ -743,7 +836,7 @@ pre, code {
       return;
     }
     try {
-      window.__render(currentData, root);
+      window.__render(currentData, root, currentMetadata);
     } catch (err) {
       root.innerHTML =
         '<div style="background:#fef2f2;border:1px solid #fda29b;border-radius:8px;padding:12px;margin:16px;color:#b91c1c;font-size:13px;">' +

--- a/internal/cmd/apps_dev_test.go
+++ b/internal/cmd/apps_dev_test.go
@@ -132,7 +132,7 @@ func TestPrepareAppsDevServer_ServesRealSandboxedIframe(t *testing.T) {
 }
 
 // A regression test for a real bug: renderApp() used to unconditionally do
-// `root.innerHTML = ''` before calling window.__render(currentData, root).
+// `root.innerHTML = ”` before calling window.__render(currentData, root).
 // The entrypoint caches its React root across calls (`if (!root) root =
 // createRoot(rootEl)`) specifically so repeat renders (e.g. selecting a
 // different queue in local dev, which re-posts LANGSMITH_DATA) reconcile
@@ -187,6 +187,65 @@ func TestPrepareAppsDevServer_OmitsQueueSelectorForStandaloneApps(t *testing.T) 
 	body, _ := io.ReadAll(resp.Body)
 	if strings.Contains(string(body), `id="ls-dev-queue-select"`) {
 		t.Errorf("standalone apps should not get a queue selector bar:\n%s", body)
+	}
+}
+
+// The config toolbar (and its Light/Dark mode toggle) renders for EVERY app,
+// standalone included — unlike the queue selector, which stays contextual.
+func TestPrepareAppsDevServer_ServesModeToggleForStandaloneApps(t *testing.T) {
+	dir := t.TempDir()
+	seedDevApp(t, dir, "module.exports = { render: function(){} }")
+
+	srv, ln, previewURL, err := prepareAppsDevServer(dir, "dist/bundle.js", map[string]any{}, false)
+	if err != nil {
+		t.Fatalf("prepareAppsDevServer: %v", err)
+	}
+	go func() { _ = srv.Serve(ln) }()
+	defer func() { _ = srv.Close() }()
+
+	resp, err := http.Get(previewURL)
+	if err != nil {
+		t.Fatalf("GET %s: %v", previewURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	page := string(body)
+
+	if !strings.Contains(page, `id="ls-dev-mode-toggle"`) {
+		t.Errorf("standalone apps should still get the Light/Dark mode toggle:\n%s", page)
+	}
+	// The mode toggle must have a distinct id from the queue selector so a
+	// standalone app can have the toggle without the (contextual) queue picker.
+	if strings.Contains(page, `id="ls-dev-queue-select"`) {
+		t.Errorf("standalone apps should not get a queue selector:\n%s", page)
+	}
+	// On READY the host posts LANGSMITH_METADATA, and the toggle re-posts it.
+	if !strings.Contains(page, "LANGSMITH_METADATA") {
+		t.Errorf("expected the host page to post LANGSMITH_METADATA:\n%s", page)
+	}
+	// The served page embeds the sandbox srcdoc; the 3-arg render call has no
+	// characters html.EscapeString would touch, so it appears verbatim.
+	if !strings.Contains(page, "window.__render(currentData, root, currentMetadata)") {
+		t.Errorf("expected the sandbox srcdoc to call render with (data, root, metadata):\n%s", page)
+	}
+}
+
+// The sandbox side must implement the pinned theme/metadata contract: handle
+// LANGSMITH_METADATA, set html.dark from mode, and pass metadata as render's
+// 3rd arg. Asserting on the template constant avoids fighting the HTML-escaping
+// the srcdoc goes through when embedded in the host page.
+func TestSandboxImplementsThemeMetadataContract(t *testing.T) {
+	for _, want := range []string{
+		"LANGSMITH_METADATA",
+		"currentMetadata = msg.metadata",
+		"classList.toggle('dark', currentMetadata && currentMetadata.mode === 'dark')",
+		"window.__render(currentData, root, currentMetadata)",
+		// First render gates on all three of theme, metadata, and data.
+		"themeReady && currentMetadata !== null && currentData !== null",
+	} {
+		if !strings.Contains(sandboxInnerHTMLTemplate, want) {
+			t.Errorf("sandboxInnerHTMLTemplate missing %q", want)
+		}
 	}
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -119,14 +119,24 @@ func GetFormat() string {
 
 // MustGetClient creates a LangSmith client or exits with an error.
 func MustGetClient() *client.Client {
-	opts, err := resolveClientOptions(true)
+	c, err := getClient()
 	if err != nil {
 		ExitError(err.Error())
 	}
-	if opts.APIKey == "" && opts.OAuthAccessToken == "" {
-		ExitError("not authenticated; run 'langsmith auth login', set LANGSMITH_API_KEY, or pass --api-key")
+	return c
+}
+
+// getClient is the non-exiting sibling of MustGetClient: it returns an error
+// instead of calling os.Exit, so request handlers can't crash.
+func getClient() (*client.Client, error) {
+	opts, err := resolveClientOptions(true)
+	if err != nil {
+		return nil, err
 	}
-	return client.NewWithOptions(opts)
+	if opts.APIKey == "" && opts.OAuthAccessToken == "" {
+		return nil, fmt.Errorf("not authenticated; run 'langsmith auth login', set LANGSMITH_API_KEY, or pass --api-key")
+	}
+	return client.NewWithOptions(opts), nil
 }
 
 func resolveClientOptions(refreshOAuth bool) (client.Options, error) {

--- a/internal/cmd/templates/agents-md/annotation_queue.md
+++ b/internal/cmd/templates/agents-md/annotation_queue.md
@@ -1,10 +1,17 @@
 # AGENTS.md — LangSmith API surface for this app
 
-This is an **annotation_queue** custom app. `render(data, root)` receives
-`data = { queueId }` — that's the *only* context the host gives you. You
-fetch everything else (run list, run detail, feedback, ...) yourself via
+This is an **annotation_queue** custom app. `render(data, root, metadata)`
+receives `data = { queueId }` — that's the *only* context the host gives you.
+You fetch everything else (run list, run detail, feedback, ...) yourself via
 `window.langsmith.call`. `src/api.ts` already wraps every operation below —
 read it before adding new API calls, you likely don't need to.
+
+`render`'s third argument is `metadata`, an open/extensible object; v1 has
+exactly one key, `metadata.mode` (`"dark"` | `"light"`). The sandbox sets
+`html.dark` from `mode` before every render, so this Tailwind/token-based app
+gets dark mode for **free** — no branching needed. Only apps that use **inline
+styles** need to branch on `metadata.mode`. `mode` is re-sent (and `render`
+re-called) whenever it changes.
 
 ## Calling the API
 

--- a/internal/cmd/templates/agents-md/none.md
+++ b/internal/cmd/templates/agents-md/none.md
@@ -1,9 +1,19 @@
 # AGENTS.md — LangSmith API surface for this app
 
 This is a **standalone** custom app (`context_type: none`) — genuinely
-open-ended. `render(data, root)` receives `data = {}` (or whatever you push
-yourself via `window.langsmith.setData(patch)`); there's no bound context.
-What to show and what data to fetch is entirely up to you.
+open-ended. `render(data, root, metadata)` receives `data = {}` (or whatever
+you push yourself via `window.langsmith.setData(patch)`); there's no bound
+context. What to show and what data to fetch is entirely up to you.
+
+## Theme (`metadata`)
+
+`render`'s third argument is `metadata`, an open/extensible object; v1 has
+exactly one key, `metadata.mode` (`"dark"` | `"light"`). The sandbox sets
+`document.documentElement.classList` `dark` from `mode` before every render,
+so Tailwind/token-based apps (like this starter's `index.css`) get dark mode
+for **free** — no branching needed. Only apps that use **inline styles** need
+to branch on `metadata.mode` themselves. `mode` is re-sent (and `render`
+re-called) whenever it changes, so react to it on each render, not just once.
 
 ## Calling the API
 

--- a/internal/cmd/templates/annotation-queue/README.md
+++ b/internal/cmd/templates/annotation-queue/README.md
@@ -51,12 +51,15 @@ you'd rather drive the build yourself.
 
 ## The bridge contract
 
-`src/entry.tsx` exports a `render(data, root)` function — the sandbox calls
-it once when `data` (`{ queueId }`) arrives, and again if it changes:
+`src/entry.tsx` exports a `render(data, root, metadata)` function — the
+sandbox calls it once when `data` (`{ queueId }`) arrives, and again if `data`
+or `metadata` changes. `metadata.mode` is `"dark"` or `"light"`; the sandbox
+sets `html.dark` from it, so this Tailwind/token UI themes automatically
+(branch on `metadata.mode` only if you use inline styles):
 
 ```ts
 export default {
-  render(data: { queueId?: string }, root: HTMLElement) {
+  render(data: { queueId?: string }, root: HTMLElement, metadata: { mode: 'dark' | 'light' }) {
     // mount your app into root
   },
 };

--- a/internal/cmd/templates/annotation-queue/src/App.tsx
+++ b/internal/cmd/templates/annotation-queue/src/App.tsx
@@ -10,6 +10,9 @@ interface Props {
   /** The only context this app receives — everything else (run list, run
    * detail, feedback, ...) is fetched itself via window.langsmith.call. */
   queueId: string;
+  /** Host render metadata; `metadata.mode` is "dark"|"light". The sandbox sets
+   * html.dark from it, so this UI needs no branching. */
+  metadata?: RenderMetadata;
 }
 
 export function App({ queueId }: Props) {

--- a/internal/cmd/templates/annotation-queue/src/entry.tsx
+++ b/internal/cmd/templates/annotation-queue/src/entry.tsx
@@ -23,12 +23,14 @@ interface RenderData {
 }
 
 export default {
-  render(data: RenderData, rootEl: HTMLElement) {
+  render(data: RenderData, rootEl: HTMLElement, metadata: RenderMetadata) {
     ensureStyleInjected();
     if (!root) root = createRoot(rootEl);
+    // metadata.mode is "dark"|"light". The sandbox sets html.dark from it, so
+    // this Tailwind UI themes without branching; passed to App.
     root.render(
       <StrictMode>
-        <App queueId={data?.queueId ?? ''} />
+        <App queueId={data?.queueId ?? ''} metadata={metadata} />
       </StrictMode>
     );
   },

--- a/internal/cmd/templates/annotation-queue/src/global.d.ts
+++ b/internal/cmd/templates/annotation-queue/src/global.d.ts
@@ -1,6 +1,10 @@
 export {};
 
 declare global {
+  /** render()'s 3rd arg, an open/extensible dict. v1 has only `mode`
+   * ("dark"|"light"); the sandbox sets `html.dark` from it. */
+  type RenderMetadata = { mode: 'dark' | 'light' };
+
   interface Window {
     /** Injected by the host page (LangSmith, or `langsmith apps dev` locally) — see AGENTS.md. */
     langsmith: {

--- a/internal/cmd/templates/annotation-queue/vite.config.ts
+++ b/internal/cmd/templates/annotation-queue/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // Library-mode build: the sandbox this app runs in evaluates a single
-// dependency-free CJS file exporting { render(data, root) } — not a
+// dependency-free CJS file exporting { render(data, root, metadata) } — not a
 // self-mounting SPA. See src/entry.tsx and AGENTS.md.
 export default defineConfig({
   plugins: [react()],

--- a/internal/cmd/templates/blank/README.md
+++ b/internal/cmd/templates/blank/README.md
@@ -39,10 +39,12 @@ the build yourself.
 
 ## The bridge contract
 
-`src/entry.tsx` exports a `render(data, root)` function that the host calls
-once on load and again whenever `data` changes — for a standalone app,
-`data` is always `{}`. `src/App.tsx` is the actual UI; edit it freely, it's
-just a React component.
+`src/entry.tsx` exports a `render(data, root, metadata)` function that the
+host calls once on load and again whenever `data` or `metadata` changes — for
+a standalone app, `data` is always `{}`. `metadata.mode` is `"dark"` or
+`"light"`; the sandbox sets `html.dark` from it, so this token-based UI themes
+automatically (branch on `metadata.mode` only if you use inline styles).
+`src/App.tsx` is the actual UI; edit it freely, it's just a React component.
 
 `window.langsmith`, injected by the host page, gives you:
 

--- a/internal/cmd/templates/blank/src/App.tsx
+++ b/internal/cmd/templates/blank/src/App.tsx
@@ -1,8 +1,8 @@
 // A static starting point — no API calls, nothing to break. Edit this
 // file (or delete it) and build whatever you want; see AGENTS.md for the
-// full LangSmith API surface and README.md for the render(data, root)
+// full LangSmith API surface and README.md for the render(data, root, metadata)
 // bridge contract.
-export function App(_props: { data: unknown }) {
+export function App(_props: { data: unknown; metadata?: RenderMetadata }) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-surface-level-1 p-6">
       <div className="w-full max-w-md rounded-xl border border-secondary bg-elevated p-8 text-center shadow-md">

--- a/internal/cmd/templates/blank/src/entry.tsx
+++ b/internal/cmd/templates/blank/src/entry.tsx
@@ -14,12 +14,14 @@ function ensureStyles() {
   styleInjected = true;
 }
 
-export function render(data: unknown, container: HTMLElement) {
+export function render(data: unknown, container: HTMLElement, metadata: RenderMetadata) {
   ensureStyles();
   if (!root) {
     root = createRoot(container);
   }
-  root.render(createElement(App, { data }));
+  // metadata.mode is "dark"|"light". The sandbox sets html.dark from it, so
+  // this token UI themes without branching; passed to App.
+  root.render(createElement(App, { data, metadata }));
 }
 
 // Some sandbox hosts call a bare default export; support both shapes.

--- a/internal/cmd/templates/blank/src/global.d.ts
+++ b/internal/cmd/templates/blank/src/global.d.ts
@@ -1,6 +1,10 @@
 export {};
 
 declare global {
+  /** render()'s 3rd arg, an open/extensible dict. v1 has only `mode`
+   * ("dark"|"light"); the sandbox sets `html.dark` from it. */
+  type RenderMetadata = { mode: 'dark' | 'light' };
+
   interface Window {
     /** Injected by the host page (LangSmith, or `langsmith apps dev` locally) — see AGENTS.md. */
     langsmith: {

--- a/internal/cmd/templates/blank/vite.config.ts
+++ b/internal/cmd/templates/blank/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // Library-mode build: the sandbox this app runs in evaluates a single
-// dependency-free CJS file exporting { render(data, root) } — not a
+// dependency-free CJS file exporting { render(data, root, metadata) } — not a
 // self-mounting SPA. See src/entry.tsx and AGENTS.md.
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
Implements the pinned render(data, root, metadata) contract in the dev sandbox (host→iframe LANGSMITH_METADATA message; sandbox sets html.dark from mode since it can't be set from outside the allow-scripts iframe). 
Adds an always-on dev toolbar with a Light/Dark toggle (defaults from OS, persists to localStorage); the queue selector becomes one item in it. 
Templates now render in both modes via the toggle with no app-level branching. Docs + tests updated.

**unrelated bug fix**: apps dev's API proxy no longer hard-crashes the server on an unauthenticated call (returns 502 instead of os.Exit).

Note: LANGSMITH_METADATA wire shape must stay byte-compatible with smith-frontend sandbox.ts.