### PR TITLE
feat(trace,thread): add --version v2 (SmithDB) flag

### DIFF
--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -104,6 +105,26 @@ func queryRunsV2(ctx context.Context, c *client.Client, params langsmith.RunQuer
 	}
 
 	return allRuns, nil
+}
+
+// queryTraceRunsV2 fetches every run in a single trace (by trace_id) via the v2
+// (SmithDB) endpoint. Results are sorted by start time ascending to mirror the
+// v1 child fetch (which passes Order: Asc); v2 has no server-side order param.
+// startTime bounds the lower edge of the query window — v2 requires a
+// min_start_time (it defaults to 1 day ago otherwise).
+func queryTraceRunsV2(ctx context.Context, c *client.Client, traceID, sessionID string, startTime time.Time, includeIO, includeFeedback bool) ([]langsmith.RunSchema, error) {
+	body := langsmith.RunQueryV2Params{
+		TraceID:      langsmith.F(traceID),
+		MinStartTime: langsmith.F(startTime),
+		PageSize:     langsmith.F(int64(1000)),
+		Selects:      langsmith.F(buildRunSelectV2(includeIO, includeFeedback)),
+	}
+	runs, err := queryRunsV2(ctx, c, body, sessionID, 1000, 0)
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(runs, func(i, j int) bool { return runs[i].StartTime.Before(runs[j].StartTime) })
+	return runs, nil
 }
 
 // buildRunQueryV2Params translates FilterFlags into a v2 query body. The

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -192,7 +192,7 @@ Examples:
 					traces = []any{}
 				}
 
-				attachRootIO(ctx, c, sessionID, startTime, traces)
+				attachRootIO(ctx, c, sessionID, startTime, traces, ff.Version)
 				for _, t := range traces {
 					trace, _ := t.(map[string]any)
 					traj := buildTraceTrajectory(trace)
@@ -252,7 +252,7 @@ Examples:
 				allTraces = allTraces[:ff.Limit]
 			}
 
-			attachRootIO(ctx, c, sessionID, startTime, allTraces)
+			attachRootIO(ctx, c, sessionID, startTime, allTraces, ff.Version)
 
 			for _, t := range allTraces {
 				trace, _ := t.(map[string]any)
@@ -275,6 +275,7 @@ Examples:
 	}
 
 	addCommonFilterFlags(cmd, &ff, true)
