### PR TITLE
fix(thread): show root previews for blank message turns

### DIFF
--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -325,27 +325,40 @@ func attachRootIO(ctx context.Context, c *client.Client, sessionID string, start
 // trace_id, so we filter by ID (the SDK's RunQueryParams has no list field
 // for trace IDs — Trace is singular).
 func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, startTime time.Time, ids []string) map[string]rootPreview {
+	out, err := queryRootPreviews(ctx, c, sessionID, startTime, ids)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: fetching root previews failed: %v\n", err)
+		return map[string]rootPreview{}
+	}
+	return out
+}
+
+// queryRootPreviews is the strict form of fetchRootPreviews. Callers that need
+// previews to make their primary output complete can return the lookup error
+// instead of silently rendering partial data.
+func queryRootPreviews(ctx context.Context, c *client.Client, sessionID string, startTime time.Time, ids []string) (map[string]rootPreview, error) {
 	out := map[string]rootPreview{}
 	if len(ids) == 0 {
-		return out
+		return out, nil
 	}
 	params := langsmith.RunQueryParams{
-		Session:   langsmith.F([]string{sessionID}),
-		IsRoot:    langsmith.F(true),
-		ID:        langsmith.F(ids),
-		StartTime: langsmith.F(startTime),
-		Order:     langsmith.F(langsmith.RunQueryParamsOrderDesc),
-		Limit:     langsmith.F(int64(len(ids))),
+		Session: langsmith.F([]string{sessionID}),
+		IsRoot:  langsmith.F(true),
+		ID:      langsmith.F(ids),
+		Order:   langsmith.F(langsmith.RunQueryParamsOrderDesc),
+		Limit:   langsmith.F(int64(len(ids))),
 		Select: langsmith.F([]langsmith.RunQueryParamsSelect{
 			langsmith.RunQueryParamsSelectTraceID,
 			langsmith.RunQueryParamsSelectInputsPreview,
 			langsmith.RunQueryParamsSelectOutputsPreview,
 		}),
 	}
+	if !startTime.IsZero() {
+		params.StartTime = langsmith.F(startTime)
+	}
 	resp, err := c.SDK.Runs.Query(ctx, params)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: fetching root previews failed: %v\n", err)
-		return out
+		return nil, err
 	}
 	for _, run := range resp.Runs {
 		tid := run.TraceID
@@ -360,7 +373,7 @@ func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, 
 			outputs: truncateHard(run.OutputsPreview, 2000),
 		}
 	}
-	return out
+	return out, nil
 }
 
 func truncateHard(s string, n int) string {

--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -334,14 +334,36 @@ Examples:
 			path := fmt.Sprintf("/v2/threads/%s/messages?%s", url.PathEscape(threadID), q.Encode())
 
 			extraHeaders := http.Header{"Accept": {"text/event-stream"}}
-			_, _, _, body, err := c.RawDo(ctx, http.MethodGet, path, nil, extraHeaders)
+			statusCode, _, _, body, err := c.RawDo(ctx, http.MethodGet, path, nil, extraHeaders)
 			if err != nil {
 				ExitErrorf("%v", err)
+			}
+			if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+				ExitErrorf(
+					"thread messages request failed (HTTP %d): %s",
+					statusCode,
+					threadMessagesHTTPError(statusCode, body),
+				)
 			}
 
 			groups, nextCursor, prevCursor, sseErr := parseSSEGroups(body)
 			if sseErr != "" {
 				ExitErrorf("server error: %s", sseErr)
+			}
+
+			blankTraceIDs, minStartTime := blankThreadTurnPreviewRequest(groups)
+			if len(blankTraceIDs) > 0 {
+				previews, err := queryRootPreviews(
+					ctx,
+					c,
+					sessionID,
+					minStartTime,
+					blankTraceIDs,
+				)
+				if err != nil {
+					ExitErrorf("fetching blank-turn root previews: %v", err)
+				}
+				groups = fillBlankThreadTurns(groups, previews)
 			}
 
 			result := map[string]any{
@@ -430,15 +452,135 @@ func parseSSEGroups(body []byte) (groups []any, nextCursor, prevCursor, errMsg s
 				}
 			}
 		case "error":
