### PR TITLE
fix: use /api/v2 for v2 runs API on single-origin deployments

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -32,6 +32,11 @@ type Client struct {
 	// Cached v2-API decision (see UseV2API), resolved once per invocation
 	// from GET /info.
 	cachedUseV2API *bool
+
+	// singleOrigin is true when the endpoint targets a single-origin deployment
+	// (API namespaced under "/api", the self-hosted form). It selects the v2 base
+	// path: "/api/v2" on single-origin, root "/v2" on a dedicated API origin (SaaS).
+	singleOrigin bool
 }
 
 // Options controls LangSmith client authentication and routing.
@@ -41,6 +46,10 @@ type Options struct {
 	APIURL           string
 	WorkspaceID      string
 	ProfileName      string
+	// SingleOrigin selects the v2 API base path (see Client.singleOrigin). Callers
+	// must derive it from the RAW endpoint via EndpointIsSingleOrigin before any
+	// NormalizeURL call, which strips the "/api/v1" suffix the detection relies on.
+	SingleOrigin bool
 }
 
 // NormalizeURL strips a trailing "/api/v1" suffix (with or without a trailing
@@ -51,12 +60,26 @@ func NormalizeURL(apiURL string) string {
 	return strings.TrimSuffix(u, "/api/v1")
 }
 
+// EndpointIsSingleOrigin reports whether the RAW endpoint targets a single-origin
+// deployment, where one host serves both the frontend and the API and the API is
+// namespaced under "/api" (e.g. "https://host/api/v1", the documented self-hosted
+// form). On such deployments smith-go's v2 API is reached at "/api/v2"; on a
+// dedicated API origin (SaaS) it is at root "/v2". Mirrors the frontend's
+// single-origin branch (smith-frontend constants.tsx).
+//
+// Call this on the RAW endpoint, before NormalizeURL strips the "/api/v1" suffix.
+func EndpointIsSingleOrigin(apiURL string) bool {
+	u := strings.TrimRight(apiURL, "/")
+	return strings.HasSuffix(u, "/api/v1") || strings.HasSuffix(u, "/api")
+}
+
 // New creates a new Client.
 func New(apiKey, apiURL string) *Client {
 	return NewWithOptions(Options{
-		APIKey:      apiKey,
-		APIURL:      apiURL,
-		WorkspaceID: os.Getenv("LANGSMITH_WORKSPACE_ID"),
+		APIKey:       apiKey,
+		APIURL:       apiURL,
+		WorkspaceID:  os.Getenv("LANGSMITH_WORKSPACE_ID"),
+		SingleOrigin: EndpointIsSingleOrigin(apiURL),
 	})
 }
 
@@ -93,7 +116,34 @@ func NewWithOptions(options Options) *Client {
 		apiURL:           normalized,
 		workspaceID:      options.WorkspaceID,
 		sessionCache:     make(map[string]string),
+		singleOrigin:     options.SingleOrigin,
 	}
+}
+
+// v2PathPrefix is the base path for the v2 (SmithDB) API: "/api/v2" on a
+// single-origin deployment, root "/v2" on a dedicated API origin (SaaS).
+func (c *Client) v2PathPrefix() string {
+	if c.singleOrigin {
+		return "/api/v2"
+	}
+	return "/v2"
+}
+
+// V2Path builds a raw-request path under the v2 API base (see v2PathPrefix).
+// suffix must begin with "/", e.g. V2Path("/traces/messages").
+func (c *Client) V2Path(suffix string) string {
+	return c.v2PathPrefix() + suffix
+}
+
+// V2RequestOptions returns per-call SDK options so the SDK's relative v2 paths
+// (e.g. "v2/runs/query") resolve under the right base. On single-origin the base
+// is shifted to "<apiURL>/api/" so "v2/…" becomes "/api/v2/…"; on SaaS no override
+// is needed (the default base resolves "v2/…" to root "/v2/…").
+func (c *Client) V2RequestOptions() []option.RequestOption {
+	if c.singleOrigin {
+		return []option.RequestOption{option.WithBaseURL(c.apiURL + "/api/")}
+	}
+	return nil
 }
 
 // ResolveSessionID resolves a project name to its session UUID, with caching.
@@ -134,13 +184,14 @@ func (c *Client) UseV2API(ctx context.Context) (bool, error) {
 	return v, nil
 }
 