+	addVersionFlag(cmd, &ff)
 	cmd.Flags().StringVar(&ff.ProjectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 	cmd.MarkFlagsMutuallyExclusive("project", "project-id")
@@ -292,7 +293,7 @@ type rootPreview struct {
 // root_outputs_preview fields. Failures are logged to stderr — the traces
 // are returned without enrichment rather than erroring out, so callers never
 // lose the main payload to a preview-lookup hiccup.
-func attachRootIO(ctx context.Context, c *client.Client, sessionID string, startTime time.Time, traces []any) {
+func attachRootIO(ctx context.Context, c *client.Client, sessionID string, startTime time.Time, traces []any, version string) {
 	if len(traces) == 0 {
 		return
 	}
@@ -303,7 +304,7 @@ func attachRootIO(ctx context.Context, c *client.Client, sessionID string, start
 			ids = append(ids, tid)
 		}
 	}
-	previews := fetchRootPreviews(ctx, c, sessionID, startTime, ids)
+	previews := fetchRootPreviews(ctx, c, sessionID, startTime, ids, version)
 	for _, t := range traces {
 		trace, _ := t.(map[string]any)
 		if trace == nil {
@@ -324,9 +325,41 @@ func attachRootIO(ctx context.Context, c *client.Client, sessionID string, start
 // map trace_id → (inputs_preview, outputs_preview). For root runs, id ==
 // trace_id, so we filter by ID (the SDK's RunQueryParams has no list field
 // for trace IDs — Trace is singular).
-func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, startTime time.Time, ids []string) map[string]rootPreview {
+func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, startTime time.Time, ids []string, version string) map[string]rootPreview {
 	out := map[string]rootPreview{}
 	if len(ids) == 0 {
+		return out
+	}
+	if version == "v2" {
+		body := langsmith.RunQueryV2Params{
+			IsRoot:       langsmith.F(true),
+			IDs:          langsmith.F(ids),
+			MinStartTime: langsmith.F(startTime),
+			PageSize:     langsmith.F(int64(len(ids))),
+			Selects: langsmith.F([]langsmith.RunQueryV2ParamsSelect{
+				langsmith.RunQueryV2ParamsSelectTraceID,
+				langsmith.RunQueryV2ParamsSelectInputsPreview,
+				langsmith.RunQueryV2ParamsSelectOutputsPreview,
+			}),
+		}
+		runs, err := queryRunsV2(ctx, c, body, sessionID, len(ids), 0)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: fetching root previews failed: %v\n", err)
+			return out
+		}
+		for _, run := range runs {
+			tid := run.TraceID
+			if tid == "" {
+				tid = run.ID
+			}
+			if tid == "" {
+				continue
+			}
+			out[tid] = rootPreview{
+				inputs:  truncateHard(run.InputsPreview, 2000),
+				outputs: truncateHard(run.OutputsPreview, 2000),
+			}
+		}
 		return out
 	}
 	params := langsmith.RunQueryParams{

--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -48,6 +48,7 @@ func newThreadListCmd() *cobra.Command {
 		limit        int
 		rawFilter    string
 		lastNMinutes int
+		version      string
 		outputFile   string
 	)
 
@@ -69,46 +70,69 @@ func newThreadListCmd() *cobra.Command {
 				ExitErrorf("%v", err)
 			}
 
-			// Query root runs (like the Python SDK does)
-			params := langsmith.RunQueryParams{
-				Session: langsmith.F([]string{sessionID}),
-				IsRoot:  langsmith.F(true),
-				Limit:   langsmith.F(int64(100)),
-			}
-
-			if rawFilter != "" {
-				params.Filter = langsmith.F(rawFilter)
-			}
-
 			// Default to last 24h if no time filter
 			startTime := time.Now().UTC().Add(-24 * time.Hour)
 			if lastNMinutes > 0 {
 				startTime = time.Now().UTC().Add(-time.Duration(lastNMinutes) * time.Minute)
 			}
-			params.StartTime = langsmith.F(startTime)
 
-			// Paginate all runs and group by thread_id
+			// Paginate all root runs and group by thread_id
 			threadsMap := make(map[string][]map[string]any)
-			cursor := ""
-			for {
-				if cursor != "" {
-					params.Cursor = langsmith.F(cursor)
+			if version == "v2" {
+				body := langsmith.RunQueryV2Params{
+					IsRoot:       langsmith.F(true),
+					MinStartTime: langsmith.F(startTime),
+					PageSize:     langsmith.F(int64(100)),
+					Selects:      langsmith.F(buildRunSelectV2(true, false)),
 				}
-				resp, err := c.SDK.Runs.Query(ctx, params)
+				if rawFilter != "" {
+					body.Filter = langsmith.F(rawFilter)
+				}
+				// v2 requires a bounded fetch; cap at 1000 root runs to group into threads.
+				runs, err := queryRunsV2(ctx, c, body, sessionID, 1000, 0)
 				if err != nil {
 					ExitErrorf("querying runs: %v", err)
 				}
-				for _, run := range resp.Runs {
+				for _, run := range runs {
 					tid := run.ThreadID
 					if tid != "" {
 						m := extract.ExtractRun(run, true, true, false)
 						threadsMap[tid] = append(threadsMap[tid], m)
 					}
 				}
-				if resp.Cursors.Next == "" {
-					break
+			} else {
+				// Query root runs (like the Python SDK does)
+				params := langsmith.RunQueryParams{
+					Session: langsmith.F([]string{sessionID}),
+					IsRoot:  langsmith.F(true),
+					Limit:   langsmith.F(int64(100)),
 				}
-				cursor = resp.Cursors.Next
+				if rawFilter != "" {
+					params.Filter = langsmith.F(rawFilter)
+				}
+				params.StartTime = langsmith.F(startTime)
+
+				cursor := ""
+				for {
+					if cursor != "" {
+						params.Cursor = langsmith.F(cursor)
+					}
+					resp, err := c.SDK.Runs.Query(ctx, params)
+					if err != nil {
+						ExitErrorf("querying runs: %v", err)
+					}
+					for _, run := range resp.Runs {
+						tid := run.ThreadID
+						if tid != "" {
+							m := extract.ExtractRun(run, true, true, false)
+							threadsMap[tid] = append(threadsMap[tid], m)
+						}
+					}
+					if resp.Cursors.Next == "" {
+						break
+					}
+					cursor = resp.Cursors.Next
+				}
 			}
 
 			// Build thread summaries
@@ -185,6 +209,7 @@ func newThreadListCmd() *cobra.Command {
 	cmd.Flags().IntVarP(&limit, "limit", "n", 20, "Maximum number of threads to return")
 	cmd.Flags().StringVar(&rawFilter, "filter", "", "Raw LangSmith filter DSL string")
 	cmd.Flags().IntVar(&lastNMinutes, "last-n-minutes", 0, "Only include threads active in last N minutes")
+	cmd.Flags().StringVar(&version, "version", "", `Query API version: "" (v1, default) or "v2" (SmithDB)`)
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 
 	return cmd
@@ -193,6 +218,7 @@ func newThreadListCmd() *cobra.Command {
 func newThreadGetCmd() *cobra.Command {
 	var (
 		project         string
+		version         string
 		includeMetadata bool
 		includeIO       bool
 		includeFeedback bool
@@ -234,17 +260,31 @@ func newThreadGetCmd() *cobra.Command {
 			if limit > 0 {
 				queryLimit = limit
 			}
-			params := langsmith.RunQueryParams{
-				Session: langsmith.F([]string{sessionID}),
-				IsRoot:  langsmith.F(true),
-				Filter:  langsmith.F(filterDSL),
-				Limit:   langsmith.F(int64(queryLimit)),
+			var runs []langsmith.RunSchema
+			if version == "v2" {
+				// v2 run-query has no thread_id field; filter root runs by the
+				// thread_id DSL. v2 requires a lower time bound and thread get has
+				// no --since flag, so use a wide window (v1 relies on the server default).
+				body := langsmith.RunQueryV2Params{
+					IsRoot:       langsmith.F(true),
+					Filter:       langsmith.F(filterDSL),
+					MinStartTime: langsmith.F(time.Now().UTC().AddDate(-1, 0, 0)),
+					PageSize:     langsmith.F(int64(queryLimit)),
+					Selects:      langsmith.F(buildRunSelectV2(includeIO, includeFeedback)),
+				}
+				runs, err = queryRunsV2(ctx, c, body, sessionID, queryLimit, 0)
+			} else {
+				params := langsmith.RunQueryParams{
+					Session: langsmith.F([]string{sessionID}),
+					IsRoot:  langsmith.F(true),
+					Filter:  langsmith.F(filterDSL),
+					Limit:   langsmith.F(int64(queryLimit)),
+				}
+				if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
+					params.Select = langsmith.F(sel)
+				}
+				runs, err = queryRuns(ctx, c, params, "", queryLimit, 0)
 			}
-			if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
-				params.Select = langsmith.F(sel)
-			}
-
-			runs, err := queryRuns(ctx, c, params, "", queryLimit, 0)
 			if err != nil {
 				ExitErrorf("querying thread runs: %v", err)
 			}
@@ -267,6 +307,7 @@ func newThreadGetCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
+	cmd.Flags().StringVar(&version, "version", "", `Query API version: "" (v1, default) or "v2" (SmithDB)`)
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
 	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
@@ -283,6 +324,7 @@ func newThreadMessagesCmd() *cobra.Command {
 		limit      int
 		cursor     string
 		traceID    string
+		version    string
 		outputFile string
 	)
 
@@ -366,6 +408,10 @@ Examples:
 	cmd.Flags().IntVarP(&limit, "limit", "n", 10, "Maximum number of turns to return (max 100)")
 	cmd.Flags().StringVar(&cursor, "cursor", "", "Pagination cursor from a previous response")
 	cmd.Flags().StringVar(&traceID, "trace-id", "", "Start the page at a specific trace ID")
+	// --version is accepted for interface consistency but is a no-op here: thread
+	// messages reads the dedicated /v2/threads/{id}/messages endpoint, which routes
+	// to the appropriate backend server-side (no v1/v2 runs-query to switch).
+	cmd.Flags().StringVar(&version, "version", "", `Query API version: "" (v1, default) or "v2" (SmithDB)`)
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 
 	return cmd

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -73,11 +73,18 @@ func newTraceListCmd() *cobra.Command {
 				ExitErrorf("%v", err)
 			}
 
-			params := BuildRunQueryParams(&ff, true, ff.Limit)
-			if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
-				params.Select = langsmith.F(sel)
+			var runs []langsmith.RunSchema
+			if ff.Version == "v2" {
+				body := buildRunQueryV2Params(&ff, true, ff.Limit)
+				body.Selects = langsmith.F(buildRunSelectV2(includeIO, includeFeedback))
+				runs, err = queryRunsV2(ctx, c, body, sessionID, ff.Limit, ff.MinTokens)
+			} else {
+				params := BuildRunQueryParams(&ff, true, ff.Limit)
+				if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
+					params.Select = langsmith.F(sel)
+				}
+				runs, err = queryRuns(ctx, c, params, sessionID, ff.Limit, ff.MinTokens)
 			}
-			runs, err := queryRuns(ctx, c, params, sessionID, ff.Limit, ff.MinTokens)
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -93,13 +100,20 @@ func newTraceListCmd() *cobra.Command {
 
 			fmt_ := GetFormat()
 
+			childStart := resolveStartTime(ff.Since, ff.LastNMinutes)
+
 			if fmt_ == "pretty" {
 				if showHierarchy {
 					for _, run := range runs {
-						allRuns, err := queryRuns(ctx, c, langsmith.RunQueryParams{
-							Trace: langsmith.F(run.TraceID),
-							Order: langsmith.F(langsmith.RunQueryParamsOrderAsc),
-						}, sessionID, 1000, 0)
+						var allRuns []langsmith.RunSchema
+						if ff.Version == "v2" {
+							allRuns, err = queryTraceRunsV2(ctx, c, run.TraceID, sessionID, childStart, includeIO, includeFeedback)
+						} else {
+							allRuns, err = queryRuns(ctx, c, langsmith.RunQueryParams{
+								Trace: langsmith.F(run.TraceID),
+								Order: langsmith.F(langsmith.RunQueryParamsOrderAsc),
+							}, sessionID, 1000, 0)
+						}
 						if err != nil {
 							ExitErrorf("%v", err)
 						}
@@ -119,8 +133,13 @@ func newTraceListCmd() *cobra.Command {
 					}
 					var result []map[string]any
 					for _, run := range runs {
-						childParams.Trace = langsmith.F(run.TraceID)
-						allRuns, err := queryRuns(ctx, c, childParams, sessionID, 1000, 0)
+						var allRuns []langsmith.RunSchema
+						if ff.Version == "v2" {
+							allRuns, err = queryTraceRunsV2(ctx, c, run.TraceID, sessionID, childStart, includeIO, includeFeedback)
+						} else {
+							childParams.Trace = langsmith.F(run.TraceID)
+							allRuns, err = queryRuns(ctx, c, childParams, sessionID, 1000, 0)
+						}
 						if err != nil {
 							ExitErrorf("%v", err)
 						}
@@ -143,6 +162,7 @@ func newTraceListCmd() *cobra.Command {
 	}
 
 	addCommonFilterFlags(cmd, &ff, false)
+	addVersionFlag(cmd, &ff)
 	cmd.Flags().StringVar(&ff.ProjectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
 	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
@@ -162,6 +182,7 @@ func newTraceGetCmd() *cobra.Command {
 		projectID       string
 		since           string
 		lastNMinutes    int
+		version         string
 		includeMetadata bool
 		includeIO       bool
 		includeFeedback bool
@@ -189,16 +210,20 @@ func newTraceGetCmd() *cobra.Command {
 				ExitErrorf("%v", err)
 			}
 
-			params := langsmith.RunQueryParams{
-				Trace:     langsmith.F(traceID),
-				StartTime: langsmith.F(resolveStartTime(since, lastNMinutes)),
-				Order:     langsmith.F(langsmith.RunQueryParamsOrderAsc),
+			var runs []langsmith.RunSchema
+			if version == "v2" {
+				runs, err = queryTraceRunsV2(ctx, c, traceID, sessionID, resolveStartTime(since, lastNMinutes), includeIO, includeFeedback)
+			} else {
+				params := langsmith.RunQueryParams{
+					Trace:     langsmith.F(traceID),
+					StartTime: langsmith.F(resolveStartTime(since, lastNMinutes)),
+					Order:     langsmith.F(langsmith.RunQueryParamsOrderAsc),
+				}
+				if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
+					params.Select = langsmith.F(sel)
+				}
+				runs, err = queryRuns(ctx, c, params, sessionID, 1000, 0)
 			}
-			if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
-				params.Select = langsmith.F(sel)
-			}
-
-			runs, err := queryRuns(ctx, c, params, sessionID, 1000, 0)
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -222,6 +247,7 @@ func newTraceGetCmd() *cobra.Command {
 	cmd.Flags().StringVar(&projectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
 	cmd.Flags().StringVar(&since, "since", "", "Only include runs after this timestamp, e.g. 2024-01-15T00:00:00Z (overrides 7-day default)")
 	cmd.Flags().IntVar(&lastNMinutes, "last-n-minutes", 0, "Only include runs from the last N minutes, e.g. 60 (overrides 7-day default)")
+	cmd.Flags().StringVar(&version, "version", "", `Query API version: "" (v1, default) or "v2" (SmithDB)`)
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
 	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
@@ -270,28 +296,41 @@ func newTraceExportCmd() *cobra.Command {
 				ExitErrorf("%v", err)
 			}
 
-			params := BuildRunQueryParams(&ff, true, ff.Limit)
 			sel := buildRunSelect(includeIO, includeFeedback)
-			if sel != nil {
-				params.Select = langsmith.F(sel)
+			var rootRuns []langsmith.RunSchema
+			if ff.Version == "v2" {
+				body := buildRunQueryV2Params(&ff, true, ff.Limit)
+				body.Selects = langsmith.F(buildRunSelectV2(includeIO, includeFeedback))
+				rootRuns, err = queryRunsV2(ctx, c, body, sessionID, ff.Limit, ff.MinTokens)
+			} else {
+				params := BuildRunQueryParams(&ff, true, ff.Limit)
+				if sel != nil {
+					params.Select = langsmith.F(sel)
+				}
+				rootRuns, err = queryRuns(ctx, c, params, sessionID, ff.Limit, ff.MinTokens)
 			}
-			rootRuns, err := queryRuns(ctx, c, params, sessionID, ff.Limit, ff.MinTokens)
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
 
+			childStart := resolveStartTime(ff.Since, ff.LastNMinutes)
 			exported := 0
 			for _, root := range rootRuns {
 				tid := root.TraceID
 
-				childParams := langsmith.RunQueryParams{
-					Trace: langsmith.F(tid),
-					Order: langsmith.F(langsmith.RunQueryParamsOrderAsc),
+				var allRuns []langsmith.RunSchema
+				if ff.Version == "v2" {
+					allRuns, err = queryTraceRunsV2(ctx, c, tid, sessionID, childStart, includeIO, includeFeedback)
+				} else {
+					childParams := langsmith.RunQueryParams{
+						Trace: langsmith.F(tid),
+						Order: langsmith.F(langsmith.RunQueryParamsOrderAsc),
+					}
+					if sel != nil {
+						childParams.Select = langsmith.F(sel)
+					}
+					allRuns, err = queryRuns(ctx, c, childParams, sessionID, 1000, 0)
 				}
-				if sel != nil {
-					childParams.Select = langsmith.F(sel)
-				}
-				allRuns, err := queryRuns(ctx, c, childParams, sessionID, 1000, 0)
 				if err != nil {
 					ExitErrorf("%v", err)
 				}
@@ -331,6 +370,7 @@ func newTraceExportCmd() *cobra.Command {
 	}
 
 	addCommonFilterFlags(cmd, &ff, false)
+	addVersionFlag(cmd, &ff)
 	cmd.Flags().StringVar(&ff.ProjectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
 	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")

--- a/internal/cmd/trace_stats.go
+++ b/internal/cmd/trace_stats.go
@@ -39,6 +39,7 @@ func newTraceStatsCmd() *cobra.Command {
 		cmpBefore   string
 		cmpLastNMin int
 		filter      string
+		version     string
 		outputFile  string
 	)
 
@@ -107,6 +108,10 @@ Examples:
 	cmd.Flags().StringVar(&cmpBefore, "compare-before", "", "Comparison window end (RFC3339 or YYYY-MM-DD; default: same as --since)")
 	cmd.Flags().IntVar(&cmpLastNMin, "compare-last-n-minutes", 0, "Shorthand: comparison window = N minutes before the primary window starts")
 	cmd.Flags().StringVar(&filter, "filter", "", "LangSmith filter DSL (applied to both windows if comparing)")
+	// --version is accepted for interface consistency but is a no-op here: SDK
+	// v0.18.2 exposes no v2 stats method (only Runs.Stats). The stats endpoint
+	// routes to SmithDB server-side, so v1/v2 selection is not a client concern.
+	cmd.Flags().StringVar(&version, "version", "", `Query API version: "" (v1, default) or "v2" (SmithDB)`)
 	cmd.Flags().StringVar(&outputFile, "output", "", "Write JSON output to file instead of stdout")
 	cmd.MarkFlagsMutuallyExclusive("project", "project-id")
 	return cmd

--- a/internal/cmd/trace_test.go
+++ b/internal/cmd/trace_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // ==================== Command structure ====================
@@ -188,5 +190,32 @@ func TestTraceExportCmd_ExactArgs(t *testing.T) {
 	}
 	if err := cmd.Args(cmd, []string{"a", "b"}); err == nil {
 		t.Error("expected error for 2 args")
+	}
+}
+
+// TestVersionFlag_PresentOnTraceAndThreadCmds asserts the --version flag (v1/v2
+// SmithDB selector) is registered on every trace and thread command, mirroring
+// the run commands.
+func TestVersionFlag_PresentOnTraceAndThreadCmds(t *testing.T) {
+	cmds := map[string]*cobra.Command{
+		"trace list":      newTraceListCmd(),
+		"trace get":       newTraceGetCmd(),
+		"trace export":    newTraceExportCmd(),
+		"trace messages":  newTraceMessagesCmd(),
+		"trace stats":     newTraceStatsCmd(),
+		"thread list":     newThreadListCmd(),
+		"thread get":      newThreadGetCmd(),
+		"thread messages": newThreadMessagesCmd(),
+	}
+	const want = `Query API version: "" (v1, default) or "v2" (SmithDB)`
+	for name, cmd := range cmds {
+		f := cmd.Flags().Lookup("version")
+		if f == nil {
+			t.Errorf("%s missing --version flag", name)
+			continue
+		}
+		if f.Usage != want {
+			t.Errorf("%s --version usage = %q, want %q", name, f.Usage, want)
+		}
 	}
 }


### PR DESCRIPTION
Add --version v2 flag was to all 8 trace + thread commands:

Real v2 routing:
- trace list
- trace get
- trace export
- trace messages (root-preview enrichment; its main payload already hits /v2/traces/messages)
- thread list
- thread get

Flag present but a documented no-op (nothing to switch):
- trace stats — no public v2 stats endpoint/SDK method; reaches SmithDB via v1 server-side