### PR TITLE
feat: warn and ignore env vars that conflict with an explicit --profile

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -161,6 +161,16 @@ func resolveClientOptions(refreshOAuth bool) (client.Options, error) {
 		}
 	}
 
+	// An explicit --profile selection wins: conflicting env vars are ignored with a warning.
+	explicitProfile := flagProfile != "" && hasProfile
+	warnEnvIgnored := func(name string) {
+		fmt.Fprintf(os.Stderr, "warning: ignoring %s because profile %q was selected with --profile\n", name, profileName)
+	}
+
+	if explicitProfile && envProfile != "" && envProfile != flagProfile {
+		warnEnvIgnored("LANGSMITH_PROFILE")
+	}
+
 	if hasProfile {
 		if profile.APIURL != "" {
 			opts.APIURL = profile.APIURL
@@ -169,29 +179,45 @@ func resolveClientOptions(refreshOAuth bool) (client.Options, error) {
 	}
 
 	if v := os.Getenv("LANGSMITH_ENDPOINT"); v != "" {
-		opts.APIURL = client.NormalizeURL(v)
+		if explicitProfile && profile.APIURL != "" {
+			warnEnvIgnored("LANGSMITH_ENDPOINT")
+		} else {
+			opts.APIURL = client.NormalizeURL(v)
+		}
 	}
 	if flagAPIURL != "" {
 		opts.APIURL = client.NormalizeURL(flagAPIURL)
 	}
 
 	if v := os.Getenv("LANGSMITH_TENANT_ID"); v != "" {
-		opts.WorkspaceID = v
+		if explicitProfile && profile.WorkspaceID != "" {
+			warnEnvIgnored("LANGSMITH_TENANT_ID")
+		} else {
+			opts.WorkspaceID = v
+		}
 	}
 	if v := os.Getenv("LANGSMITH_WORKSPACE_ID"); v != "" {
-		opts.WorkspaceID = v
+		if explicitProfile && profile.WorkspaceID != "" {
+			warnEnvIgnored("LANGSMITH_WORKSPACE_ID")
+		} else {
+			opts.WorkspaceID = v
+		}
 	}
 	if flagWorkspaceID != "" {
 		opts.WorkspaceID = flagWorkspaceID
 	}
+
+	profileHasAuth := profile.AccessToken() != "" || profile.OAuth.RefreshToken != "" || profile.APIKey != ""
+	envAPIKey := os.Getenv("LANGSMITH_API_KEY")
+	if envAPIKey != "" && explicitProfile && profileHasAuth {
+		warnEnvIgnored("LANGSMITH_API_KEY")
+		envAPIKey = ""
+	}
 	switch {
 	case flagAPIKey != "":
 		opts.APIKey = flagAPIKey
-	case os.Getenv("LANGSMITH_API_KEY") != "":
-		if flagProfile != "" {
-			fmt.Fprintln(os.Stderr, "warning: --profile was specified, but LANGSMITH_API_KEY is set and takes precedence over saved profile auth")
-		}
-		opts.APIKey = os.Getenv("LANGSMITH_API_KEY")
+	case envAPIKey != "":
+		opts.APIKey = envAPIKey
 	case hasProfile && (profile.AccessToken() != "" || (refreshOAuth && profile.OAuth.RefreshToken != "")):
 		if refreshOAuth && profile.OAuth.RefreshToken != "" &&
 			(profile.AccessToken() == "" || profile.TokenExpiresSoon(time.Now(), time.Minute)) {

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -50,16 +50,6 @@ func getFlagString(cmd *cobra.Command, name string) string {
 	return ""
 }
 
-func isFlagChanged(cmd *cobra.Command, name string) bool {
-	if f := cmd.Flags().Lookup(name); f != nil {
-		return f.Changed
-	}
-	if f := cmd.PersistentFlags().Lookup(name); f != nil {
-		return f.Changed
-	}
-	return false
-}
-
 // ResolveAPIKey reads the API key from cobra's flag tree → env.
 func ResolveAPIKey(cmd *cobra.Command) string {
 	if v := getFlagString(cmd, "api-key"); v != "" {
@@ -132,6 +122,16 @@ func ResolveClientOptions(cmd *cobra.Command, refreshOAuth bool) (client.Options
 		}
 	}
 
+	// An explicit --profile selection wins: conflicting env vars are ignored with a warning.
+	explicitProfile := flagProfile != "" && hasProfile
+	warnEnvIgnored := func(name string) {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: ignoring %s because profile %q was selected with --profile\n", name, profileName)
+	}
+
+	if explicitProfile && envProfile != "" && envProfile != flagProfile {
+		warnEnvIgnored("LANGSMITH_PROFILE")
+	}
+
 	if hasProfile {
 		if profile.APIURL != "" {
 			opts.APIURL = profile.APIURL
@@ -140,17 +140,29 @@ func ResolveClientOptions(cmd *cobra.Command, refreshOAuth bool) (client.Options
 	}
 
 	if v := os.Getenv("LANGSMITH_ENDPOINT"); v != "" {
-		opts.APIURL = client.NormalizeURL(v)
+		if explicitProfile && profile.APIURL != "" {
+			warnEnvIgnored("LANGSMITH_ENDPOINT")
+		} else {
+			opts.APIURL = client.NormalizeURL(v)
+		}
 	}
 	if v := getFlagString(cmd, "api-url"); v != "" {
 		opts.APIURL = client.NormalizeURL(v)
 	}
 
 	if v := os.Getenv("LANGSMITH_TENANT_ID"); v != "" {
-		opts.WorkspaceID = v
+		if explicitProfile && profile.WorkspaceID != "" {
+			warnEnvIgnored("LANGSMITH_TENANT_ID")
+		} else {
+			opts.WorkspaceID = v
+		}
 	}
 	if v := os.Getenv("LANGSMITH_WORKSPACE_ID"); v != "" {
-		opts.WorkspaceID = v
+		if explicitProfile && profile.WorkspaceID != "" {
+			warnEnvIgnored("LANGSMITH_WORKSPACE_ID")
+		} else {
+			opts.WorkspaceID = v
+		}
 	}
 	if v := getFlagString(cmd, "workspace"); v != "" {
 		opts.WorkspaceID = v
@@ -158,14 +170,17 @@ func ResolveClientOptions(cmd *cobra.Command, refreshOAuth bool) (client.Options
 		opts.WorkspaceID = v
 	}
 
+	profileHasAuth := profile.AccessToken() != "" || profile.OAuth.RefreshToken != "" || profile.APIKey != ""
+	envAPIKey := os.Getenv("LANGSMITH_API_KEY")
+	if envAPIKey != "" && explicitProfile && profileHasAuth {
+		warnEnvIgnored("LANGSMITH_API_KEY")
+		envAPIKey = ""
+	}
 	switch {
 	case getFlagString(cmd, "api-key") != "":
 		opts.APIKey = getFlagString(cmd, "api-key")
-	case os.Getenv("LANGSMITH_API_KEY") != "":
-		if isFlagChanged(cmd, "profile") {
-			fmt.Fprintln(cmd.ErrOrStderr(), "warning: --profile was specified, but LANGSMITH_API_KEY is set and takes precedence over saved profile auth")
-		}
-		opts.APIKey = os.Getenv("LANGSMITH_API_KEY")
+	case envAPIKey != "":
+		opts.APIKey = envAPIKey
 	case hasProfile && (profile.AccessToken() != "" || (refreshOAuth && profile.OAuth.RefreshToken != "")):
 		if refreshOAuth && profile.OAuth.RefreshToken != "" &&
 			(profile.AccessToken() == "" || profile.TokenExpiresSoon(time.Now(), time.Minute)) {

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -336,7 +336,7 @@ func TestResolveClientOptions_EnvAPIKeyOverridesProfileBearer(t *testing.T) {
 	}
 }
 
-func TestResolveClientOptions_ProfileFlagWarnsWhenEnvAPIKeyOverrides(t *testing.T) {
+func TestResolveClientOptions_ProfileFlagIgnoresEnvAPIKey(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("LANGSMITH_CONFIG_FILE", path)
 	t.Setenv("LANGSMITH_API_KEY", "from-env")
@@ -360,9 +360,67 @@ func TestResolveClientOptions_ProfileFlagWarnsWhenEnvAPIKeyOverrides(t *testing.
 
 	opts, err := ResolveClientOptions(cmd, false)
 	require.NoError(t, err)
-	require.Equal(t, "from-env", opts.APIKey)
-	require.Empty(t, opts.OAuthAccessToken)
-	require.Contains(t, stderr.String(), "warning: --profile was specified, but LANGSMITH_API_KEY is set")
+	require.Empty(t, opts.APIKey)
+	require.Equal(t, "test-access-token", opts.OAuthAccessToken)
+	require.Contains(t, stderr.String(), "warning: ignoring LANGSMITH_API_KEY")
+}
+
+func TestResolveClientOptions_ProfileFlagIgnoresConflictingEnvEndpointAndWorkspace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "http://env.example.com")
+	t.Setenv("LANGSMITH_WORKSPACE_ID", "ws-env")
+	err := os.WriteFile(path, []byte(`{
+  "profiles": {
+    "prod": {
+      "api_key": "prod-key",
+      "api_url": "http://prod.example.com",
+      "workspace_id": "ws-prod"
+    }
+  }
+}
+`), 0600)
+	require.NoError(t, err)
+
+	cmd := newTestCmd()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	require.NoError(t, cmd.PersistentFlags().Set("profile", "prod"))
+
+	opts, err := ResolveClientOptions(cmd, false)
+	require.NoError(t, err)
+	require.Equal(t, "http://prod.example.com", opts.APIURL)
+	require.Equal(t, "ws-prod", opts.WorkspaceID)
+	require.Contains(t, stderr.String(), "warning: ignoring LANGSMITH_ENDPOINT")
+	require.Contains(t, stderr.String(), "warning: ignoring LANGSMITH_WORKSPACE_ID")
+}
+
+func TestResolveClientOptions_ImplicitProfileDoesNotIgnoreEnv(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "http://env.example.com")
+	err := os.WriteFile(path, []byte(`{
+  "current_profile": "prod",
+  "profiles": {
+    "prod": {
+      "api_key": "prod-key",
+      "api_url": "http://prod.example.com"
+    }
+  }
+}
+`), 0600)
+	require.NoError(t, err)
+
+	cmd := newTestCmd()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	opts, err := ResolveClientOptions(cmd, false)
+	require.NoError(t, err)
+	require.Equal(t, "http://env.example.com", opts.APIURL)
+	require.Empty(t, stderr.String())
 }
 
 func TestResolveClientOptionsRefreshesProfileWithoutAccessToken(t *testing.T) {


### PR DESCRIPTION
## What

When `--profile` is passed **explicitly on the command line** and the profile exists, env vars that conflict with values the profile provides are now ignored (the profile wins), with a warning logged to stderr. Previously these env vars silently overrode the explicitly-selected profile.

Applies to both auth resolvers: `resolveClientOptions` in `internal/cmd/root.go` (main CLI) and `ResolveClientOptions` in `internal/cmdutil/resolve.go` (`langsmith api` / sandbox helpers).

| Env var | Ignored when explicit profile also sets… |
|---|---|
| `LANGSMITH_API_KEY` | auth (OAuth token or api_key) |
| `LANGSMITH_ENDPOINT` | `api_url` |
| `LANGSMITH_TENANT_ID` / `LANGSMITH_WORKSPACE_ID` | `workspace_id` |
| `LANGSMITH_PROFILE` | names a different profile than `--profile` |

Warning format: `warning: ignoring LANGSMITH_API_KEY because profile "prod" was selected with --profile`

## Boundaries

- **Command-line flags still win** — `--api-url`, `--workspace`, `--api-key` override the profile as before. This change is scoped to env vars only.
- **Implicit profiles are unaffected** — a profile resolved from `current_profile` or `LANGSMITH_PROFILE` is not "selected on the command line," so env vars still override those (preserves prior behavior).
- "Conflict" means the profile actually sets that field; an env var filling in a field the profile omits is still honored.

The prior `LANGSMITH_API_KEY` warning (which said env took precedence) is reversed accordingly.

## Test Plan

- [x] Updated `TestResolveClientOptions_ProfileFlagIgnoresEnvAPIKey` for the reversed precedence
- [x] Added `TestResolveClientOptions_ProfileFlagIgnoresConflictingEnvEndpointAndWorkspace`
- [x] Added `TestResolveClientOptions_ImplicitProfileDoesNotIgnoreEnv`
- [x] `go build ./...` and `go test ./internal/...` pass

Made by [Open SWE](https://dev.open-swe.langchain.dev/agents/1700cb42-7cf9-4965-a735-8c500c7308bb) · openai:gpt-5.6-sol (high)
