### PR TITLE
feat: auto-select v1/v2 runs API from deployment; remove --version flag [LIN-466]

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,12 +168,7 @@ langsmith run get <run-id> --full
 langsmith run export llm_calls.jsonl --project my-app --run-type llm --full
 ```
 
-> **For agents querying runs:** prefer `--version v2` first (SmithDB-backed; faster on tenants that are rolled out). If the call fails with a 4xx (typically 403, 404, or 422), retry the **same command without** `--version` to fall back to v1. Example:
->
-> ```bash
-> langsmith run list --project my-app --version v2 \
->   || langsmith run list --project my-app
-> ```
+> **Query backend:** the CLI selects the runs query API automatically from the deployment reported by `/info` — LangSmith Cloud and self-hosted `>= 0.16` use the v2 (SmithDB) API; older self-hosted uses v1. No flag is needed. A few v2-only features (`trace messages`, `thread messages`) are unavailable on self-hosted `< 0.16`.
 
 ### `thread` — Query conversation threads
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,6 +28,10 @@ type Client struct {
 
 	// Cached session name → ID mappings (per invocation).
 	sessionCache map[string]string
+
+	// Cached run-query backend decision (see UseV2Runs), resolved once per
+	// invocation from GET /info.
+	runsUseV2 *bool
 }
 
 // Options controls LangSmith client authentication and routing.
@@ -109,6 +114,74 @@ func (c *Client) ResolveSessionID(ctx context.Context, projectName string) (stri
 	id := resp.Items[0].ID
 	c.sessionCache[projectName] = id
 	return id, nil
+}
+
+// minSelfHostedV2Minor is the minor version (major 0) at which self-hosted
+// deployments gain the v2 (SmithDB) run-query API. Self-hosted >= 0.16 uses v2;
+// older self-hosted must use v1.
+const minSelfHostedV2Minor = 16
+
+// UseV2Runs reports whether run queries should target the v2 (SmithDB) API for
+// the connected deployment. The decision is resolved once via the SDK GET /info
+// method and cached for the client's lifetime.
+func (c *Client) UseV2Runs(ctx context.Context) (bool, error) {
+	if c.runsUseV2 != nil {
+		return *c.runsUseV2, nil
+	}
+	info, err := c.SDK.Info.List(ctx)
+	if err != nil {
+		return false, fmt.Errorf("fetching deployment info: %w", err)
+	}
+	v := useV2Runs(info.Version)
+	c.runsUseV2 = &v
+	return v, nil
+}
+
+// useV2Runs decides the run-query backend from a deployment's /info version.
+//
+// Cloud reports a non-release version (e.g. "dev") that does not parse as a
+// release semver and always uses v2. Self-hosted reports a release semver:
+// v2 (SmithDB) methods require >= 0.16, so older self-hosted uses v1.
+func useV2Runs(version string) bool {
+	major, minor, ok := parseReleaseVersion(version)
+	if !ok {
+		return true // Cloud / non-release version → v2
+	}
+	if major != 0 {
+		return true // 1.x and beyond → v2
+	}
+	return minor >= minSelfHostedV2Minor
+}
+
+// parseReleaseVersion extracts the numeric major and minor components of a
+// release version string like "0.16.18rc1" or "v1.2.3". It returns ok=false for
+// non-release versions (e.g. "dev", "") that don't start with numeric
+// major.minor components.
+func parseReleaseVersion(v string) (major, minor int, ok bool) {
+	v = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(v), "v"))
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+	major, err := strconv.Atoi(leadingDigits(parts[0]))
+	if err != nil {
+		return 0, 0, false
+	}
+	minor, err = strconv.Atoi(leadingDigits(parts[1]))
+	if err != nil {
+		return 0, 0, false
+	}
+	return major, minor, true
+}
+
+// leadingDigits returns the leading run of ASCII digits in s (e.g. "16rc1" →
+// "16"), or "" when s does not start with a digit.
+func leadingDigits(s string) string {
+	i := 0
+	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+		i++
+	}
+	return s[:i]
 }
 
 // --- Raw HTTP helpers for endpoints not covered by the SDK ---

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -29,9 +29,9 @@ type Client struct {
 	// Cached session name → ID mappings (per invocation).
 	sessionCache map[string]string
 
-	// Cached run-query backend decision (see UseV2Runs), resolved once per
-	// invocation from GET /info.
-	runsUseV2 *bool
+	// Cached v2-API decision (see UseV2API), resolved once per invocation
+	// from GET /info.
+	cachedUseV2API *bool
 }
 
 // Options controls LangSmith client authentication and routing.
@@ -119,25 +119,25 @@ func (c *Client) ResolveSessionID(ctx context.Context, projectName string) (stri
 // Self-hosted gains the v2 (SmithDB) run-query API at 0.16.
 const minSelfHostedV2Minor = 16
 
-// UseV2Runs reports whether run queries should use the v2 (SmithDB) API for the
-// connected deployment, resolved once from GET /info and cached.
-func (c *Client) UseV2Runs(ctx context.Context) (bool, error) {
-	if c.runsUseV2 != nil {
-		return *c.runsUseV2, nil
+// UseV2API reports whether the connected deployment's v2 (SmithDB) API should
+// be used, resolved once from GET /info and cached.
+func (c *Client) UseV2API(ctx context.Context) (bool, error) {
+	if c.cachedUseV2API != nil {
+		return *c.cachedUseV2API, nil
 	}
 	info, err := c.SDK.Info.List(ctx)
 	if err != nil {
 		return false, fmt.Errorf("fetching deployment info: %w", err)
 	}
-	v := useV2Runs(info.Version)
-	c.runsUseV2 = &v
+	v := useV2API(info.Version)
+	c.cachedUseV2API = &v
 	return v, nil
 }
 
-// useV2Runs decides the run-query backend from the /info version. Cloud reports
+// useV2API decides whether to use the v2 API from the /info version. Cloud reports
 // a non-release version (e.g. "dev") → v2; self-hosted reports a semver, v2 at
 // >= 0.16 else v1.
-func useV2Runs(version string) bool {
+func useV2API(version string) bool {
 	major, minor, ok := parseReleaseVersion(version)
 	if !ok {
 		return true // Cloud / non-release version

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -116,14 +116,11 @@ func (c *Client) ResolveSessionID(ctx context.Context, projectName string) (stri
 	return id, nil
 }
 
-// minSelfHostedV2Minor is the minor version (major 0) at which self-hosted
-// deployments gain the v2 (SmithDB) run-query API. Self-hosted >= 0.16 uses v2;
-// older self-hosted must use v1.
+// Self-hosted gains the v2 (SmithDB) run-query API at 0.16.
 const minSelfHostedV2Minor = 16
 
-// UseV2Runs reports whether run queries should target the v2 (SmithDB) API for
-// the connected deployment. The decision is resolved once via the SDK GET /info
-// method and cached for the client's lifetime.
+// UseV2Runs reports whether run queries should use the v2 (SmithDB) API for the
+// connected deployment, resolved once from GET /info and cached.
 func (c *Client) UseV2Runs(ctx context.Context) (bool, error) {
 	if c.runsUseV2 != nil {
 		return *c.runsUseV2, nil
@@ -137,26 +134,22 @@ func (c *Client) UseV2Runs(ctx context.Context) (bool, error) {
 	return v, nil
 }
 
-// useV2Runs decides the run-query backend from a deployment's /info version.
-//
-// Cloud reports a non-release version (e.g. "dev") that does not parse as a
-// release semver and always uses v2. Self-hosted reports a release semver:
-// v2 (SmithDB) methods require >= 0.16, so older self-hosted uses v1.
+// useV2Runs decides the run-query backend from the /info version. Cloud reports
+// a non-release version (e.g. "dev") → v2; self-hosted reports a semver, v2 at
+// >= 0.16 else v1.
 func useV2Runs(version string) bool {
 	major, minor, ok := parseReleaseVersion(version)
 	if !ok {
-		return true // Cloud / non-release version → v2
+		return true // Cloud / non-release version
 	}
 	if major != 0 {
-		return true // 1.x and beyond → v2
+		return true
 	}
 	return minor >= minSelfHostedV2Minor
 }
 
-// parseReleaseVersion extracts the numeric major and minor components of a
-// release version string like "0.16.18rc1" or "v1.2.3". It returns ok=false for
-// non-release versions (e.g. "dev", "") that don't start with numeric
-// major.minor components.
+// parseReleaseVersion pulls major.minor from a release version like "0.16.18rc1"
+// or "v1.2.3"; ok=false for non-release versions (e.g. "dev", "").
 func parseReleaseVersion(v string) (major, minor int, ok bool) {
 	v = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(v), "v"))
 	parts := strings.SplitN(v, ".", 3)
@@ -174,8 +167,7 @@ func parseReleaseVersion(v string) (major, minor int, ok bool) {
 	return major, minor, true
 }
 
-// leadingDigits returns the leading run of ASCII digits in s (e.g. "16rc1" →
-// "16"), or "" when s does not start with a digit.
+// leadingDigits returns the leading ASCII digits of s (e.g. "16rc1" → "16").
 func leadingDigits(s string) string {
 	i := 0
 	for i < len(s) && s[i] >= '0' && s[i] <= '9' {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -726,7 +726,7 @@ func TestAPIURL(t *testing.T) {
 
 // ---------- Run-query backend selection ----------
 
-func TestUseV2Runs(t *testing.T) {
+func TestUseV2API(t *testing.T) {
 	cases := []struct {
 		version string
 		want    bool
@@ -750,8 +750,8 @@ func TestUseV2Runs(t *testing.T) {
 		{"0.0.1", false},
 	}
 	for _, tc := range cases {
-		if got := useV2Runs(tc.version); got != tc.want {
-			t.Errorf("useV2Runs(%q) = %v, want %v", tc.version, got, tc.want)
+		if got := useV2API(tc.version); got != tc.want {
+			t.Errorf("useV2API(%q) = %v, want %v", tc.version, got, tc.want)
 		}
 	}
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -723,3 +723,35 @@ func TestAPIURL(t *testing.T) {
 		t.Errorf("expected http://localhost:1234, got %q", c.APIURL())
 	}
 }
+
+// ---------- Run-query backend selection ----------
+
+func TestUseV2Runs(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		// Cloud reports a non-release version.
+		{"dev", true},
+		{"", true},
+		{"latest", true},
+		// Self-hosted release semvers.
+		{"0.16", true},
+		{"0.16.0", true},
+		{"0.16.18", true},
+		{"0.16.18rc1", true},
+		{"v0.16.0", true},
+		{"0.17.3", true},
+		{"1.0.0", true},
+		{"1.2.3", true},
+		{"0.15.9", false},
+		{"0.15", false},
+		{"0.10.7", false},
+		{"0.0.1", false},
+	}
+	for _, tc := range cases {
+		if got := useV2Runs(tc.version); got != tc.want {
+			t.Errorf("useV2Runs(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}

--- a/internal/cmd/filters.go
+++ b/internal/cmd/filters.go
@@ -30,7 +30,6 @@ type FilterFlags struct {
 	Tags         string
 	Metadata     string
 	RawFilter    string
-	Version      string
 }
 
 // addCommonFilterFlags attaches shared filter flags to a command.
@@ -55,11 +54,6 @@ func addCommonFilterFlags(cmd *cobra.Command, f *FilterFlags, includeRunType boo
 	if includeRunType {
 		cmd.Flags().StringVar(&f.RunType, "run-type", "", "Filter by run type (llm, chain, tool, retriever, prompt, parser)")
 	}
-}
-
-// addVersionFlag attaches the --version flag for selecting the runs query backend.
-func addVersionFlag(cmd *cobra.Command, f *FilterFlags) {
-	cmd.Flags().StringVar(&f.Version, "version", "", `Query API version: "" (v1, default) or "v2" (SmithDB)`)
 }
 
 // resolveStartTime returns the start time for a query.

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -106,10 +106,8 @@ func queryRunsV2(ctx context.Context, c *client.Client, params langsmith.RunQuer
 	return allRuns, nil
 }
 
-// requireV2Feature exits with a clear error when the connected deployment does
-// not support the v2 (SmithDB) API that the named feature depends on. Used to
-// gate v2-only commands (e.g. the message endpoints) on older self-hosted
-// deployments.
+// requireV2Feature exits with a clear error when the deployment lacks the v2
+// (SmithDB) API a v2-only feature needs (older self-hosted).
 func requireV2Feature(ctx context.Context, c *client.Client, feature string) {
 	useV2, err := c.UseV2Runs(ctx)
 	if err != nil {
@@ -120,11 +118,9 @@ func requireV2Feature(ctx context.Context, c *client.Client, feature string) {
 	}
 }
 
-// queryRunsAuto queries runs using the v2 (SmithDB) backend when the deployment
-// supports it (see client.UseV2Runs), otherwise the v1 backend. params is the
-// canonical v1 query; v2Selects is the select-field set requested on the v2 path
-// — always pass a base set (see buildRunSelectV2), since omitting selects makes
-// v2 return only run IDs.
+// queryRunsAuto queries runs via the v2 (SmithDB) backend when the deployment
+// supports it, else v1. params is the canonical v1 query; always pass a base
+// v2Selects set (see buildRunSelectV2) or v2 returns only run IDs.
 func queryRunsAuto(ctx context.Context, c *client.Client, params langsmith.RunQueryParams, v2Selects []langsmith.RunQueryV2ParamsSelect, sessionID string, limit, minTokens int) ([]langsmith.RunSchema, error) {
 	useV2, err := c.UseV2Runs(ctx)
 	if err != nil {
@@ -136,10 +132,8 @@ func queryRunsAuto(ctx context.Context, c *client.Client, params langsmith.RunQu
 	return queryRuns(ctx, c, params, sessionID, limit, minTokens)
 }
 
-// toV2Params translates a canonical v1 RunQueryParams into the equivalent v2
-// RunQueryV2Params. The v1 Order (asc/desc) has no v2 equivalent — v2 returns
-// runs newest-first — and is dropped. Session is applied separately by
-// queryRunsV2 (as ProjectIDs) and is not translated here.
+// toV2Params translates canonical v1 RunQueryParams to v2. Order is dropped (no
+// v2 equivalent; v2 is newest-first); Session is applied by queryRunsV2.
 func toV2Params(p langsmith.RunQueryParams, selects []langsmith.RunQueryV2ParamsSelect) langsmith.RunQueryV2Params {
 	var v2 langsmith.RunQueryV2Params
 	if len(selects) > 0 {

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -109,7 +109,7 @@ func queryRunsV2(ctx context.Context, c *client.Client, params langsmith.RunQuer
 // requireV2Feature exits with a clear error when the deployment lacks the v2
 // (SmithDB) API a v2-only feature needs (older self-hosted).
 func requireV2Feature(ctx context.Context, c *client.Client, feature string) {
-	useV2, err := c.UseV2Runs(ctx)
+	useV2, err := c.UseV2API(ctx)
 	if err != nil {
 		ExitErrorf("%v", err)
 	}
@@ -122,7 +122,7 @@ func requireV2Feature(ctx context.Context, c *client.Client, feature string) {
 // supports it, else v1. params is the canonical v1 query; always pass a base
 // v2Selects set (see buildRunSelectV2) or v2 returns only run IDs.
 func queryRunsAuto(ctx context.Context, c *client.Client, params langsmith.RunQueryParams, v2Selects []langsmith.RunQueryV2ParamsSelect, sessionID string, limit, minTokens int) ([]langsmith.RunSchema, error) {
-	useV2, err := c.UseV2Runs(ctx)
+	useV2, err := c.UseV2API(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -106,55 +106,73 @@ func queryRunsV2(ctx context.Context, c *client.Client, params langsmith.RunQuer
 	return allRuns, nil
 }
 
-// buildRunQueryV2Params translates FilterFlags into a v2 query body. The
-// project name is left for queryRunsV2 to resolve into ProjectIDs.
-func buildRunQueryV2Params(f *FilterFlags, isRoot bool, defaultLimit int) langsmith.RunQueryV2Params {
-	var params langsmith.RunQueryV2Params
-
-	limit := defaultLimit
-	if f.Limit > 0 {
-		limit = f.Limit
+// requireV2Feature exits with a clear error when the connected deployment does
+// not support the v2 (SmithDB) API that the named feature depends on. Used to
+// gate v2-only commands (e.g. the message endpoints) on older self-hosted
+// deployments.
+func requireV2Feature(ctx context.Context, c *client.Client, feature string) {
+	useV2, err := c.UseV2Runs(ctx)
+	if err != nil {
+		ExitErrorf("%v", err)
 	}
-	params.PageSize = langsmith.F(int64(limit))
-
-	if isRoot {
-		params.IsRoot = langsmith.F(true)
+	if !useV2 {
+		ExitErrorf("%s is only available on LangSmith Cloud or self-hosted >= 0.16 (SmithDB); this deployment does not support it", feature)
 	}
+}
 
-	params.MinStartTime = langsmith.F(resolveStartTime(f.Since, f.LastNMinutes))
-	if f.Before != "" {
-		t, err := time.Parse(time.RFC3339, f.Before)
-		if err != nil {
-			t, err = time.Parse("2006-01-02T15:04:05", f.Before)
-			if err != nil {
-				ExitErrorf("invalid --before timestamp: %s", f.Before)
-			}
-		}
-		params.MaxStartTime = langsmith.F(t.UTC())
+// queryRunsAuto queries runs using the v2 (SmithDB) backend when the deployment
+// supports it (see client.UseV2Runs), otherwise the v1 backend. params is the
+// canonical v1 query; v2Selects is the select-field set requested on the v2 path
+// — always pass a base set (see buildRunSelectV2), since omitting selects makes
+// v2 return only run IDs.
+func queryRunsAuto(ctx context.Context, c *client.Client, params langsmith.RunQueryParams, v2Selects []langsmith.RunQueryV2ParamsSelect, sessionID string, limit, minTokens int) ([]langsmith.RunSchema, error) {
+	useV2, err := c.UseV2Runs(ctx)
+	if err != nil {
+		return nil, err
 	}
-
-	if f.RunType != "" {
-		params.RunType = langsmith.F(langsmith.RunQueryV2ParamsRunType(strings.ToUpper(f.RunType)))
+	if useV2 {
+		return queryRunsV2(ctx, c, toV2Params(params, v2Selects), sessionID, limit, minTokens)
 	}
+	return queryRuns(ctx, c, params, sessionID, limit, minTokens)
+}
 
-	if f.ErrorFlag {
-		params.HasError = langsmith.F(true)
-	} else if f.NoErrorFlag {
-		params.HasError = langsmith.F(false)
+// toV2Params translates a canonical v1 RunQueryParams into the equivalent v2
+// RunQueryV2Params. The v1 Order (asc/desc) has no v2 equivalent — v2 returns
+// runs newest-first — and is dropped. Session is applied separately by
+// queryRunsV2 (as ProjectIDs) and is not translated here.
+func toV2Params(p langsmith.RunQueryParams, selects []langsmith.RunQueryV2ParamsSelect) langsmith.RunQueryV2Params {
+	var v2 langsmith.RunQueryV2Params
+	if len(selects) > 0 {
+		v2.Selects = langsmith.F(selects)
 	}
-
-	if f.TraceIDs != "" {
-		ids := splitTrim(f.TraceIDs)
-		if len(ids) == 1 {
-			params.TraceID = langsmith.F(ids[0])
-		}
+	if p.Trace.Present {
+		v2.TraceID = langsmith.F(p.Trace.Value)
 	}
-
-	if s := buildFilterDSL(f); s != "" {
-		params.Filter = langsmith.F(s)
+	if p.IsRoot.Present {
+		v2.IsRoot = langsmith.F(p.IsRoot.Value)
 	}
-
-	return params
+	if p.RunType.Present {
+		v2.RunType = langsmith.F(langsmith.RunQueryV2ParamsRunType(strings.ToUpper(string(p.RunType.Value))))
+	}
+	if p.Error.Present {
+		v2.HasError = langsmith.F(p.Error.Value)
+	}
+	if p.StartTime.Present {
+		v2.MinStartTime = langsmith.F(p.StartTime.Value)
+	}
+	if p.EndTime.Present {
+		v2.MaxStartTime = langsmith.F(p.EndTime.Value)
+	}
+	if p.Filter.Present {
+		v2.Filter = langsmith.F(p.Filter.Value)
+	}
+	if len(p.ID.Value) > 0 {
+		v2.IDs = langsmith.F(p.ID.Value)
+	}
+	if p.Limit.Present {
+		v2.PageSize = langsmith.F(p.Limit.Value)
+	}
+	return v2
 }
 
 // buildRunSelectV2 returns the v2 select-field set covering the same base

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -550,3 +550,65 @@ func TestRunV2ToSchema_MapsFirstTokenTimeAndEvents(t *testing.T) {
 		t.Errorf("expected event name=new_token, got %v", out.Events[0]["name"])
 	}
 }
+
+// ---------- toV2Params ----------
+
+func TestToV2Params_TranslatesFields(t *testing.T) {
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+	p := langsmith.RunQueryParams{
+		Trace:     langsmith.F("trace-1"),
+		IsRoot:    langsmith.F(true),
+		RunType:   langsmith.F(langsmith.RunTypeEnum("llm")),
+		Error:     langsmith.F(true),
+		StartTime: langsmith.F(start),
+		EndTime:   langsmith.F(end),
+		Filter:    langsmith.F(`eq(name, "x")`),
+		ID:        langsmith.F([]string{"id-1", "id-2"}),
+		Limit:     langsmith.F(int64(25)),
+		Order:     langsmith.F(langsmith.RunQueryParamsOrderDesc), // dropped
+	}
+	sel := []langsmith.RunQueryV2ParamsSelect{langsmith.RunQueryV2ParamsSelectID}
+
+	v2 := toV2Params(p, sel)
+
+	if v2.TraceID.Value != "trace-1" {
+		t.Errorf("TraceID = %q, want trace-1", v2.TraceID.Value)
+	}
+	if !v2.IsRoot.Value {
+		t.Error("IsRoot = false, want true")
+	}
+	if v2.RunType.Value != langsmith.RunQueryV2ParamsRunType("LLM") {
+		t.Errorf("RunType = %q, want LLM (uppercased)", v2.RunType.Value)
+	}
+	if !v2.HasError.Value {
+		t.Error("HasError = false, want true")
+	}
+	if !v2.MinStartTime.Value.Equal(start) {
+		t.Errorf("MinStartTime = %v, want %v", v2.MinStartTime.Value, start)
+	}
+	if !v2.MaxStartTime.Value.Equal(end) {
+		t.Errorf("MaxStartTime = %v, want %v", v2.MaxStartTime.Value, end)
+	}
+	if v2.Filter.Value != `eq(name, "x")` {
+		t.Errorf("Filter = %q", v2.Filter.Value)
+	}
+	if len(v2.IDs.Value) != 2 {
+		t.Errorf("IDs = %v, want 2 entries", v2.IDs.Value)
+	}
+	if v2.PageSize.Value != 25 {
+		t.Errorf("PageSize = %d, want 25", v2.PageSize.Value)
+	}
+	if !v2.Selects.Present {
+		t.Error("Selects not set")
+	}
+}
+
+func TestToV2Params_OmitsUnsetFields(t *testing.T) {
+	v2 := toV2Params(langsmith.RunQueryParams{}, nil)
+	if v2.TraceID.Present || v2.IsRoot.Present || v2.HasError.Present ||
+		v2.MinStartTime.Present || v2.Filter.Present || v2.IDs.Present ||
+		v2.PageSize.Present || v2.Selects.Present {
+		t.Error("expected all fields unset for empty input")
+	}
+}

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -133,6 +133,9 @@ Examples:
 
 			c := MustGetClient()
 			ctx := context.Background()
+
+			requireV2Feature(ctx, c, "trace messages")
+
 			sessionID, err := resolveSessionID(ctx, c, ff.Project, ff.ProjectID, "trace messages")
 			if err != nil {
 				ExitErrorf("%v", err)
@@ -330,7 +333,6 @@ func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, 
 		return out
 	}
 	params := langsmith.RunQueryParams{
-		Session:   langsmith.F([]string{sessionID}),
 		IsRoot:    langsmith.F(true),
 		ID:        langsmith.F(ids),
 		StartTime: langsmith.F(startTime),
@@ -342,12 +344,17 @@ func fetchRootPreviews(ctx context.Context, c *client.Client, sessionID string, 
 			langsmith.RunQueryParamsSelectOutputsPreview,
 		}),
 	}
-	resp, err := c.SDK.Runs.Query(ctx, params)
+	v2Select := []langsmith.RunQueryV2ParamsSelect{
+		langsmith.RunQueryV2ParamsSelectTraceID,
+		langsmith.RunQueryV2ParamsSelectInputsPreview,
+		langsmith.RunQueryV2ParamsSelectOutputsPreview,
+	}
+	runs, err := queryRunsAuto(ctx, c, params, v2Select, sessionID, len(ids), 0)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: fetching root previews failed: %v\n", err)
 		return out
 	}
-	for _, run := range resp.Runs {
+	for _, run := range runs {
 		tid := run.TraceID
 		if tid == "" {
 			tid = run.ID

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -100,10 +100,10 @@ func TestTraceMessages_Success(t *testing.T) {
 					},
 				},
 			})
-		case r.URL.Path == "/api/v1/runs/query" && r.Method == "POST":
-			// attachRootIO always fetches root run previews
+		case r.URL.Path == "/v2/runs/query" && r.Method == "POST":
+			// attachRootIO always fetches root run previews (v2 backend here)
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{"runs": []any{}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
 		default:
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 			http.Error(w, "not found", 404)
@@ -599,9 +599,9 @@ func TestTraceMessages_FeedbackStats(t *testing.T) {
 				},
 				"next_cursor": "",
 			})
-		case r.URL.Path == "/api/v1/runs/query" && r.Method == "POST":
+		case r.URL.Path == "/v2/runs/query" && r.Method == "POST":
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{"runs": []any{}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
 		default:
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 			http.Error(w, "not found", 404)

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -65,18 +65,11 @@ func newRunListCmd() *cobra.Command {
 				ExitErrorf("%v", err)
 			}
 
-			var runs []langsmith.RunSchema
-			if ff.Version == "v2" {
-				body := buildRunQueryV2Params(&ff, false, ff.Limit)
-				body.Selects = langsmith.F(buildRunSelectV2(includeIO, includeFeedback))
-				runs, err = queryRunsV2(ctx, c, body, sessionID, ff.Limit, ff.MinTokens)
-			} else {
-				params := BuildRunQueryParams(&ff, false, ff.Limit)
-				if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
-					params.Select = langsmith.F(sel)
-				}
-				runs, err = queryRuns(ctx, c, params, sessionID, ff.Limit, ff.MinTokens)
+			params := BuildRunQueryParams(&ff, false, ff.Limit)
+			if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
+				params.Select = langsmith.F(sel)
 			}
+			runs, err := queryRunsAuto(ctx, c, params, buildRunSelectV2(includeIO, includeFeedback), sessionID, ff.Limit, ff.MinTokens)
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -94,7 +87,6 @@ func newRunListCmd() *cobra.Command {
 	}
 
 	addCommonFilterFlags(cmd, &ff, true)
-	addVersionFlag(cmd, &ff)
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
 	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
@@ -109,7 +101,6 @@ func newRunGetCmd() *cobra.Command {
 		project         string
 		since           string
 		lastNMinutes    int
-		version         string
 		includeMetadata bool
 		includeIO       bool
 		includeFeedback bool
@@ -137,26 +128,15 @@ func newRunGetCmd() *cobra.Command {
 				ExitErrorf("%v", err)
 			}
 
-			var runs []langsmith.RunSchema
-			if version == "v2" {
-				params := langsmith.RunQueryV2Params{
-					IDs:          langsmith.F([]string{runID}),
-					MinStartTime: langsmith.F(resolveStartTime(since, lastNMinutes)),
-					PageSize:     langsmith.F(int64(1)),
-					Selects:      langsmith.F(buildRunSelectV2(includeIO, includeFeedback)),
-				}
-				runs, err = queryRunsV2(ctx, c, params, sessionID, 1, 0)
-			} else {
-				params := langsmith.RunQueryParams{
-					ID:        langsmith.F([]string{runID}),
-					Limit:     langsmith.F(int64(1)),
-					StartTime: langsmith.F(resolveStartTime(since, lastNMinutes)),
-				}
-				if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
-					params.Select = langsmith.F(sel)
-				}
-				runs, err = queryRuns(ctx, c, params, sessionID, 1, 0)
+			params := langsmith.RunQueryParams{
+				ID:        langsmith.F([]string{runID}),
+				Limit:     langsmith.F(int64(1)),
+				StartTime: langsmith.F(resolveStartTime(since, lastNMinutes)),
 			}
+			if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
+				params.Select = langsmith.F(sel)
+			}
+			runs, err := queryRunsAuto(ctx, c, params, buildRunSelectV2(includeIO, includeFeedback), sessionID, 1, 0)
 			if err != nil {
 				ExitErrorf("fetching run: %v", err)
 			}
@@ -178,7 +158,6 @@ func newRunGetCmd() *cobra.Command {
 	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
 	cmd.Flags().StringVar(&since, "since", "", "Only include runs after this timestamp, e.g. 2024-01-15T00:00:00Z (overrides 7-day default)")
 	cmd.Flags().IntVar(&lastNMinutes, "last-n-minutes", 0, "Only include runs from the last N minutes, e.g. 60 (overrides 7-day default)")
-	cmd.Flags().StringVar(&version, "version", "", `Query API version: "" (v1, default) or "v2" (SmithDB)`)
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
 	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
@@ -221,18 +200,11 @@ func newRunExportCmd() *cobra.Command {
 				ExitErrorf("%v", err)
 			}
 
-			var runs []langsmith.RunSchema
-			if ff.Version == "v2" {
-				body := buildRunQueryV2Params(&ff, false, ff.Limit)
-				body.Selects = langsmith.F(buildRunSelectV2(includeIO, includeFeedback))
-				runs, err = queryRunsV2(ctx, c, body, sessionID, ff.Limit, ff.MinTokens)
-			} else {
-				params := BuildRunQueryParams(&ff, false, ff.Limit)
-				if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
-					params.Select = langsmith.F(sel)
-				}
-				runs, err = queryRuns(ctx, c, params, sessionID, ff.Limit, ff.MinTokens)
+			params := BuildRunQueryParams(&ff, false, ff.Limit)
+			if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
+				params.Select = langsmith.F(sel)
 			}
+			runs, err := queryRunsAuto(ctx, c, params, buildRunSelectV2(includeIO, includeFeedback), sessionID, ff.Limit, ff.MinTokens)
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -243,7 +215,6 @@ func newRunExportCmd() *cobra.Command {
 	}
 
 	addCommonFilterFlags(cmd, &ff, true)
-	addVersionFlag(cmd, &ff)
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
 	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -211,6 +211,9 @@ func TestRunExportCmd_NoOutputFlag(t *testing.T) {
 // runs is returned for any /runs/query POST.
 func newRunTestServer(t *testing.T, sessions map[string]string, runs []map[string]any) *httptest.Server {
 	t.Helper()
+	// These fixtures mock the v1 /runs/query endpoint, so pin the deployment to
+	// an older self-hosted version that selects the v1 backend.
+	withDeploymentVersion(t, "0.15.0")
 	return newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -211,8 +211,7 @@ func TestRunExportCmd_NoOutputFlag(t *testing.T) {
 // runs is returned for any /runs/query POST.
 func newRunTestServer(t *testing.T, sessions map[string]string, runs []map[string]any) *httptest.Server {
 	t.Helper()
-	// These fixtures mock the v1 /runs/query endpoint, so pin the deployment to
-	// an older self-hosted version that selects the v1 backend.
+	// Fixtures mock the v1 /runs/query endpoint; pin to a v1 deployment.
 	withDeploymentVersion(t, "0.15.0")
 	return newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/cmd/testutil_test.go
+++ b/internal/cmd/testutil_test.go
@@ -2,12 +2,30 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 )
+
+// testDeploymentVersion is the version newTestServer reports at
+// GET /api/v1/info, which drives the v1/v2 run-query backend selection
+// (see client.UseV2Runs). It defaults to a Cloud-style non-release version
+// ("dev"), so commands take the v2 path by default. Tests that need to
+// exercise the v1 (older self-hosted) path override it via
+// withDeploymentVersion.
+var testDeploymentVersion = "dev"
+
+// withDeploymentVersion overrides the version newTestServer reports at /info
+// for the duration of the test.
+func withDeploymentVersion(t *testing.T, version string) {
+	t.Helper()
+	prev := testDeploymentVersion
+	testDeploymentVersion = version
+	t.Cleanup(func() { testDeploymentVersion = prev })
+}
 
 // captureStdout redirects os.Stdout during fn and returns what was written.
 func captureStdout(t *testing.T, fn func()) string {
@@ -31,10 +49,20 @@ func captureStdout(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
-// newTestServer creates an httptest server with the given handler.
+// newTestServer creates an httptest server with the given handler. It serves a
+// default GET /api/v1/info response (version testDeploymentVersion) so commands
+// that resolve the run-query backend via client.UseV2Runs work without every
+// test mocking /info; all other paths fall through to handler.
 func newTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	t.Helper()
-	ts := httptest.NewServer(handler)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/info" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"version": testDeploymentVersion})
+			return
+		}
+		handler(w, r)
+	}))
 	t.Cleanup(ts.Close)
 	return ts
 }

--- a/internal/cmd/testutil_test.go
+++ b/internal/cmd/testutil_test.go
@@ -45,7 +45,7 @@ func captureStdout(t *testing.T, fn func()) string {
 }
 
 // newTestServer creates an httptest server with the given handler, serving a
-// default /info (version testDeploymentVersion) so UseV2Runs works without every
+// default /info (version testDeploymentVersion) so UseV2API works without every
 // test mocking it; other paths fall through to handler.
 func newTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	t.Helper()

--- a/internal/cmd/testutil_test.go
+++ b/internal/cmd/testutil_test.go
@@ -10,16 +10,11 @@ import (
 	"testing"
 )
 
-// testDeploymentVersion is the version newTestServer reports at
-// GET /api/v1/info, which drives the v1/v2 run-query backend selection
-// (see client.UseV2Runs). It defaults to a Cloud-style non-release version
-// ("dev"), so commands take the v2 path by default. Tests that need to
-// exercise the v1 (older self-hosted) path override it via
-// withDeploymentVersion.
+// testDeploymentVersion is the version newTestServer reports at /info, driving
+// v1/v2 selection. Defaults to "dev" (Cloud → v2); override for the v1 path.
 var testDeploymentVersion = "dev"
 
-// withDeploymentVersion overrides the version newTestServer reports at /info
-// for the duration of the test.
+// withDeploymentVersion overrides the reported /info version for one test.
 func withDeploymentVersion(t *testing.T, version string) {
 	t.Helper()
 	prev := testDeploymentVersion
@@ -49,10 +44,9 @@ func captureStdout(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
-// newTestServer creates an httptest server with the given handler. It serves a
-// default GET /api/v1/info response (version testDeploymentVersion) so commands
-// that resolve the run-query backend via client.UseV2Runs work without every
-// test mocking /info; all other paths fall through to handler.
+// newTestServer creates an httptest server with the given handler, serving a
+// default /info (version testDeploymentVersion) so UseV2Runs works without every
+// test mocking it; other paths fall through to handler.
 func newTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	t.Helper()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -76,9 +76,8 @@ func newThreadListCmd() *cobra.Command {
 				startTime = time.Now().UTC().Add(-time.Duration(lastNMinutes) * time.Minute)
 			}
 
-			// Query root runs (like the Python SDK does). Limit here is the
-			// per-request page size; the query paginates over all matching root
-			// runs so they can be grouped by thread_id below.
+			// Limit is the per-request page size; paginate all root runs, then
+			// group by thread_id below.
 			params := langsmith.RunQueryParams{
 				IsRoot:    langsmith.F(true),
 				Limit:     langsmith.F(int64(100)),

--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -69,46 +70,40 @@ func newThreadListCmd() *cobra.Command {
 				ExitErrorf("%v", err)
 			}
 
-			// Query root runs (like the Python SDK does)
-			params := langsmith.RunQueryParams{
-				Session: langsmith.F([]string{sessionID}),
-				IsRoot:  langsmith.F(true),
-				Limit:   langsmith.F(int64(100)),
-			}
-
-			if rawFilter != "" {
-				params.Filter = langsmith.F(rawFilter)
-			}
-
 			// Default to last 24h if no time filter
 			startTime := time.Now().UTC().Add(-24 * time.Hour)
 			if lastNMinutes > 0 {
 				startTime = time.Now().UTC().Add(-time.Duration(lastNMinutes) * time.Minute)
 			}
-			params.StartTime = langsmith.F(startTime)
 
-			// Paginate all runs and group by thread_id
+			// Query root runs (like the Python SDK does). Limit here is the
+			// per-request page size; the query paginates over all matching root
+			// runs so they can be grouped by thread_id below.
+			params := langsmith.RunQueryParams{
+				IsRoot:    langsmith.F(true),
+				Limit:     langsmith.F(int64(100)),
+				StartTime: langsmith.F(startTime),
+			}
+			if rawFilter != "" {
+				params.Filter = langsmith.F(rawFilter)
+			}
+			if sel := buildRunSelect(true, false); sel != nil {
+				params.Select = langsmith.F(sel)
+			}
+
+			runs, err := queryRunsAuto(ctx, c, params, buildRunSelectV2(true, false), sessionID, math.MaxInt32, 0)
+			if err != nil {
+				ExitErrorf("querying runs: %v", err)
+			}
+
+			// Group runs by thread_id
 			threadsMap := make(map[string][]map[string]any)
-			cursor := ""
-			for {
-				if cursor != "" {
-					params.Cursor = langsmith.F(cursor)
+			for _, run := range runs {
+				tid := run.ThreadID
+				if tid != "" {
+					m := extract.ExtractRun(run, true, true, false)
+					threadsMap[tid] = append(threadsMap[tid], m)
 				}
-				resp, err := c.SDK.Runs.Query(ctx, params)
-				if err != nil {
-					ExitErrorf("querying runs: %v", err)
-				}
-				for _, run := range resp.Runs {
-					tid := run.ThreadID
-					if tid != "" {
-						m := extract.ExtractRun(run, true, true, false)
-						threadsMap[tid] = append(threadsMap[tid], m)
-					}
-				}
-				if resp.Cursors.Next == "" {
-					break
-				}
-				cursor = resp.Cursors.Next
 			}
 
 			// Build thread summaries
@@ -235,16 +230,15 @@ func newThreadGetCmd() *cobra.Command {
 				queryLimit = limit
 			}
 			params := langsmith.RunQueryParams{
-				Session: langsmith.F([]string{sessionID}),
-				IsRoot:  langsmith.F(true),
-				Filter:  langsmith.F(filterDSL),
-				Limit:   langsmith.F(int64(queryLimit)),
+				IsRoot: langsmith.F(true),
+				Filter: langsmith.F(filterDSL),
+				Limit:  langsmith.F(int64(queryLimit)),
 			}
 			if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
 				params.Select = langsmith.F(sel)
 			}
 
-			runs, err := queryRuns(ctx, c, params, "", queryLimit, 0)
+			runs, err := queryRunsAuto(ctx, c, params, buildRunSelectV2(includeIO, includeFeedback), sessionID, queryLimit, 0)
 			if err != nil {
 				ExitErrorf("querying thread runs: %v", err)
 			}
@@ -313,6 +307,8 @@ Examples:
 
 			c := MustGetClient()
 			ctx := context.Background()
+
+			requireV2Feature(ctx, c, "thread messages")
 
 			sessionID, err := c.ResolveSessionID(ctx, project)
 			if err != nil {

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -77,7 +77,7 @@ func newTraceListCmd() *cobra.Command {
 			if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
 				params.Select = langsmith.F(sel)
 			}
-			runs, err := queryRuns(ctx, c, params, sessionID, ff.Limit, ff.MinTokens)
+			runs, err := queryRunsAuto(ctx, c, params, buildRunSelectV2(includeIO, includeFeedback), sessionID, ff.Limit, ff.MinTokens)
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -96,10 +96,17 @@ func newTraceListCmd() *cobra.Command {
 			if fmt_ == "pretty" {
 				if showHierarchy {
 					for _, run := range runs {
-						allRuns, err := queryRuns(ctx, c, langsmith.RunQueryParams{
+						childParams := langsmith.RunQueryParams{
 							Trace: langsmith.F(run.TraceID),
 							Order: langsmith.F(langsmith.RunQueryParamsOrderAsc),
-						}, sessionID, 1000, 0)
+						}
+						// Bound v2's min_start_time to the trace's own start
+						// (the root run's) so older traces aren't clipped by the
+						// v2 default 1-day window; children start at or after it.
+						if !run.StartTime.IsZero() {
+							childParams.StartTime = langsmith.F(run.StartTime)
+						}
+						allRuns, err := queryRunsAuto(ctx, c, childParams, buildRunSelectV2(includeIO, includeFeedback), sessionID, 1000, 0)
 						if err != nil {
 							ExitErrorf("%v", err)
 						}
@@ -111,16 +118,21 @@ func newTraceListCmd() *cobra.Command {
 				}
 			} else {
 				if showHierarchy {
-					childParams := langsmith.RunQueryParams{
-						Order: langsmith.F(langsmith.RunQueryParamsOrderAsc),
-					}
-					if sel := buildRunSelect(includeIO, includeFeedback); sel != nil {
-						childParams.Select = langsmith.F(sel)
-					}
+					baseSelect := buildRunSelect(includeIO, includeFeedback)
+					v2Select := buildRunSelectV2(includeIO, includeFeedback)
 					var result []map[string]any
 					for _, run := range runs {
-						childParams.Trace = langsmith.F(run.TraceID)
-						allRuns, err := queryRuns(ctx, c, childParams, sessionID, 1000, 0)
+						childParams := langsmith.RunQueryParams{
+							Trace: langsmith.F(run.TraceID),
+							Order: langsmith.F(langsmith.RunQueryParamsOrderAsc),
+						}
+						if baseSelect != nil {
+							childParams.Select = langsmith.F(baseSelect)
+						}
+						if !run.StartTime.IsZero() {
+							childParams.StartTime = langsmith.F(run.StartTime)
+						}
+						allRuns, err := queryRunsAuto(ctx, c, childParams, v2Select, sessionID, 1000, 0)
 						if err != nil {
 							ExitErrorf("%v", err)
 						}
@@ -198,7 +210,7 @@ func newTraceGetCmd() *cobra.Command {
 				params.Select = langsmith.F(sel)
 			}
 
-			runs, err := queryRuns(ctx, c, params, sessionID, 1000, 0)
+			runs, err := queryRunsAuto(ctx, c, params, buildRunSelectV2(includeIO, includeFeedback), sessionID, 1000, 0)
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -275,7 +287,8 @@ func newTraceExportCmd() *cobra.Command {
 			if sel != nil {
 				params.Select = langsmith.F(sel)
 			}
-			rootRuns, err := queryRuns(ctx, c, params, sessionID, ff.Limit, ff.MinTokens)
+			v2Select := buildRunSelectV2(includeIO, includeFeedback)
+			rootRuns, err := queryRunsAuto(ctx, c, params, v2Select, sessionID, ff.Limit, ff.MinTokens)
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -291,7 +304,10 @@ func newTraceExportCmd() *cobra.Command {
 				if sel != nil {
 					childParams.Select = langsmith.F(sel)
 				}
-				allRuns, err := queryRuns(ctx, c, childParams, sessionID, 1000, 0)
+				if !root.StartTime.IsZero() {
+					childParams.StartTime = langsmith.F(root.StartTime)
+				}
+				allRuns, err := queryRunsAuto(ctx, c, childParams, v2Select, sessionID, 1000, 0)
 				if err != nil {
 					ExitErrorf("%v", err)
 				}

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -100,9 +100,8 @@ func newTraceListCmd() *cobra.Command {
 							Trace: langsmith.F(run.TraceID),
 							Order: langsmith.F(langsmith.RunQueryParamsOrderAsc),
 						}
-						// Bound v2's min_start_time to the trace's own start
-						// (the root run's) so older traces aren't clipped by the
-						// v2 default 1-day window; children start at or after it.
+						// Bound v2's min_start_time to the root's start so older
+						// traces aren't clipped by v2's default 1-day window.
 						if !run.StartTime.IsZero() {
 							childParams.StartTime = langsmith.F(run.StartTime)
 						}


### PR DESCRIPTION
## Description

Use /v2 runs, trace and thread endpoints for any instances that support them. Determined from `GET /info`, cached once per invocation:

- **Cloud**→ **v2**
- **Self-hosted `>= 0.16`** → **v2**
- **Self-hosted `< 0.16`** → **v1**

Matches the [v1→v2 migration guide](https://docs.langchain.com/langsmith/smithdb-sdk-migration) (self-hosted v2 requires `>= 0.16`). Follows the spirit of langchain-ai/langsmith-sdk#3257 but keys off deployment/version rather than the `sdb_query_enabled` instance flag.

## Changes

- **`client.UseV2API`** — reads `/info`, decides v1/v2, caches the resul
- **`queryRunsAuto` + `toV2Params`** — a single auto-selecting run-query path. Canonical v1 `RunQueryParams` translate to v2 (`Trace`→`TraceID`, `Error`→`HasError`, `StartTime`→`MinStartTime`, `EndTime`→`MaxStartTime`, `ID`→`IDs`, `Limit`→`PageSize`; v1 `Order` has no v2 equivalent and is dropped — v2 returns newest-first).
- **All run-query call sites routed through it**: `run list/get/export`, `trace list/get/export` (incl. `--show-hierarchy`), `thread list/get`, and the `trace messages` root-preview lookup. This is required so these commands work on **SmithDB-only** deployments, where the v1 `POST /runs/query` returns HTTP 501. Trace-scoped child queries propagate `min_start_time` from the root run so older traces aren't clipped by the v2 default 1-day window.
- **v2-only message features gated** via `requireV2Feature`.
- BREAKING: Removed the `--version` flag and the unused v2 `FilterFlags` plumbing.

## Testing

- [x] End-to-end against **SaaS** (dual mode, `version=dev`): `run list/get`, `trace list/get`, `thread list`, `trace messages` all work over v2.
- [x] Against local mocks simulating **old self-hosted `v0.15` (v1-only)** — `run list` uses v1, `trace messages` returns the gate error — and **SmithDB-only `v0.16`** (v1 `/runs/query` → 501) — `run list` correctly uses v2 and `trace messages` works.