-			var errPayload struct {
-				Error string `json:"error"`
-			}
-			if err := json.Unmarshal([]byte(ev.Data), &errPayload); err == nil {
-				errMsg = errPayload.Error
-			}
+			errMsg = threadMessagesSSEError(ev.Data)
 		}
 	}
 	return
+}
+
+func threadMessagesSSEError(data string) string {
+	var payload struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+		Detail  string `json:"detail"`
+		Title   string `json:"title"`
+	}
+	if err := json.Unmarshal([]byte(data), &payload); err != nil {
+		return "invalid error event from server"
+	}
+	for _, message := range []string{payload.Error, payload.Detail, payload.Message, payload.Title} {
+		if message = strings.TrimSpace(message); message != "" {
+			return truncateHard(message, 1000)
+		}
+	}
+	return "unspecified server error"
+}
+
+func threadMessagesHTTPError(statusCode int, body []byte) string {
+	message := threadMessagesSSEError(string(body))
+	if message == "invalid error event from server" || message == "unspecified server error" {
+		if statusText := http.StatusText(statusCode); statusText != "" {
+			return statusText
+		}
+	}
+	return message
+}
+
+// blankThreadTurnPreviewRequest returns the trace IDs for turn-boundary
+// segments with no message/tool groups and the earliest available start time.
+func blankThreadTurnPreviewRequest(groups []any) ([]string, time.Time) {
+	var (
+		traceIDs     []string
+		seen         = map[string]struct{}{}
+		currentTrace string
+		currentStart time.Time
+		hasMessages  bool
+		minStartTime time.Time
+	)
+
+	flush := func() {
+		if currentTrace == "" || hasMessages {
+			return
+		}
+		if _, ok := seen[currentTrace]; ok {
+			return
+		}
+		seen[currentTrace] = struct{}{}
+		traceIDs = append(traceIDs, currentTrace)
+		if !currentStart.IsZero() && (minStartTime.IsZero() || currentStart.Before(minStartTime)) {
+			minStartTime = currentStart
+		}
+	}
+
+	for _, rawGroup := range groups {
+		group, _ := rawGroup.(map[string]any)
+		switch group["type"] {
+		case "turn_boundary":
+			flush()
+			boundary, _ := group["turnBoundary"].(map[string]any)
+			currentTrace, _ = boundary["trace_id"].(string)
+			currentStart = time.Time{}
+			if rawStart, ok := boundary["start_time"].(string); ok {
+				currentStart, _ = time.Parse(time.RFC3339Nano, rawStart)
+			}
+			hasMessages = false
+		case "message", "tool_interaction":
+			if currentTrace != "" {
+				hasMessages = true
+			}
+		}
+	}
+	flush()
+	return traceIDs, minStartTime
+}
+
+// fillBlankThreadTurns inserts bounded root I/O previews only for turns where
+// the message stream emitted no normalized message groups.
+func fillBlankThreadTurns(groups []any, previews map[string]rootPreview) []any {
+	blankTraceIDs, _ := blankThreadTurnPreviewRequest(groups)
+	blank := make(map[string]struct{}, len(blankTraceIDs))
+	for _, traceID := range blankTraceIDs {
+		blank[traceID] = struct{}{}
+	}
+
+	result := make([]any, 0, len(groups)+2*len(blank))
+	for _, rawGroup := range groups {
+		result = append(result, rawGroup)
+		group, _ := rawGroup.(map[string]any)
+		if group["type"] != "turn_boundary" {
+			continue
+		}
+		boundary, _ := group["turnBoundary"].(map[string]any)
+		traceID, _ := boundary["trace_id"].(string)
+		if _, ok := blank[traceID]; !ok {
+			continue
+		}
+		preview, ok := previews[traceID]
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(preview.inputs) != "" {
+			result = append(result, rootPreviewMessageGroup(traceID, "human", preview.inputs))
+		}
+		if strings.TrimSpace(preview.outputs) != "" {
+			result = append(result, rootPreviewMessageGroup(traceID, "ai", preview.outputs))
+		}
+	}
+	return result
+}
+
+func rootPreviewMessageGroup(traceID, role, content string) map[string]any {
+	return map[string]any{
+		"type": "message",
+		"message": map[string]any{
+			"role":    role,
+			"content": content,
+		},
+		"metadata": map[string]any{
+			"trace_id": traceID,
+			"source":   "root_io_preview",
+		},
+	}
 }
 
 // printThreadMessages prints a human-readable view of thread messages grouped by turn.
