### PR TITLE
fix(custom apps): coding agent dashboard template field

### DIFF
--- a/internal/cmd/templates/coding-agent-dashboard/src/App.tsx
+++ b/internal/cmd/templates/coding-agent-dashboard/src/App.tsx
@@ -4,9 +4,9 @@ import { OverviewPanel } from './components/OverviewPanel';
 import { RunsTable } from './components/RunsTable';
 import { Section } from './components/primitives';
 import { Spinner } from './components/Spinner';
-import { fetchProjectStats, fetchRecentRuns } from './api';
+import { fetchCodingShare, fetchProjectStats, fetchRecentRuns } from './api';
 import { cn } from './lib/utils';
-import type { ProjectStats, Run, StatsScope } from './types';
+import type { CodingShare, ProjectStats, Run, StatsScope } from './types';
 
 const EMPTY_STATS: ProjectStats = { turns: null, threads: null, failedScopes: [] };
 
@@ -34,9 +34,12 @@ export function App(_props: { data: unknown; metadata?: RenderMetadata }) {
   const [runsLoading, setRunsLoading] = useState(false);
   const [runsFailed, setRunsFailed] = useState(false);
 
+  const [codingShare, setCodingShare] = useState<CodingShare | null>(null);
+
   useEffect(() => {
     setStats(EMPTY_STATS);
     setRuns([]);
+    setCodingShare(null);
     setCrashed(false);
     setRunsFailed(false);
     if (!projectId) return;
@@ -58,6 +61,12 @@ export function App(_props: { data: unknown; metadata?: RenderMetadata }) {
         setRunsFailed(true);
       })
       .finally(() => setRunsLoading(false));
+
+    // The coding-share tile has its own query (unfiltered recent runs). A
+    // failure here just leaves the tile at "—" — no separate error surface.
+    fetchCodingShare(projectId, windowDays)
+      .then(setCodingShare)
+      .catch((e) => console.error('Failed to load coding share', e));
   }, [projectId, windowDays]);
 
   const hasAnyStats = stats.turns != null || stats.threads != null;
@@ -109,7 +118,7 @@ export function App(_props: { data: unknown; metadata?: RenderMetadata }) {
           </p>
         )}
 
-        <OverviewPanel stats={stats} />
+        <OverviewPanel stats={stats} codingShare={codingShare} />
 
         <Section
           title="Recent runs"

--- a/internal/cmd/templates/coding-agent-dashboard/src/api.ts
+++ b/internal/cmd/templates/coding-agent-dashboard/src/api.ts
@@ -1,6 +1,6 @@
 // All LangSmith access goes through window.langsmith.call — the sandbox has
 // no network of its own. See AGENTS.md for the operation format and endpoints.
-import type { Project, ProjectStats, RunGroupStats, RunsQueryResponse, RunStats, StatsScope } from './types';
+import type { CodingShare, Project, ProjectStats, RunGroupStats, RunsQueryResponse, RunStats, StatsScope } from './types';
 
 // Metadata equality is two paired clauses in the filter DSL, not
 // eq(metadata.key, ...).
@@ -66,7 +66,6 @@ const STATS_SELECT = [
   'error_rate',
   'latency_p50',
   'latency_p99',
-  'latency_avg',
   'total_tokens',
   'prompt_tokens',
   'completion_tokens',
@@ -131,4 +130,26 @@ export async function fetchRecentRuns(sessionId: string, windowDays: number) {
     },
   });
   return resp?.runs ?? [];
+}
+
+// What fraction of the most recent root runs in this window are coding-agent
+// traces. Unlike every other query here it is deliberately *unfiltered* — the
+// non-coding runs are the denominator — and we count coding ones client-side
+// off each run's extra.metadata. Bounded to the same 100-row recency sample as
+// the runs table, so the result is "share of the last N (≤100)", not a
+// whole-window rate.
+export async function fetchCodingShare(sessionId: string, windowDays: number): Promise<CodingShare> {
+  await sleep(INTER_QUERY_GAP_MS);
+  const resp = await callWithRetry<RunsQueryResponse>('POST /api/v1/runs/query', {
+    body: {
+      session: [sessionId],
+      start_time: windowStart(windowDays),
+      is_root: true,
+      limit: RECENT_RUNS_LIMIT,
+      select: ['id', 'extra'],
+    },
+  });
+  const runs = resp?.runs ?? [];
+  const coding = runs.filter((r) => r.extra?.metadata?.ls_agent_purpose === 'coding').length;
+  return { coding, total: runs.length };
 }