-// useV2API decides whether to use the v2 API from the /info version. Cloud reports
-// a non-release version (e.g. "dev") → v2; self-hosted reports a semver, v2 at
-// >= 0.16 else v1.
+// useV2API decides whether to use the v2 API from the /info version. Both SaaS
+// and self-hosted report a real semver (currently 0.16.x), so the rule is
+// "major != 0, or minor >= 16 → v2, else v1". A non-parseable version (e.g. a
+// local/dev build reporting "dev" or a bare git sha) is treated as v2.
 func useV2API(version string) bool {
 	major, minor, ok := parseReleaseVersion(version)
 	if !ok {
-		return true // Cloud / non-release version
+		return true // non-release version (local/dev build)
 	}
 	if major != 0 {
 		return true

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -33,9 +33,7 @@ type Client struct {
 	// from GET /info.
 	cachedUseV2API *bool
 
-	// singleOrigin is true when the endpoint targets a single-origin deployment
-	// (API namespaced under "/api", the self-hosted form). It selects the v2 base
-	// path: "/api/v2" on single-origin, root "/v2" on a dedicated API origin (SaaS).
+	// singleOrigin selects the v2 base path: "/api/v2" if set, else "/v2".
 	singleOrigin bool
 }
 
@@ -46,9 +44,8 @@ type Options struct {
 	APIURL           string
 	WorkspaceID      string
 	ProfileName      string
-	// SingleOrigin selects the v2 API base path (see Client.singleOrigin). Callers
-	// must derive it from the RAW endpoint via EndpointIsSingleOrigin before any
-	// NormalizeURL call, which strips the "/api/v1" suffix the detection relies on.
+	// SingleOrigin must come from the raw endpoint (EndpointIsSingleOrigin), before
+	// NormalizeURL strips the "/api/v1" suffix.
 	SingleOrigin bool
 }
 
@@ -60,14 +57,8 @@ func NormalizeURL(apiURL string) string {
 	return strings.TrimSuffix(u, "/api/v1")
 }
 
-// EndpointIsSingleOrigin reports whether the RAW endpoint targets a single-origin
-// deployment, where one host serves both the frontend and the API and the API is
-// namespaced under "/api" (e.g. "https://host/api/v1", the documented self-hosted
-// form). On such deployments smith-go's v2 API is reached at "/api/v2"; on a
-// dedicated API origin (SaaS) it is at root "/v2". Mirrors the frontend's
-// single-origin branch (smith-frontend constants.tsx).
-//
-// Call this on the RAW endpoint, before NormalizeURL strips the "/api/v1" suffix.
+// EndpointIsSingleOrigin reports whether the raw endpoint is a single-origin
+// deployment (API under "/api", e.g. ".../api/v1"). Call before NormalizeURL.
 func EndpointIsSingleOrigin(apiURL string) bool {
 	u := strings.TrimRight(apiURL, "/")
 	return strings.HasSuffix(u, "/api/v1") || strings.HasSuffix(u, "/api")
@@ -120,8 +111,7 @@ func NewWithOptions(options Options) *Client {
 	}
 }
 
-// v2PathPrefix is the base path for the v2 (SmithDB) API: "/api/v2" on a
-// single-origin deployment, root "/v2" on a dedicated API origin (SaaS).
+// v2PathPrefix is the v2 API base path: "/api/v2" on single-origin, else "/v2".
 func (c *Client) v2PathPrefix() string {
 	if c.singleOrigin {
 		return "/api/v2"
@@ -129,16 +119,13 @@ func (c *Client) v2PathPrefix() string {
 	return "/v2"
 }
 
-// V2Path builds a raw-request path under the v2 API base (see v2PathPrefix).
-// suffix must begin with "/", e.g. V2Path("/traces/messages").
+// V2Path returns suffix under the v2 API base (suffix must start with "/").
 func (c *Client) V2Path(suffix string) string {
 	return c.v2PathPrefix() + suffix
 }
 
-// V2RequestOptions returns per-call SDK options so the SDK's relative v2 paths
-// (e.g. "v2/runs/query") resolve under the right base. On single-origin the base
-// is shifted to "<apiURL>/api/" so "v2/…" becomes "/api/v2/…"; on SaaS no override
-// is needed (the default base resolves "v2/…" to root "/v2/…").
+// V2RequestOptions shifts the SDK base to "<apiURL>/api/" on single-origin so the
+// SDK's relative "v2/…" paths resolve to "/api/v2/…"; nil (default base) otherwise.
 func (c *Client) V2RequestOptions() []option.RequestOption {
 	if c.singleOrigin {
 		return []option.RequestOption{option.WithBaseURL(c.apiURL + "/api/")}
@@ -184,14 +171,12 @@ func (c *Client) UseV2API(ctx context.Context) (bool, error) {
 	return v, nil
 }
 
-// useV2API decides whether to use the v2 API from the /info version. Both SaaS
-// and self-hosted report a real semver (currently 0.16.x), so the rule is
-// "major != 0, or minor >= 16 → v2, else v1". A non-parseable version (e.g. a
-// local/dev build reporting "dev" or a bare git sha) is treated as v2.
+// useV2API decides v1 vs v2 from the /info version: major != 0 or minor >= 16 → v2.
+// Both SaaS and self-hosted report a real semver; an unparseable version → v2.
 func useV2API(version string) bool {
 	major, minor, ok := parseReleaseVersion(version)
 	if !ok {
-		return true // non-release version (local/dev build)
+		return true // unparseable version
 	}
 	if major != 0 {
 		return true

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -758,19 +758,17 @@ func TestUseV2API(t *testing.T) {
 	}
 }
 
-// ---------- v2 API base path (single-origin vs dedicated API origin) ----------
+// ---------- v2 API base path ----------
 
 func TestEndpointIsSingleOrigin(t *testing.T) {
 	cases := []struct {
 		endpoint string
 		want     bool
 	}{
-		// Single-origin (self-hosted): API namespaced under /api.
 		{"https://host/api/v1", true},
 		{"https://host/api/v1/", true},
 		{"https://host/api", true},
 		{"https://host/base-path/api/v1", true},
-		// Dedicated API origin (SaaS) or default.
 		{"https://api.smith.langchain.com", false},
 		{"https://host", false},
 		{"", false},
@@ -800,8 +798,7 @@ func TestV2Path(t *testing.T) {
 	}
 }
 
-// TestQueryV2PathResolution verifies the SDK's relative v2 path resolves to the
-// right base on each topology: root /v2 on SaaS, /api/v2 on single-origin.
+// TestQueryV2PathResolution checks the SDK v2 path: /v2 on SaaS, /api/v2 on single-origin.
 func TestQueryV2PathResolution(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	langsmith "github.com/langchain-ai/langsmith-go"
 )
 
 // ---------- NormalizeURL ----------
@@ -753,5 +755,81 @@ func TestUseV2API(t *testing.T) {
 		if got := useV2API(tc.version); got != tc.want {
 			t.Errorf("useV2API(%q) = %v, want %v", tc.version, got, tc.want)
 		}
+	}
+}
+
+// ---------- v2 API base path (single-origin vs dedicated API origin) ----------
+
+func TestEndpointIsSingleOrigin(t *testing.T) {
+	cases := []struct {
+		endpoint string
+		want     bool
+	}{
+		// Single-origin (self-hosted): API namespaced under /api.
+		{"https://host/api/v1", true},
+		{"https://host/api/v1/", true},
+		{"https://host/api", true},
+		{"https://host/base-path/api/v1", true},
+		// Dedicated API origin (SaaS) or default.
+		{"https://api.smith.langchain.com", false},
+		{"https://host", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := EndpointIsSingleOrigin(tc.endpoint); got != tc.want {
+			t.Errorf("EndpointIsSingleOrigin(%q) = %v, want %v", tc.endpoint, got, tc.want)
+		}
+	}
+}
+
+func TestV2Path(t *testing.T) {
+	saas := New("key", "https://api.smith.langchain.com")
+	if got := saas.V2Path("/traces/messages"); got != "/v2/traces/messages" {
+		t.Errorf("SaaS V2Path = %q, want /v2/traces/messages", got)
+	}
+	if n := len(saas.V2RequestOptions()); n != 0 {
+		t.Errorf("SaaS V2RequestOptions len = %d, want 0", n)
+	}
+
+	sh := New("key", "https://host/api/v1")
+	if got := sh.V2Path("/traces/messages"); got != "/api/v2/traces/messages" {
+		t.Errorf("self-hosted V2Path = %q, want /api/v2/traces/messages", got)
+	}
+	if n := len(sh.V2RequestOptions()); n != 1 {
+		t.Errorf("self-hosted V2RequestOptions len = %d, want 1", n)
+	}
+}
+
+// TestQueryV2PathResolution verifies the SDK's relative v2 path resolves to the
+// right base on each topology: root /v2 on SaaS, /api/v2 on single-origin.
+func TestQueryV2PathResolution(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint func(base string) string
+		wantPath string
+	}{
+		{"saas root", func(b string) string { return b }, "/v2/runs/query"},
+		{"single-origin", func(b string) string { return b + "/api/v1" }, "/api/v2/runs/query"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"items":[],"next_cursor":""}`))
+			}))
+			defer ts.Close()
+
+			c := New("key", tc.endpoint(ts.URL))
+			iter := c.SDK.Runs.QueryV2AutoPaging(context.Background(), langsmith.RunQueryV2Params{}, c.V2RequestOptions()...)
+			iter.Next()
+			if err := iter.Err(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotPath != tc.wantPath {
+				t.Errorf("v2 request path = %q, want %q", gotPath, tc.wantPath)
+			}
+		})
 	}
 }

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -88,7 +88,7 @@ func queryRunsV2(ctx context.Context, c *client.Client, params langsmith.RunQuer
 
 	var allRuns []langsmith.RunSchema
 
-	iter := c.SDK.Runs.QueryV2AutoPaging(ctx, params)
+	iter := c.SDK.Runs.QueryV2AutoPaging(ctx, params, c.V2RequestOptions()...)
 	for iter.Next() {
 		if len(allRuns) >= limit {
 			break

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -184,9 +184,7 @@ func loginProfileName(cfg *lsconfig.Config) string {
 	return "default"
 }
 
-// loginRawAPIURL resolves the effective endpoint (profile → env → flag) without
-// normalizing, so callers can detect single-origin before the "/api/v1" suffix
-// is stripped.
+// loginRawAPIURL resolves the endpoint (profile → env → flag) without normalizing.
 func loginRawAPIURL(cfg *lsconfig.Config, profileName string) string {
 	apiURL := lsconfig.DefaultAPIURL
 	if profile, ok := cfg.Profiles[profileName]; ok && profile.APIURL != "" {

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -135,6 +135,7 @@ func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspa
 	profile := cfg.Profiles[profileName]
 	if profile.APIURL == "" || flagAPIURL != "" || strings.TrimSpace(profile.APIURL) != apiURL {
 		profile.APIURL = apiURL
+		profile.SingleOrigin = client.EndpointIsSingleOrigin(loginRawAPIURL(cfg, profileName))
 	}
 	if workspaceID == "" && promptWorkspace {
 		workspaceID, err = promptWorkspaceSelection(cmd, apiURL, token.AccessToken)
@@ -183,7 +184,10 @@ func loginProfileName(cfg *lsconfig.Config) string {
 	return "default"
 }
 
-func loginAPIURL(cfg *lsconfig.Config, profileName string) string {
+// loginRawAPIURL resolves the effective endpoint (profile → env → flag) without
+// normalizing, so callers can detect single-origin before the "/api/v1" suffix
+// is stripped.
+func loginRawAPIURL(cfg *lsconfig.Config, profileName string) string {
 	apiURL := lsconfig.DefaultAPIURL
 	if profile, ok := cfg.Profiles[profileName]; ok && profile.APIURL != "" {
 		apiURL = profile.APIURL
@@ -194,7 +198,11 @@ func loginAPIURL(cfg *lsconfig.Config, profileName string) string {
 	if flagAPIURL != "" {
 		apiURL = flagAPIURL
 	}
-	return client.NormalizeURL(apiURL)
+	return apiURL
+}
+
+func loginAPIURL(cfg *lsconfig.Config, profileName string) string {
+	return client.NormalizeURL(loginRawAPIURL(cfg, profileName))
 }
 
 func validateProfileName(name string) error {

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -186,7 +186,7 @@ Examples:
 				body["page_size"] = pageSize
 
 				var result map[string]any
-				if err := c.RawPost(ctx, "/v2/traces/messages", body, &result); err != nil {
+				if err := c.RawPost(ctx, c.V2Path("/traces/messages"), body, &result); err != nil {
 					ExitErrorf("%v", err)
 				}
 
@@ -234,7 +234,7 @@ Examples:
 				body["page_size"] = pageSize
 
 				var result map[string]any
-				if err := c.RawPost(ctx, "/v2/traces/messages", body, &result); err != nil {
+				if err := c.RawPost(ctx, c.V2Path("/traces/messages"), body, &result); err != nil {
 					ExitErrorf("%v", err)
 				}
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -164,14 +164,19 @@ func resolveClientOptions(refreshOAuth bool) (client.Options, error) {
 	if hasProfile {
 		if profile.APIURL != "" {
 			opts.APIURL = profile.APIURL
+			opts.SingleOrigin = profile.SingleOrigin
 		}
 		opts.WorkspaceID = profile.WorkspaceID
 	}
 
+	// SingleOrigin must be derived from the RAW endpoint (env/flag) before
+	// NormalizeURL strips the "/api/v1" suffix the detection keys on.
 	if v := os.Getenv("LANGSMITH_ENDPOINT"); v != "" {
+		opts.SingleOrigin = client.EndpointIsSingleOrigin(v)
 		opts.APIURL = client.NormalizeURL(v)
 	}
 	if flagAPIURL != "" {
+		opts.SingleOrigin = client.EndpointIsSingleOrigin(flagAPIURL)
 		opts.APIURL = client.NormalizeURL(flagAPIURL)
 	}
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -169,8 +169,6 @@ func resolveClientOptions(refreshOAuth bool) (client.Options, error) {
 		opts.WorkspaceID = profile.WorkspaceID
 	}
 
-	// SingleOrigin must be derived from the RAW endpoint (env/flag) before
-	// NormalizeURL strips the "/api/v1" suffix the detection keys on.
 	if v := os.Getenv("LANGSMITH_ENDPOINT"); v != "" {
 		opts.SingleOrigin = client.EndpointIsSingleOrigin(v)
 		opts.APIURL = client.NormalizeURL(v)

--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -326,7 +326,7 @@ Examples:
 				q.Set("trace_id", traceID)
 			}
 
-			path := fmt.Sprintf("/v2/threads/%s/messages?%s", url.PathEscape(threadID), q.Encode())
+			path := fmt.Sprintf("%s?%s", c.V2Path("/threads/"+url.PathEscape(threadID)+"/messages"), q.Encode())
 
 			extraHeaders := http.Header{"Accept": {"text/event-stream"}}
 			_, _, _, body, err := c.RawDo(ctx, http.MethodGet, path, nil, extraHeaders)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,11 @@ type Profile struct {
 	APIURL      string `json:"api_url,omitempty"`
 	WorkspaceID string `json:"workspace_id,omitempty"`
 	OAuth       OAuth  `json:"oauth,omitempty"`
+	// SingleOrigin records whether the endpoint this profile was created with was a
+	// single-origin deployment (API under "/api"). APIURL is stored normalized, so
+	// this is captured at creation from the raw endpoint. Selects the v2 API base
+	// path; profiles predating this field default to false (dedicated API origin).
+	SingleOrigin bool `json:"single_origin,omitempty"`
 }
 
 // OAuth stores OAuth tokens written by `langsmith login`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,10 +20,8 @@ type Profile struct {
 	APIURL      string `json:"api_url,omitempty"`
 	WorkspaceID string `json:"workspace_id,omitempty"`
 	OAuth       OAuth  `json:"oauth,omitempty"`
-	// SingleOrigin records whether the endpoint this profile was created with was a
-	// single-origin deployment (API under "/api"). APIURL is stored normalized, so
-	// this is captured at creation from the raw endpoint. Selects the v2 API base
-	// path; profiles predating this field default to false (dedicated API origin).
+	// SingleOrigin selects the v2 API base path; captured at login from the raw
+	// endpoint (APIURL is stored normalized). Absent in older profiles → false.
 	SingleOrigin bool `json:"single_origin,omitempty"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,13 +16,11 @@ const (
 
 // Profile represents one named LangSmith CLI profile.
 type Profile struct {
-	APIKey      string `json:"api_key,omitempty"`
-	APIURL      string `json:"api_url,omitempty"`
-	WorkspaceID string `json:"workspace_id,omitempty"`
-	OAuth       OAuth  `json:"oauth,omitempty"`
-	// SingleOrigin selects the v2 API base path; captured at login from the raw
-	// endpoint (APIURL is stored normalized). Absent in older profiles → false.
-	SingleOrigin bool `json:"single_origin,omitempty"`
+	APIKey       string `json:"api_key,omitempty"`
+	APIURL       string `json:"api_url,omitempty"`
+	WorkspaceID  string `json:"workspace_id,omitempty"`
+	OAuth        OAuth  `json:"oauth,omitempty"`
+	SingleOrigin bool   `json:"single_origin,omitempty"`
 }
 
 // OAuth stores OAuth tokens written by `langsmith login`.


### PR DESCRIPTION
The v2 (SmithDB) runs API is served at bare root /v2 on SaaS (a dedicated API origin) but at /api/v2 on self-hosted single-origin, where the frontend owns "/" and the API is namespaced under /api. The CLI (and the go SDK's QueryV2) hardcoded root /v2, so v2 queries hit the frontend and 405'd on self-hosted while working on SaaS.

Detect single-origin from the raw endpoint (the "/api/v1" suffix that NormalizeURL strips) and select the v2 base accordingly: /api/v2 on single-origin, root /v2 otherwise. This mirrors smith-frontend's constants.tsx (singleOrigin ? /api/v2 : /v2).

Verified end-to-end: self-hosted now returns runs (was 405); SaaS dev unchanged.