@@ -465,7 +607,11 @@ func printThreadMessages(result map[string]any) {
 			fmt.Printf("\n--- Turn %d (trace: %s) ---\n", int(turnIndex)+1, traceID)
 		case "message":
 			msg, _ := group["message"].(map[string]any)
-			printMessage(msg)
+			if isRootPreviewGroup(group) {
+				printRootPreviewMessage(msg)
+			} else {
+				printMessage(msg)
+			}
 		case "tool_interaction":
 			aiMsg, _ := group["aiMessage"].(map[string]any)
 			printMessage(aiMsg)
@@ -488,4 +634,18 @@ func printThreadMessages(result map[string]any) {
 	if prev, ok := cursors["prev"].(string); ok && prev != "" {
 		fmt.Printf("Prev cursor: %s\n", prev)
 	}
+}
+
+func isRootPreviewGroup(group map[string]any) bool {
+	metadata, _ := group["metadata"].(map[string]any)
+	return metadata["source"] == "root_io_preview"
+}
+
+func printRootPreviewMessage(msg map[string]any) {
+	role, _ := msg["role"].(string)
+	text := coerceContent(msg["content"])
+	if len(text) > 200 {
+		text = text[:200] + "..."
+	}
+	fmt.Printf("  [%s, root preview] %s\n", role, text)
 }

--- a/internal/cmd/thread_test.go
+++ b/internal/cmd/thread_test.go
@@ -1,7 +1,12 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
 	"testing"
+	"time"
 )
 
 // ==================== Command structure ====================