--- a/internal/cmd/templates/coding-agent-dashboard/src/components/OverviewPanel.tsx
+++ b/internal/cmd/templates/coding-agent-dashboard/src/components/OverviewPanel.tsx
@@ -1,4 +1,4 @@
-import type { ProjectStats } from '../types';
+import type { CodingShare, ProjectStats } from '../types';
 import { formatCost, formatDuration, formatInt, formatPct, formatTokens } from '../lib/format';
 import { StatTile, type StatTone } from './primitives';
 
@@ -15,9 +15,14 @@ function errorTone(rate: number | null | undefined): StatTone | undefined {
 // whole-window aggregates, not derived from the sampled recent-runs table
 // below. A tile shows "—" only when its field is genuinely absent from the
 // response, never a silently-wrong zero.
-export function OverviewPanel({ stats }: { stats: ProjectStats }) {
+export function OverviewPanel({ stats, codingShare }: { stats: ProjectStats; codingShare: CodingShare | null }) {
   const t = stats.turns;
   const th = stats.threads;
+
+  // "50%" over the last N root runs, with "10 of last 20" spelling out the
+  // sample. Null (query failed / no runs yet) shows "—", never a fake 0%.
+  const hasShare = codingShare != null && codingShare.total > 0;
+  const sharePct = hasShare ? (codingShare!.coding / codingShare!.total) * 100 : null;
 
   const tokenHint =
     t?.prompt_tokens != null && t?.completion_tokens != null
@@ -39,7 +44,11 @@ export function OverviewPanel({ stats }: { stats: ProjectStats }) {
         value={t?.error_rate != null ? formatPct(t.error_rate) : DASH}
         tone={errorTone(t?.error_rate)}
       />
-      <StatTile label="Avg latency" value={t?.latency_avg != null ? formatDuration(t.latency_avg) : DASH} />
+      <StatTile
+        label="Coding share"
+        value={sharePct != null ? formatPct(sharePct) : DASH}
+        hint={hasShare ? `${formatInt(codingShare!.coding)} of last ${formatInt(codingShare!.total)}` : undefined}
+      />
       <StatTile label="p50 latency" value={t?.latency_p50 != null ? formatDuration(t.latency_p50) : DASH} />
       <StatTile label="p99 latency" value={t?.latency_p99 != null ? formatDuration(t.latency_p99) : DASH} />
     </div>

--- a/internal/cmd/templates/coding-agent-dashboard/src/types.ts
+++ b/internal/cmd/templates/coding-agent-dashboard/src/types.ts
@@ -30,7 +30,6 @@ export interface RunStats {
   error_rate?: number | null;
   latency_p50?: number | null;
   latency_p99?: number | null;
-  latency_avg?: number | null;
   total_tokens?: number | null;
   prompt_tokens?: number | null;
   completion_tokens?: number | null;
@@ -43,6 +42,15 @@ export interface RunStats {
 // returned by POST /api/v1/runs/group/stats with group_by="conversation".
 export interface RunGroupStats extends RunStats {
   group_count?: number | null;
+}
+
+// Share of the most recent root runs (up to 100) that are coding-agent
+// traces — metadata ls_agent_purpose="coding". Computed client-side over an
+// unfiltered recent-runs sample, so it's "share of the last N", not a
+// whole-window rate. See fetchCodingShare.
+export interface CodingShare {
+  coding: number;
+  total: number;
 }
 
 export type StatsScope = 'turns' | 'threads';


### PR DESCRIPTION
Avg latency was never calculated, always undefined. POST /api/v1/runs/stats never returns that key.
Replaced the "Avg latency" tile with a Coding share tile showing the % of recent traces that are coding-agent traces.