@@ -158,5 +163,216 @@ func TestThreadGetCmd_ProjectFlagHelpMentionsEnv(t *testing.T) {
 	}
 	if f.Usage != "Project name [env: LANGSMITH_PROJECT]" {
 		t.Errorf("expected project flag usage to mention env var, got %q", f.Usage)
+	}
+}
+
+func TestBlankThreadTurnPreviewRequest(t *testing.T) {
+	groups := []any{
+		threadTestBoundary("trace-1", 0, "2026-07-20T12:00:00Z"),
+		threadTestBoundary("trace-2", 1, "2026-07-20T12:01:00Z"),
+		threadTestBoundary("trace-3", 2, "2026-07-20T12:02:00Z"),
+		map[string]any{
+			"type": "message",
+			"message": map[string]any{
+				"role":    "human",
+				"content": "streamed question",
+			},
+		},
+		threadTestBoundary("trace-4", 3, "2026-07-20T12:03:00Z"),
+		threadTestBoundary("trace-5", 4, "2026-07-20T12:04:00Z"),
+	}
+
+	traceIDs, minStartTime := blankThreadTurnPreviewRequest(groups)
+	if got, want := strings.Join(traceIDs, ","), "trace-1,trace-2,trace-4,trace-5"; got != want {
+		t.Fatalf("blank trace IDs = %q, want %q", got, want)
+	}
+	if got, want := minStartTime.Format(time.RFC3339), "2026-07-20T12:00:00Z"; got != want {
+		t.Fatalf("minimum start time = %q, want %q", got, want)
+	}
+}
+
+func TestFillBlankThreadTurnsAddsMarkedPreviewsOnlyToBlankTurns(t *testing.T) {
+	groups := []any{
+		threadTestBoundary("trace-1", 0, "2026-07-20T12:00:00Z"),
+		threadTestBoundary("trace-2", 1, "2026-07-20T12:01:00Z"),
+		map[string]any{
+			"type": "message",
+			"message": map[string]any{
+				"role":    "ai",
+				"content": "streamed answer",
+			},
+		},
+	}
+	previews := map[string]rootPreview{
+		"trace-1": {inputs: "preview question", outputs: "preview answer"},
+		"trace-2": {inputs: "must not be inserted", outputs: "must not be inserted"},
+	}
+
+	filled := fillBlankThreadTurns(groups, previews)
+	if got, want := len(filled), 5; got != want {
+		t.Fatalf("group count = %d, want %d", got, want)
+	}
+
+	human := filled[1].(map[string]any)
+	ai := filled[2].(map[string]any)
+	for _, group := range []map[string]any{human, ai} {
+		metadata, _ := group["metadata"].(map[string]any)
+		if metadata["source"] != "root_io_preview" || metadata["trace_id"] != "trace-1" {
+			t.Fatalf("fallback metadata = %v", metadata)
+		}
+	}
+	if role := human["message"].(map[string]any)["role"]; role != "human" {
+		t.Fatalf("input preview role = %v, want human", role)
+	}
+	if role := ai["message"].(map[string]any)["role"]; role != "ai" {
+		t.Fatalf("output preview role = %v, want ai", role)
+	}
+	for _, group := range filled {
+		if strings.Contains(fmt.Sprint(group), "must not be inserted") {
+			t.Fatal("populated turn received duplicate root previews")
+		}
+	}
+}
+
+func TestParseSSEGroupsSupportsLegacyAndProblemDetailErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{name: "legacy", data: `{"error":"turn could not be parsed"}`, want: "turn could not be parsed"},
+		{name: "problem details", data: `{"title":"Bad Request","status":400,"detail":"unsupported trace format"}`, want: "unsupported trace format"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body := []byte("event: error\ndata: " + test.data + "\n\n")
+			_, _, _, got := parseSSEGroups(body)
+			if got != test.want {
+				t.Fatalf("SSE error = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestThreadMessagesHTTPErrorDoesNotEchoUnknownBody(t *testing.T) {
+	if got := threadMessagesHTTPError(http.StatusUnauthorized, []byte("opaque upstream body")); got != "Unauthorized" {
+		t.Fatalf("HTTP error = %q, want Unauthorized", got)
+	}
+	if got := threadMessagesHTTPError(
+		http.StatusBadRequest,
+		[]byte(`{"detail":"invalid thread cursor"}`),
+	); got != "invalid thread cursor" {
+		t.Fatalf("problem detail = %q, want invalid thread cursor", got)
+	}
+}
+
+func TestThreadMessagesCmdFillsBlankTurnsFromScopedRootPreviews(t *testing.T) {
+	var previewQuery map[string]any
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/sessions" && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"id": "session-123", "name": "test-project"},
+			})
+		case r.URL.Path == "/v2/threads/thread-123/messages" && r.Method == http.MethodGet:
+			if got := r.URL.Query().Get("project_id"); got != "session-123" {
+				t.Errorf("project_id = %q, want session-123", got)
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = fmt.Fprint(w,
+				"event: data\ndata: {\"type\":\"turn_boundary\",\"turnBoundary\":{\"trace_id\":\"trace-blank\",\"turn_index\":0,\"start_time\":\"2026-07-20T12:00:00Z\"}}\n\n"+
+					"event: data\ndata: {\"type\":\"turn_boundary\",\"turnBoundary\":{\"trace_id\":\"trace-populated\",\"turn_index\":1,\"start_time\":\"2026-07-20T12:01:00Z\"}}\n\n"+
+					"event: data\ndata: {\"type\":\"message\",\"message\":{\"role\":\"ai\",\"content\":\"streamed answer\"}}\n\n"+
+					"event: metadata\ndata: {\"next_cursor\":null,\"prev_cursor\":null}\n\n",
+			)
+		case r.URL.Path == "/api/v1/runs/query" && r.Method == http.MethodPost:
+			if err := json.NewDecoder(r.Body).Decode(&previewQuery); err != nil {
+				t.Fatalf("decode preview query: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"runs": []map[string]any{
+					{
+						"id":              "trace-blank",
+						"trace_id":        "trace-blank",
+						"name":            "root",
+						"run_type":        "chain",
+						"start_time":      "2026-07-20T12:00:00Z",
+						"inputs_preview":  "preview question",
+						"outputs_preview": "preview answer",
+					},
+				},
+				"cursors": map[string]any{},
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	})
+	cleanup := setupTestEnv(t, ts.URL)
+	defer cleanup()
+	flagOutputFormat = "json"
+
+	out := captureStdout(t, func() {
+		cmd := newThreadMessagesCmd()
+		cmd.SetArgs([]string{"thread-123", "--project", "test-project"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("thread messages: %v", err)
+		}
+	})
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, out)
+	}
+	groups, _ := result["groups"].([]any)
+	if got, want := len(groups), 5; got != want {
+		t.Fatalf("group count = %d, want %d: %s", got, want, out)
+	}
+	if got := groups[1].(map[string]any)["message"].(map[string]any)["content"]; got != "preview question" {
+		t.Fatalf("fallback input = %v", got)
+	}
+	if got := groups[2].(map[string]any)["message"].(map[string]any)["content"]; got != "preview answer" {
+		t.Fatalf("fallback output = %v", got)
+	}
+	if got := groups[4].(map[string]any)["message"].(map[string]any)["content"]; got != "streamed answer" {
+		t.Fatalf("streamed content changed: %v", got)
+	}
+
+	if got := fmt.Sprint(previewQuery["session"]); got != "[session-123]" {
+		t.Fatalf("preview session scope = %v", previewQuery["session"])
+	}
+	if got := fmt.Sprint(previewQuery["id"]); got != "[trace-blank]" {
+		t.Fatalf("preview IDs = %v", previewQuery["id"])
+	}
+	if got := previewQuery["is_root"]; got != true {
+		t.Fatalf("preview is_root = %v, want true", got)
+	}
+}
+
+func TestPrintThreadMessagesLabelsRootPreviews(t *testing.T) {
+	result := map[string]any{
+		"thread_id": "thread-123",
+		"groups": []any{
+			threadTestBoundary("trace-1", 0, "2026-07-20T12:00:00Z"),
+			rootPreviewMessageGroup("trace-1", "human", "preview question"),
+		},
+		"cursors": map[string]any{},
+	}
+	out := captureStdout(t, func() { printThreadMessages(result) })
+	if !strings.Contains(out, "[human, root preview] preview question") {
+		t.Fatalf("pretty output did not label fallback content:\n%s", out)
+	}
+}
+
+func threadTestBoundary(traceID string, turnIndex int, startTime string) map[string]any {
+	return map[string]any{
+		"type": "turn_boundary",
+		"turnBoundary": map[string]any{
+			"trace_id":   traceID,
+			"turn_index": float64(turnIndex),
+			"start_time": startTime,
+		},
 	}
 }


### PR DESCRIPTION
Fixes #185.

## Summary

- Fill boundary-only thread turns from the root run input/output previews when the messages stream cannot normalize that trace format.
- Scope the fallback query to the resolved project, root runs, and only missing trace IDs; preserve streamed groups unchanged.
- Mark fallback groups as `root_io_preview`, label them in pretty output, and fail closed on HTTP, SSE, or required preview lookup errors.

## Test Plan

- [x] Added an HTTP regression test covering mixed blank and populated turns plus exact project/root/trace query scoping.
- [x] Added unit coverage for fallback placement, duplicate prevention, preview labeling, and legacy/RFC 7807 stream errors.