### PR TITLE
feat(custom apps): apps init dir, source archive push/pull, delete by name [LSDK-400, LSDK-401]

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -176,6 +176,16 @@ func leadingDigits(s string) string {
 	return s[:i]
 }
 
+// CustomAppRequest is the body of custom-app create (POST) and update (PATCH).
+// Unset pointer fields are omitted, leaving the server value untouched.
+type CustomAppRequest struct {
+	Name          *string           `json:"name,omitempty"`
+	Description   *string           `json:"description,omitempty"`
+	Files         map[string]string `json:"files,omitempty"`
+	Entrypoint    *string           `json:"entrypoint,omitempty"`
+	SourceArchive *string           `json:"source_archive,omitempty"`
+}
+
 // --- Raw HTTP helpers for endpoints not covered by the SDK ---
 
 // RawGet performs a GET request to the LangSmith API.
@@ -196,6 +206,23 @@ func (c *Client) RawPatch(ctx context.Context, path string, body any, result any
 // RawDelete performs a DELETE request to the LangSmith API.
 func (c *Client) RawDelete(ctx context.Context, path string, result any) error {
 	return c.rawRequest(ctx, http.MethodDelete, path, nil, result)
+}
+
+// FetchCustomAppSource returns the stored .tar.gz bytes for a custom app.
+// The response is binary, so it bypasses the JSON-decoding raw helpers.
+func (c *Client) FetchCustomAppSource(ctx context.Context, appID string) ([]byte, error) {
+	path := "/v1/platform/custom-apps/" + url.PathEscape(appID) + "/source"
+	resp, err := c.doHTTP(ctx, http.MethodGet, path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.statusCode >= 400 {
+		return nil, &httpError{statusCode: resp.statusCode, body: resp.body}
+	}
+	if len(resp.body) == 0 {
+		return nil, fmt.Errorf("custom app source response was empty")
+	}
+	return resp.body, nil
 }
 
 // httpResponse holds the parsed result of a raw HTTP call.
@@ -228,6 +255,11 @@ func IsConflict(err error) bool {
 func IsForbidden(err error) bool {
 	var httpErr *httpError
 	return errors.As(err, &httpErr) && httpErr.statusCode == http.StatusForbidden
+}
+
+func IsBadRequest(err error) bool {
+	var httpErr *httpError
+	return errors.As(err, &httpErr) && httpErr.statusCode == http.StatusBadRequest
 }
 
 type httpErrorBody struct {

--- a/internal/cmd/apps.go
+++ b/internal/cmd/apps.go
@@ -71,15 +71,18 @@ Examples:
   langsmith apps init --name my-queue-app --template annotation-queue
   langsmith apps dev
   langsmith apps push
+  langsmith apps pull my-app
   langsmith apps list
   langsmith apps delete <app-id> --yes
 
-"init" creates a new directory named after --name. Except init/list/delete,
-these act on the current directory — cd into your app's directory first.`,
+"init" and "pull" create a new directory named after the app. Except
+init/pull/list/delete, these act on the current directory — cd into your
+app's directory first.`,
 	}
 	cmd.AddCommand(newAppsInitCmd())
 	cmd.AddCommand(newAppsDevCmd())
 	cmd.AddCommand(newAppsPushCmd())
+	cmd.AddCommand(newAppsPullCmd())
 	cmd.AddCommand(newAppsListCmd())
 	cmd.AddCommand(newAppsDeleteCmd())
 	return cmd

--- a/internal/cmd/apps.go
+++ b/internal/cmd/apps.go
@@ -73,7 +73,7 @@ Examples:
   langsmith apps push
   langsmith apps pull my-app
   langsmith apps list
-  langsmith apps delete <app-id> --yes
+  langsmith apps delete my-app --yes
 
 "init" and "pull" create a new directory named after the app. Except
 init/pull/list/delete, these act on the current directory — cd into your

--- a/internal/cmd/apps.go
+++ b/internal/cmd/apps.go
@@ -74,8 +74,8 @@ Examples:
   langsmith apps list
   langsmith apps delete <app-id> --yes
 
-Except list/delete, these act on the current directory — cd into your app's
-directory first.`,
+"init" creates a new directory named after --name. Except init/list/delete,
+these act on the current directory — cd into your app's directory first.`,
 	}
 	cmd.AddCommand(newAppsInitCmd())
 	cmd.AddCommand(newAppsDevCmd())

--- a/internal/cmd/apps_archive.go
+++ b/internal/cmd/apps_archive.go
@@ -1,0 +1,300 @@
+package cmd
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const appsMaxSourceRawBytes = 1 << 30
+
+// Backend cap on the decoded .tar.gz; var so tests can shrink it.
+var appsMaxSourceArchiveBytes int64 = 50 << 20
+
+// Never archived, whatever .gitignore says.
+var appsSourceDenyDirs = map[string]bool{
+	".git":          true,
+	"node_modules":  true,
+	"dist":          true,
+	"build":         true,
+	"out":           true,
+	"coverage":      true,
+	".next":         true,
+	".nuxt":         true,
+	".svelte-kit":   true,
+	".turbo":        true,
+	".cache":        true,
+	".parcel-cache": true,
+	"__pycache__":   true,
+	".venv":         true,
+	"venv":          true,
+}
+
+var appsSourceDenyFiles = map[string]bool{
+	".DS_Store":        true,
+	"Thumbs.db":        true,
+	".npmrc":           true,
+	".netrc":           true,
+	".pgpass":          true,
+	".htpasswd":        true,
+	"id_rsa":           true,
+	"id_dsa":           true,
+	"id_ecdsa":         true,
+	"id_ed25519":       true,
+	"credentials.json": true,
+	"secrets.json":     true,
+}
+
+var appsSourceDenySuffixes = []string{
+	".pem", ".key", ".p12", ".pfx", ".jks", ".keystore", ".ppk", ".local",
+}
+
+type sourceFile struct {
+	rel  string
+	size int64
+	mode fs.FileMode
+}
+
+func deniedSourceFile(base string) bool {
+	if appsSourceDenyFiles[base] || strings.HasPrefix(base, ".env") {
+		return true
+	}
+	lower := strings.ToLower(base)
+	for _, suffix := range appsSourceDenySuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// buildSourceArchive returns the base64 of a .tar.gz of root.
+func buildSourceArchive(root string) (string, error) {
+	files, err := collectSourceFiles(root)
+	if err != nil {
+		return "", err
+	}
+	if len(files) == 0 {
+		return "", nil
+	}
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, f := range files {
+		hdr := &tar.Header{
+			Name:     f.rel,
+			Mode:     int64(f.mode.Perm()),
+			Size:     f.size,
+			Typeflag: tar.TypeReg,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return "", fmt.Errorf("archiving %s: %w", f.rel, err)
+		}
+		data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(f.rel)))
+		if err != nil {
+			return "", fmt.Errorf("reading %s: %w", f.rel, err)
+		}
+		// Guard against a file changing size mid-walk.
+		if int64(len(data)) != f.size {
+			return "", fmt.Errorf("%s changed while archiving; try again", f.rel)
+		}
+		if _, err := tw.Write(data); err != nil {
+			return "", fmt.Errorf("archiving %s: %w", f.rel, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return "", fmt.Errorf("finalizing source archive: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return "", fmt.Errorf("compressing source archive: %w", err)
+	}
+
+	if int64(buf.Len()) > appsMaxSourceArchiveBytes {
+		return "", oversizeSourceArchiveError(int64(buf.Len()), files)
+	}
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}
+
+func collectSourceFiles(root string) ([]sourceFile, error) {
+	rules := loadGitignore(root)
+
+	var (
+		files []sourceFile
+		total int64
+	)
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		base := d.Name()
+
+		if d.IsDir() {
+			if appsSourceDenyDirs[base] || rules.ignored(rel, true) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		if deniedSourceFile(base) || rules.ignored(rel, false) {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", rel, err)
+		}
+		total += info.Size()
+		if total > appsMaxSourceRawBytes {
+			return fmt.Errorf("source directory exceeds %s of files; nothing was uploaded", formatArchiveBytes(appsMaxSourceRawBytes))
+		}
+		files = append(files, sourceFile{rel: rel, size: info.Size(), mode: info.Mode()})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].rel < files[j].rel })
+	return files, nil
+}
+
+func oversizeSourceArchiveError(compressed int64, files []sourceFile) error {
+	msg := fmt.Sprintf("source archive is %s compressed, over the %s limit",
+		formatArchiveBytes(compressed), formatArchiveBytes(appsMaxSourceArchiveBytes))
+	if top := biggestSourceContributors(files, 3); top != "" {
+		msg += "; biggest contributors: " + top
+	}
+	return fmt.Errorf("%s. Delete or .gitignore those paths, then push again", msg)
+}
+
+// biggestSourceContributors summarizes the heaviest top-level paths.
+func biggestSourceContributors(files []sourceFile, n int) string {
+	sizes := map[string]int64{}
+	for _, f := range files {
+		key := f.rel
+		if i := strings.Index(f.rel, "/"); i != -1 {
+			key = f.rel[:i] + "/"
+		}
+		sizes[key] += f.size
+	}
+	keys := make([]string, 0, len(sizes))
+	for k := range sizes {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if sizes[keys[i]] != sizes[keys[j]] {
+			return sizes[keys[i]] > sizes[keys[j]]
+		}
+		return keys[i] < keys[j]
+	})
+	if len(keys) > n {
+		keys = keys[:n]
+	}
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s (%s)", k, formatArchiveBytes(sizes[k])))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatArchiveBytes(b int64) string {
+	switch {
+	case b >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(b)/float64(1<<20))
+	case b >= 1<<10:
+		return fmt.Sprintf("%.1f KB", float64(b)/float64(1<<10))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}
+
+type gitignoreRule struct {
+	pattern  string
+	dirOnly  bool
+	negate   bool
+	anchored bool
+}
+
+type gitignoreRules []gitignoreRule
+
+// loadGitignore parses root/.gitignore; best-effort, never fatal.
+func loadGitignore(root string) gitignoreRules {
+	data, err := os.ReadFile(filepath.Join(root, ".gitignore"))
+	if err != nil {
+		return nil
+	}
+	var rules gitignoreRules
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		var r gitignoreRule
+		if strings.HasPrefix(line, "!") {
+			r.negate = true
+			line = line[1:]
+		}
+		if strings.HasSuffix(line, "/") {
+			r.dirOnly = true
+			line = strings.TrimSuffix(line, "/")
+		}
+		line = strings.TrimPrefix(line, "**/")
+		if strings.HasPrefix(line, "/") {
+			r.anchored = true
+			line = strings.TrimPrefix(line, "/")
+		}
+		if line == "" {
+			continue
+		}
+		r.pattern = line
+		rules = append(rules, r)
+	}
+	return rules
+}
+
+// ignored reports whether rel matches; last matching rule wins.
+func (rules gitignoreRules) ignored(rel string, isDir bool) bool {
+	result := false
+	for _, r := range rules {
+		if r.dirOnly && !isDir {
+			continue
+		}
+		if r.matches(rel) {
+			result = !r.negate
+		}
+	}
+	return result
+}
+
+func (r gitignoreRule) matches(rel string) bool {
+	if r.anchored || strings.Contains(r.pattern, "/") {
+		if ok, _ := path.Match(r.pattern, rel); ok {
+			return true
+		}
+		return strings.HasPrefix(rel, r.pattern+"/")
+	}
+	for _, segment := range strings.Split(rel, "/") {
+		if ok, _ := path.Match(r.pattern, segment); ok {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cmd/apps_archive_test.go
+++ b/internal/cmd/apps_archive_test.go
@@ -1,0 +1,254 @@
+package cmd
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func seedFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	path := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+// untarBase64 decodes a source_archive value into path → content.
+func untarBase64(t *testing.T, encoded string) map[string]string {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("source archive is not valid base64: %v", err)
+	}
+	if len(raw) < 2 || raw[0] != 0x1f || raw[1] != 0x8b {
+		t.Fatalf("source archive is missing gzip magic bytes, got % x", raw[:min(2, len(raw))])
+	}
+	gz, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer gz.Close()
+
+	out := map[string]string{}
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading tar: %v", err)
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatalf("reading tar entry %s: %v", hdr.Name, err)
+		}
+		out[hdr.Name] = string(data)
+	}
+	return out
+}
+
+func TestBuildSourceArchive_ExcludesDenylistedPathsEvenWhenGitignoreUnignoresThem(t *testing.T) {
+	dir := t.TempDir()
+	seedFile(t, dir, "src/App.tsx", "export default function App() {}")
+	seedFile(t, dir, "package.json", `{"name":"x"}`)
+	seedFile(t, dir, "node_modules/react/index.js", "module.exports = {}")
+	seedFile(t, dir, ".git/config", "[core]")
+	seedFile(t, dir, "dist/bundle.js", "built")
+	seedFile(t, dir, "build/out.js", "built")
+	seedFile(t, dir, ".env", "LANGSMITH_API_KEY=lsv2_secret")
+	seedFile(t, dir, ".env.production", "KEY=2")
+	seedFile(t, dir, "settings.local", "local")
+	seedFile(t, dir, "id_rsa", "PRIVATE KEY")
+	seedFile(t, dir, "certs/server.pem", "PRIVATE KEY")
+	seedFile(t, dir, "certs/server.key", "PRIVATE KEY")
+	seedFile(t, dir, ".npmrc", "//registry:_authToken=secret")
+	// Even an explicit un-ignore must not resurrect these.
+	seedFile(t, dir, ".gitignore", "!node_modules\n!.env\n!id_rsa\n")
+
+	encoded, err := buildSourceArchive(dir)
+	if err != nil {
+		t.Fatalf("buildSourceArchive: %v", err)
+	}
+	entries := untarBase64(t, encoded)
+
+	for _, want := range []string{"src/App.tsx", "package.json", ".gitignore"} {
+		if _, ok := entries[want]; !ok {
+			t.Errorf("expected %q in the archive, got %v", want, keysOf(entries))
+		}
+	}
+	for _, unwanted := range []string{
+		"node_modules/react/index.js",
+		".git/config",
+		"dist/bundle.js",
+		"build/out.js",
+		".env",
+		".env.production",
+		"settings.local",
+		"id_rsa",
+		"certs/server.pem",
+		"certs/server.key",
+		".npmrc",
+	} {
+		if _, ok := entries[unwanted]; ok {
+			t.Errorf("%q must never be archived", unwanted)
+		}
+	}
+	if got := entries["src/App.tsx"]; got != "export default function App() {}" {
+		t.Errorf("archived content mismatch: %q", got)
+	}
+}
+
+func TestBuildSourceArchive_HonorsGitignoreAsAdditionalExcludes(t *testing.T) {
+	dir := t.TempDir()
+	seedFile(t, dir, "src/App.tsx", "app")
+	seedFile(t, dir, "src/debug.log", "noise")
+	seedFile(t, dir, "keep.log", "kept")
+	seedFile(t, dir, "tmp/scratch.txt", "scratch")
+	seedFile(t, dir, "rootonly.txt", "root")
+	seedFile(t, dir, "nested/rootonly.txt", "nested")
+	seedFile(t, dir, "fixtures/big.bin", "data")
+	seedFile(t, dir, ".gitignore", "# comment\n\n*.log\n!keep.log\ntmp/\n/rootonly.txt\nfixtures\n")
+
+	encoded, err := buildSourceArchive(dir)
+	if err != nil {
+		t.Fatalf("buildSourceArchive: %v", err)
+	}
+	entries := untarBase64(t, encoded)
+
+	for _, want := range []string{"src/App.tsx", "keep.log", "nested/rootonly.txt"} {
+		if _, ok := entries[want]; !ok {
+			t.Errorf("expected %q in the archive, got %v", want, keysOf(entries))
+		}
+	}
+	for _, unwanted := range []string{"src/debug.log", "tmp/scratch.txt", "rootonly.txt", "fixtures/big.bin"} {
+		if _, ok := entries[unwanted]; ok {
+			t.Errorf("expected .gitignore to exclude %q, got %v", unwanted, keysOf(entries))
+		}
+	}
+}
+
+func TestBuildSourceArchive_NoGitignoreStillExcludesDenylist(t *testing.T) {
+	dir := t.TempDir()
+	seedFile(t, dir, "src/App.tsx", "app")
+	seedFile(t, dir, "node_modules/react/index.js", "dep")
+	seedFile(t, dir, ".env.local", "SECRET=1")
+
+	encoded, err := buildSourceArchive(dir)
+	if err != nil {
+		t.Fatalf("buildSourceArchive: %v", err)
+	}
+	entries := untarBase64(t, encoded)
+	if _, ok := entries["src/App.tsx"]; !ok {
+		t.Errorf("expected src/App.tsx, got %v", keysOf(entries))
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected only source files without a .gitignore, got %v", keysOf(entries))
+	}
+}
+
+func TestBuildSourceArchive_RejectsOversizeBeforeUploading(t *testing.T) {
+	dir := t.TempDir()
+	seedFile(t, dir, "src/App.tsx", "app")
+
+	// Incompressible bytes so the gzip output really exceeds the cap.
+	blob := make([]byte, 256*1024)
+	rng := rand.New(rand.NewSource(1))
+	if _, err := rng.Read(blob); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "assets"), 0o755); err != nil {
+		t.Fatalf("mkdir assets: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "assets", "blob.bin"), blob, 0o644); err != nil {
+		t.Fatalf("write blob: %v", err)
+	}
+
+	prev := appsMaxSourceArchiveBytes
+	appsMaxSourceArchiveBytes = 64 * 1024
+	t.Cleanup(func() { appsMaxSourceArchiveBytes = prev })
+
+	_, err := buildSourceArchive(dir)
+	if err == nil {
+		t.Fatal("expected an oversize archive to be rejected locally")
+	}
+	if !strings.Contains(err.Error(), "limit") || !strings.Contains(err.Error(), "assets/") {
+		t.Errorf("expected an actionable oversize error naming the bloat, got: %v", err)
+	}
+}
+
+func TestBuildSourceArchive_DefaultCapMatchesBackend(t *testing.T) {
+	if appsMaxSourceArchiveBytes != 50<<20 {
+		t.Errorf("expected the 50 MB backend cap, got %d", appsMaxSourceArchiveBytes)
+	}
+}
+
+func TestBuildSourceArchive_EmptyDirProducesNoArchive(t *testing.T) {
+	dir := t.TempDir()
+	seedFile(t, dir, "node_modules/react/index.js", "dep")
+
+	encoded, err := buildSourceArchive(dir)
+	if err != nil {
+		t.Fatalf("buildSourceArchive: %v", err)
+	}
+	if encoded != "" {
+		t.Errorf("expected no archive when nothing is archivable, got %d bytes", len(encoded))
+	}
+}
+
+func TestGitignoreRules_Matching(t *testing.T) {
+	rules := loadGitignoreFromString("*.log\n!keep.log\ntmp/\n/root.txt\nsrc/generated\n**/cache\n")
+	tests := []struct {
+		rel   string
+		isDir bool
+		want  bool
+	}{
+		{"a.log", false, true},
+		{"deep/a.log", false, true},
+		{"keep.log", false, false},
+		{"tmp", true, true},
+		{"tmp.txt", false, false},
+		{"root.txt", false, true},
+		{"nested/root.txt", false, false},
+		{"src/generated", true, true},
+		{"src/generated/x.ts", false, true},
+		{"any/where/cache", true, true},
+		{"src/App.tsx", false, false},
+	}
+	for _, tt := range tests {
+		if got := rules.ignored(tt.rel, tt.isDir); got != tt.want {
+			t.Errorf("ignored(%q, dir=%v) = %v, want %v", tt.rel, tt.isDir, got, tt.want)
+		}
+	}
+}
+
+func loadGitignoreFromString(contents string) gitignoreRules {
+	dir, err := os.MkdirTemp("", "gitignore")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(contents), 0o644); err != nil {
+		panic(err)
+	}
+	return loadGitignore(dir)
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/cmd/apps_crud_test.go
+++ b/internal/cmd/apps_crud_test.go
@@ -114,17 +114,56 @@ func TestAppsDelete_SkipsConfirmationWithYes(t *testing.T) {
 	}
 }
 
-func TestAppsDelete_RejectsNonUUID(t *testing.T) {
+func TestAppsDelete_ResolvesNameToID(t *testing.T) {
+	const id = "33333333-3333-3333-3333-333333333333"
+	var deletePath string
 	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Errorf("unexpected request for non-UUID id: %s %s", r.Method, r.URL.Path)
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/v1/platform/custom-apps":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]customApp{
+				{ID: "44444444-4444-4444-4444-444444444444", Name: "other"},
+				{ID: id, Name: "My App"},
+			})
+		case r.Method == "DELETE":
+			deletePath = r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	out := captureStdout(t, func() {
+		cmd := newAppsCmd()
+		cmd.SetArgs([]string{"delete", "My App", "--yes"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+	if deletePath != "/v1/platform/custom-apps/"+id {
+		t.Errorf("expected the name resolved to its ID before deleting, got %q", deletePath)
+	}
+	if !strings.Contains(out, `"name": "My App"`) {
+		t.Errorf("expected the resolved name in the output:\n%s", out)
+	}
+}
+
+func TestAppsDelete_RejectsUnknownName(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "DELETE" {
+			t.Error("delete should not run for an unknown name")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]customApp{{ID: "55555555-5555-5555-5555-555555555555", Name: "one"}})
 	})
 	defer setupTestEnv(t, srv.URL)()
 
 	cmd := newAppsCmd()
 	cmd.SetArgs([]string{"delete", "myapp", "--yes"})
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "expected a UUID") {
-		t.Fatalf("expected UUID rejection, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "no custom app named") {
+		t.Fatalf("expected an unknown-name error, got %v", err)
 	}
 }
 

--- a/internal/cmd/apps_delete.go
+++ b/internal/cmd/apps_delete.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -14,33 +13,18 @@ func newAppsDeleteCmd() *cobra.Command {
 	var yes bool
 
 	cmd := &cobra.Command{
-		Use:   "delete APP_ID",
-		Short: "Delete a custom app",
+		Use:   "delete APP_ID_OR_NAME",
+		Short: "Delete a custom app by ID or name",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id := args[0]
-			if _, err := uuid.Parse(id); err != nil {
-				return fmt.Errorf("invalid app ID %q: expected a UUID (run `langsmith apps list` to find it)", id)
-			}
-
 			c := MustGetClient()
 			ctx := cmd.Context()
 
-			var apps []customApp
-			if err := c.RawGet(ctx, "/v1/platform/custom-apps", &apps); err != nil {
-				return fmt.Errorf("looking up custom app %s: %w", id, err)
+			app, err := resolveCustomApp(ctx, c, args[0])
+			if err != nil {
+				return err
 			}
-			var found bool
-			var name string
-			for _, a := range apps {
-				if a.ID == id {
-					found, name = true, a.Name
-					break
-				}
-			}
-			if !found {
-				return fmt.Errorf("custom app %s not found (run `langsmith apps list`)", id)
-			}
+			id, name := app.ID, app.Name
 
 			if !yes {
 				fmt.Fprintf(cmd.ErrOrStderr(), "Delete custom app %q (%s)? [y/N] ", name, id)
@@ -57,6 +41,7 @@ func newAppsDeleteCmd() *cobra.Command {
 			output.OutputJSON(map[string]any{
 				"status": "deleted",
 				"app_id": id,
+				"name":   name,
 			}, "")
 			return nil
 		},

--- a/internal/cmd/apps_init.go
+++ b/internal/cmd/apps_init.go
@@ -118,8 +118,8 @@ func newAppsInitCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "init --name NAME [--template annotation-queue|annotation-queue-grid|coding-agent-dashboard|experiment-comparison]",
-		Short: "Scaffold a starter custom app in the current directory",
-		Long: `Scaffold a starter custom app in the current directory.
+		Short: "Scaffold a starter custom app in a new directory named after the app",
+		Long: `Scaffold a starter custom app into a new directory named after --name.
 
 --template picks which starter gets scaffolded; omit it for a blank single-file starter.
 
@@ -128,8 +128,8 @@ func newAppsInitCmd() *cobra.Command {
   coding-agent-dashboard  Charts over coding-agent runs: usage, cost, errors, activity over time.
   experiment-comparison   Compare evaluation experiments against a baseline.
 
-Installs dependencies as the last step, so you can run "langsmith apps dev" next.
-Run "langsmith apps push" to upload.`,
+Installs dependencies as the last step, so you can cd in and run
+"langsmith apps dev" next. Run "langsmith apps push" to upload.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			templateName := templateFlag
 			if templateName == "" {
@@ -141,9 +141,17 @@ Run "langsmith apps push" to upload.`,
 			if !ok {
 				return fmt.Errorf("--template must be one of: %s", strings.Join(appTypeNames(), ", "))
 			}
-			dir, err := os.Getwd()
+			slug := slugifyAppName(name)
+			if slug == "" {
+				return fmt.Errorf("--name %q has no characters usable in a directory name", name)
+			}
+			cwd, err := os.Getwd()
 			if err != nil {
 				return fmt.Errorf("getting current directory: %w", err)
+			}
+			dir := filepath.Join(cwd, slug)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return fmt.Errorf("creating %s: %w", slug, err)
 			}
 			written, err := scaffoldCustomAppStarter(dir, name, description, at, force)
 			if err != nil {
@@ -155,7 +163,7 @@ Run "langsmith apps push" to upload.`,
 			if err := installAppDeps(dir); err != nil {
 				return err
 			}
-			fmt.Fprintln(os.Stderr, "Next: langsmith apps dev.")
+			fmt.Fprintf(os.Stderr, "Next: cd %s && langsmith apps dev.\n", slug)
 			output.OutputJSON(map[string]any{
 				"status":   "scaffolded",
 				"dir":      dir,
@@ -170,9 +178,29 @@ Run "langsmith apps push" to upload.`,
 	cmd.Flags().StringVar(&name, "name", "", "Name for the app, written into package.json/README (required)")
 	cmd.Flags().StringVar(&description, "description", "", "One-line description written into README.md")
 	cmd.Flags().StringVar(&templateFlag, "template", "", "Starter template. Omittable for a blank starter.")
-	cmd.Flags().BoolVar(&force, "force", false, "Write even if the current directory is non-empty")
+	cmd.Flags().BoolVar(&force, "force", false, "Write even if the target directory already exists and is non-empty")
 	_ = cmd.MarkFlagRequired("name")
 	return cmd
+}
+
+// slugifyAppName turns --name into a directory name: lowercase, non-alphanumeric
+// runs collapsed to a single dash, no leading/trailing dashes.
+func slugifyAppName(name string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(strings.TrimSpace(name)) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			lastDash = false
+		default:
+			if !lastDash && b.Len() > 0 {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.TrimRight(b.String(), "-")
 }
 
 // installAppDeps runs npm install

--- a/internal/cmd/apps_init_test.go
+++ b/internal/cmd/apps_init_test.go
@@ -447,17 +447,18 @@ func TestAppsInitCmd_DefaultsToBlankWhenTemplateOmitted(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("expected init to succeed with --template omitted, got: %v", err)
 	}
+	target := filepath.Join(dir, "my-app")
 
 	// Omitting --template scaffolds the blank starter: a partial link and a
 	// queue-free App.tsx.
-	link, err := readAppLink(dir)
+	link, err := readAppLink(target)
 	if err != nil {
 		t.Fatalf("readAppLink: %v", err)
 	}
 	if link == nil || link.Name != "my-app" {
 		t.Errorf("expected a partial link recording the name, got %+v", link)
 	}
-	appTsx, err := os.ReadFile(filepath.Join(dir, "src", "App.tsx"))
+	appTsx, err := os.ReadFile(filepath.Join(target, "src", "App.tsx"))
 	if err != nil {
 		t.Fatalf("read App.tsx: %v", err)
 	}
@@ -476,11 +477,13 @@ func TestAppsInitCmd_AcceptsAnnotationQueueGridTemplate(t *testing.T) {
 		t.Fatalf("expected init to succeed for --template annotation-queue-grid, got: %v", err)
 	}
 
+	target := filepath.Join(dir, "grid-app")
+
 	// The grid variant's own component is scaffolded.
-	if _, err := os.Stat(filepath.Join(dir, "src", "components", "DataGrid.tsx")); err != nil {
+	if _, err := os.Stat(filepath.Join(target, "src", "components", "DataGrid.tsx")); err != nil {
 		t.Errorf("expected the grid template's DataGrid.tsx to be scaffolded: %v", err)
 	}
-	link, err := readAppLink(dir)
+	link, err := readAppLink(target)
 	if err != nil {
 		t.Fatalf("readAppLink: %v", err)
 	}
@@ -498,7 +501,7 @@ func TestAppsInitCmd_AcceptsCodingAgentDashboardTemplate(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("expected init to succeed for --template coding-agent-dashboard, got: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, "src", "components", "OverviewPanel.tsx")); err != nil {
+	if _, err := os.Stat(filepath.Join(dir, "dash", "src", "components", "OverviewPanel.tsx")); err != nil {
 		t.Errorf("expected the dashboard's OverviewPanel.tsx to be scaffolded: %v", err)
 	}
 }
@@ -512,8 +515,100 @@ func TestAppsInitCmd_AcceptsExperimentComparisonTemplate(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("expected init to succeed for --template experiment-comparison, got: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, "src", "components", "SummaryPanel.tsx")); err != nil {
+	if _, err := os.Stat(filepath.Join(dir, "cmp", "src", "components", "SummaryPanel.tsx")); err != nil {
 		t.Errorf("expected the SummaryPanel.tsx to be scaffolded: %v", err)
+	}
+}
+
+func TestAppsInitCmd_ScaffoldsIntoSlugifiedSubdirNotCwd(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	fakeNpm(t, "exit 1")
+	cmd := newAppsCmd()
+	cmd.SetArgs([]string{"init", "--name", "My Cool App!"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	target := filepath.Join(dir, "my-cool-app")
+	if _, err := os.Stat(filepath.Join(target, "package.json")); err != nil {
+		t.Errorf("expected package.json under the slugified subdir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "package.json")); !os.IsNotExist(err) {
+		t.Error("expected nothing scaffolded into the current directory")
+	}
+
+	link, err := readAppLink(target)
+	if err != nil {
+		t.Fatalf("readAppLink: %v", err)
+	}
+	if link == nil || link.Name != "My Cool App!" {
+		t.Errorf("expected the raw --name recorded in the link, got %+v", link)
+	}
+	pkg, err := os.ReadFile(filepath.Join(target, "package.json"))
+	if err != nil {
+		t.Fatalf("read package.json: %v", err)
+	}
+	if !strings.Contains(string(pkg), `"name": "My Cool App!"`) {
+		t.Errorf("expected the raw --name in package.json:\n%s", pkg)
+	}
+}
+
+func TestAppsInitCmd_RejectsExistingNonEmptyDirWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	fakeNpm(t, "exit 1")
+	if err := os.MkdirAll(filepath.Join(dir, "my-app"), 0o755); err != nil {
+		t.Fatalf("seed dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "my-app", "existing.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	cmd := newAppsCmd()
+	cmd.SetArgs([]string{"init", "--name", "my-app"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not empty") {
+		t.Fatalf("expected a not-empty error for an existing populated dir, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "my-app", "package.json")); !os.IsNotExist(err) {
+		t.Error("expected nothing written into the existing directory")
+	}
+
+	cmd = newAppsCmd()
+	cmd.SetArgs([]string{"init", "--name", "my-app", "--force"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected --force to write into the existing dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "my-app", "package.json")); err != nil {
+		t.Errorf("expected package.json after --force: %v", err)
+	}
+}
+
+func TestAppsInitCmd_RejectsUnslugifiableName(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	cmd := newAppsCmd()
+	cmd.SetArgs([]string{"init", "--name", "///"})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected an error for a name that slugifies to nothing")
+	}
+}
+
+func TestSlugifyAppName(t *testing.T) {
+	tests := map[string]string{
+		"my-app":        "my-app",
+		"My Cool App!":  "my-cool-app",
+		"  spaced  out": "spaced-out",
+		"a__b--c":       "a-b-c",
+		"Queue 2.0":     "queue-2-0",
+		"///":           "",
+		"":              "",
+	}
+	for in, want := range tests {
+		if got := slugifyAppName(in); got != want {
+			t.Errorf("slugifyAppName(%q) = %q, want %q", in, got, want)
+		}
 	}
 }
 

--- a/internal/cmd/apps_pull.go
+++ b/internal/cmd/apps_pull.go
@@ -273,6 +273,9 @@ func safeSourceArchivePath(dest, name string) (string, bool, error) {
 	if strings.HasPrefix(slash, "/") || filepath.IsAbs(name) || strings.Contains(name, `\`) {
 		return "", false, fmt.Errorf("source archive entry %q is not a relative path; refusing to extract", name)
 	}
+	if !filepath.IsLocal(slash) {
+		return "", false, fmt.Errorf("source archive entry %q would escape the target directory; refusing to extract", name)
+	}
 	clean := filepath.Clean(filepath.FromSlash(slash))
 	for _, segment := range strings.Split(filepath.ToSlash(clean), "/") {
 		if segment == ".." {

--- a/internal/cmd/apps_pull.go
+++ b/internal/cmd/apps_pull.go
@@ -1,0 +1,287 @@
+package cmd
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/langchain-ai/langsmith-cli/internal/client"
+	"github.com/langchain-ai/langsmith-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func newAppsPullCmd() *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "pull APP_ID_OR_NAME",
+		Short: "Download a custom app's source into a new directory",
+		Long: `Download the source a previous "langsmith apps push" uploaded.
+
+Takes an app ID or name, creates a directory named after the app in the
+current directory, and extracts the source into it. Apps pushed before
+source upload existed have no stored source — re-push them first.
+
+The target directory is replaced, not merged. Run "npm install" after.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			nameOrID := args[0]
+			c := MustGetClient()
+			ctx := cmd.Context()
+
+			app, err := resolveCustomApp(ctx, c, nameOrID)
+			if err != nil {
+				return err
+			}
+
+			archive, err := c.FetchCustomAppSource(ctx, app.ID)
+			if err != nil {
+				return customAppSourceError(err, app.Name)
+			}
+
+			dirName := slugifyAppName(app.Name)
+			if dirName == "" {
+				dirName = app.ID
+			}
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current directory: %w", err)
+			}
+			dest := filepath.Join(cwd, dirName)
+			if err := confirmSourceDirReplace(cmd, dest, force); err != nil {
+				return err
+			}
+			if err := os.RemoveAll(dest); err != nil {
+				return fmt.Errorf("clearing %s: %w", dest, err)
+			}
+			if err := os.MkdirAll(dest, 0o755); err != nil {
+				return fmt.Errorf("creating %s: %w", dest, err)
+			}
+
+			written, err := extractSourceArchive(dest, archive)
+			if err != nil {
+				return err
+			}
+			if len(written) == 0 {
+				return fmt.Errorf("the stored source archive for %q is empty", app.Name)
+			}
+			if err := writeAppLink(dest, appLink{AppID: app.ID, Name: app.Name}); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(os.Stderr, "Pulled %q into %s (%d files).\n", app.Name, dest, len(written))
+			fmt.Fprintf(os.Stderr, "Next: cd %s && npm install && langsmith apps dev.\n", dirName)
+			output.OutputJSON(map[string]any{
+				"status": "pulled",
+				"app_id": app.ID,
+				"name":   app.Name,
+				"dir":    dest,
+				"files":  written,
+			}, "")
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Replace the target directory without confirming")
+	return cmd
+}
+
+// resolveCustomApp accepts an app ID or name.
+func resolveCustomApp(ctx context.Context, c *client.Client, nameOrID string) (*customApp, error) {
+	var apps []customApp
+	if err := c.RawGet(ctx, "/v1/platform/custom-apps", &apps); err != nil {
+		return nil, fmt.Errorf("looking up custom app %q: %w", nameOrID, err)
+	}
+
+	if _, err := uuid.Parse(nameOrID); err == nil {
+		for i := range apps {
+			if apps[i].ID == nameOrID {
+				return &apps[i], nil
+			}
+		}
+		return nil, fmt.Errorf("custom app %s not found in this workspace (run `langsmith apps list`)", nameOrID)
+	}
+
+	for i := range apps {
+		if apps[i].Name == nameOrID {
+			return &apps[i], nil
+		}
+	}
+	for i := range apps {
+		if strings.EqualFold(apps[i].Name, nameOrID) {
+			return &apps[i], nil
+		}
+	}
+	return nil, fmt.Errorf("no custom app named %q in this workspace (run `langsmith apps list`)", nameOrID)
+}
+
+func customAppSourceError(err error, name string) error {
+	msg := strings.ToLower(err.Error())
+	switch {
+	case client.IsNotFound(err) && strings.Contains(msg, "no source archive"):
+		return fmt.Errorf("custom app %q has no stored source — it was pushed before source upload existed. Ask whoever owns it to run `langsmith apps push` again, then retry", name)
+	case client.IsNotFound(err):
+		return fmt.Errorf("custom app %q not found (run `langsmith apps list`)", name)
+	case client.IsBadRequest(err):
+		return fmt.Errorf("the server rejected this app ID: %w", err)
+	default:
+		return fmt.Errorf("downloading source for %q: %w", name, err)
+	}
+}
+
+// confirmSourceDirReplace gates the destructive replace.
+func confirmSourceDirReplace(cmd *cobra.Command, dest string, force bool) error {
+	info, err := os.Stat(dest)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", dest, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s exists and is not a directory", dest)
+	}
+	entries, err := os.ReadDir(dest)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", dest, err)
+	}
+	if len(entries) == 0 || force {
+		return nil
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "%s already exists and is not empty. Replace its contents? [y/N] ", dest)
+	var confirm string
+	_, _ = fmt.Fscanln(cmd.InOrStdin(), &confirm)
+	if ans := strings.ToLower(strings.TrimSpace(confirm)); ans != "y" && ans != "yes" {
+		return errors.New("aborted: pass --force to replace the directory")
+	}
+	return nil
+}
+
+// extractSourceArchive gunzips and untars into dest.
+func extractSourceArchive(dest string, archive []byte) ([]string, error) {
+	if err := validateSourceArchivePaths(dest, archive); err != nil {
+		return nil, err
+	}
+
+	tr, closeFn, err := newSourceArchiveReader(archive)
+	if err != nil {
+		return nil, err
+	}
+	defer closeFn()
+
+	var (
+		written []string
+		total   int64
+	)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading source archive: %w", err)
+		}
+		path, ok, err := safeSourceArchivePath(dest, hdr.Name)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(path, 0o755); err != nil {
+				return nil, fmt.Errorf("creating %s: %w", hdr.Name, err)
+			}
+		case tar.TypeReg:
+			total += hdr.Size
+			if total > appsMaxSourceRawBytes {
+				return nil, fmt.Errorf("source archive expands beyond %s; refusing to extract", formatArchiveBytes(appsMaxSourceRawBytes))
+			}
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				return nil, fmt.Errorf("creating directory for %s: %w", hdr.Name, err)
+			}
+			perm := hdr.FileInfo().Mode().Perm()
+			if perm == 0 {
+				perm = 0o644
+			}
+			f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, perm)
+			if err != nil {
+				return nil, fmt.Errorf("creating %s: %w", hdr.Name, err)
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				return nil, fmt.Errorf("writing %s: %w", hdr.Name, err)
+			}
+			if err := f.Close(); err != nil {
+				return nil, fmt.Errorf("writing %s: %w", hdr.Name, err)
+			}
+			written = append(written, filepath.ToSlash(hdr.Name))
+		default:
+			// Symlinks and devices are skipped.
+			continue
+		}
+	}
+	sort.Strings(written)
+	return written, nil
+}
+
+// validateSourceArchivePaths rejects traversal before writing anything.
+func validateSourceArchivePaths(dest string, archive []byte) error {
+	tr, closeFn, err := newSourceArchiveReader(archive)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("reading source archive: %w", err)
+		}
+		if _, _, err := safeSourceArchivePath(dest, hdr.Name); err != nil {
+			return err
+		}
+	}
+}
+
+func newSourceArchiveReader(archive []byte) (*tar.Reader, func(), error) {
+	gz, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return nil, nil, fmt.Errorf("the stored source archive is not a valid gzip file: %w", err)
+	}
+	return tar.NewReader(gz), func() { gz.Close() }, nil
+}
+
+// safeSourceArchivePath resolves an entry inside dest.
+func safeSourceArchivePath(dest, name string) (string, bool, error) {
+	slash := filepath.ToSlash(name)
+	if slash == "" || slash == "." || slash == "./" {
+		return "", false, nil
+	}
+	if strings.HasPrefix(slash, "/") || filepath.IsAbs(name) || strings.Contains(name, `\`) {
+		return "", false, fmt.Errorf("source archive entry %q is not a relative path; refusing to extract", name)
+	}
+	clean := filepath.Clean(filepath.FromSlash(slash))
+	for _, segment := range strings.Split(filepath.ToSlash(clean), "/") {
+		if segment == ".." {
+			return "", false, fmt.Errorf("source archive entry %q would escape the target directory; refusing to extract", name)
+		}
+	}
+	path := filepath.Join(dest, clean)
+	if path != dest && !strings.HasPrefix(path, dest+string(filepath.Separator)) {
+		return "", false, fmt.Errorf("source archive entry %q would escape the target directory; refusing to extract", name)
+	}
+	return path, true, nil
+}

--- a/internal/cmd/apps_pull_test.go
+++ b/internal/cmd/apps_pull_test.go
@@ -1,0 +1,373 @@
+package cmd
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// tarGz builds a .tar.gz from path → content.
+func tarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		hdr := &tar.Header{Name: name, Mode: 0o644, Size: int64(len(content)), Typeflag: tar.TypeReg}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("tar header %s: %v", name, err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("tar write %s: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func tarGzWithSymlink(t *testing.T, target string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	body := "keep me"
+	if err := tw.WriteHeader(&tar.Header{Name: "src/App.tsx", Mode: 0o644, Size: int64(len(body)), Typeflag: tar.TypeReg}); err != nil {
+		t.Fatalf("tar header: %v", err)
+	}
+	if _, err := tw.Write([]byte(body)); err != nil {
+		t.Fatalf("tar write: %v", err)
+	}
+	if err := tw.WriteHeader(&tar.Header{Name: "link.txt", Linkname: target, Mode: 0o777, Typeflag: tar.TypeSymlink}); err != nil {
+		t.Fatalf("tar symlink header: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// appsSourceServer serves the list and source endpoints.
+func appsSourceServer(t *testing.T, apps []customApp, source map[string][]byte) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/platform/custom-apps", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(apps)
+	})
+	mux.HandleFunc("/v1/platform/custom-apps/", func(w http.ResponseWriter, r *http.Request) {
+		id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v1/platform/custom-apps/"), "/source")
+		archive, ok := source[id]
+		if !ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "no source archive stored for this custom app"})
+			return
+		}
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	})
+	return mux
+}
+
+const testAppID = "6f1c9b0e-6b3e-4a0e-9a4a-2c1d3e4f5a6b"
+
+func TestAppsPull_ResolvesNameToIDAndExtracts(t *testing.T) {
+	var sourcePath string
+	archive := tarGz(t, map[string]string{
+		"package.json":     `{"name":"my-app"}`,
+		"src/App.tsx":      "export default function App() {}",
+		"src/lib/utils.ts": "export const cn = () => {}",
+	})
+	mux := appsSourceServer(t,
+		[]customApp{{ID: testAppID, Name: "My App"}},
+		map[string][]byte{testAppID: archive},
+	)
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/source") {
+			sourcePath = r.URL.Path
+		}
+		mux.ServeHTTP(w, r)
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	out := captureStdout(t, func() {
+		cmd := newAppsCmd()
+		cmd.SetArgs([]string{"pull", "My App"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if sourcePath != "/v1/platform/custom-apps/"+testAppID+"/source" {
+		t.Errorf("expected the name to resolve to an ID before fetching source, got %q", sourcePath)
+	}
+
+	target := filepath.Join(dir, "my-app")
+	for rel, want := range map[string]string{
+		"package.json":     `{"name":"my-app"}`,
+		"src/App.tsx":      "export default function App() {}",
+		"src/lib/utils.ts": "export const cn = () => {}",
+	} {
+		got, err := os.ReadFile(filepath.Join(target, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Errorf("expected %s extracted: %v", rel, err)
+			continue
+		}
+		if string(got) != want {
+			t.Errorf("%s content mismatch: got %q", rel, got)
+		}
+	}
+
+	link, err := readAppLink(target)
+	if err != nil {
+		t.Fatalf("readAppLink: %v", err)
+	}
+	if link == nil || link.AppID != testAppID || link.Name != "My App" {
+		t.Errorf("expected the pulled directory linked to the app, got %+v", link)
+	}
+	if !strings.Contains(out, `"status": "pulled"`) {
+		t.Errorf("expected pulled status in output:\n%s", out)
+	}
+}
+
+func TestAppsPull_AcceptsAppID(t *testing.T) {
+	archive := tarGz(t, map[string]string{"src/App.tsx": "app"})
+	mux := appsSourceServer(t,
+		[]customApp{{ID: testAppID, Name: "my-app"}},
+		map[string][]byte{testAppID: archive},
+	)
+	srv := newTestServer(t, mux.ServeHTTP)
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	captureStdout(t, func() {
+		cmd := newAppsCmd()
+		cmd.SetArgs([]string{"pull", testAppID})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if _, err := os.Stat(filepath.Join(dir, "my-app", "src", "App.tsx")); err != nil {
+		t.Errorf("expected the source extracted under the app's name: %v", err)
+	}
+}
+
+func TestAppsPull_ErrorsOnUnknownName(t *testing.T) {
+	mux := appsSourceServer(t, []customApp{{ID: testAppID, Name: "my-app"}}, nil)
+	srv := newTestServer(t, mux.ServeHTTP)
+	defer setupTestEnv(t, srv.URL)()
+	t.Chdir(t.TempDir())
+
+	cmd := newAppsCmd()
+	cmd.SetArgs([]string{"pull", "nope"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "no custom app named") {
+		t.Errorf("expected an actionable not-found error, got %v", err)
+	}
+}
+
+func TestAppsPull_SurfacesNoSourceArchive404(t *testing.T) {
+	mux := appsSourceServer(t, []customApp{{ID: testAppID, Name: "my-app"}}, nil)
+	srv := newTestServer(t, mux.ServeHTTP)
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cmd := newAppsCmd()
+	cmd.SetArgs([]string{"pull", "my-app"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error when no source archive is stored")
+	}
+	if !strings.Contains(err.Error(), "no stored source") || !strings.Contains(err.Error(), "push") {
+		t.Errorf("expected a re-push hint, got: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "my-app")); !os.IsNotExist(statErr) {
+		t.Error("expected no directory created when the fetch failed")
+	}
+}
+
+func TestAppsPull_RefusesNonEmptyDirWithoutForce(t *testing.T) {
+	archive := tarGz(t, map[string]string{"src/App.tsx": "fresh"})
+	mux := appsSourceServer(t,
+		[]customApp{{ID: testAppID, Name: "my-app"}},
+		map[string][]byte{testAppID: archive},
+	)
+	srv := newTestServer(t, mux.ServeHTTP)
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	seedFile(t, dir, "my-app/existing.txt", "mine")
+
+	cmd := newAppsCmd()
+	cmd.SetArgs([]string{"pull", "my-app"})
+	cmd.SetIn(strings.NewReader("n\n"))
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "aborted") {
+		t.Fatalf("expected the non-empty target to be refused, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "my-app", "existing.txt")); statErr != nil {
+		t.Errorf("expected the existing file left alone after aborting: %v", statErr)
+	}
+
+	// --force replaces the directory outright.
+	captureStdout(t, func() {
+		cmd = newAppsCmd()
+		cmd.SetArgs([]string{"pull", "my-app", "--force"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute with --force: %v", err)
+		}
+	})
+	if _, statErr := os.Stat(filepath.Join(dir, "my-app", "existing.txt")); !os.IsNotExist(statErr) {
+		t.Error("expected --force to replace, not merge into, the target directory")
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "my-app", "src", "App.tsx"))
+	if err != nil || string(got) != "fresh" {
+		t.Errorf("expected the pulled source after --force, got %q (%v)", got, err)
+	}
+}
+
+func TestAppsPull_ConfirmedNonEmptyDirProceeds(t *testing.T) {
+	archive := tarGz(t, map[string]string{"src/App.tsx": "fresh"})
+	mux := appsSourceServer(t,
+		[]customApp{{ID: testAppID, Name: "my-app"}},
+		map[string][]byte{testAppID: archive},
+	)
+	srv := newTestServer(t, mux.ServeHTTP)
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	seedFile(t, dir, "my-app/existing.txt", "mine")
+
+	captureStdout(t, func() {
+		cmd := newAppsCmd()
+		cmd.SetArgs([]string{"pull", "my-app"})
+		cmd.SetIn(strings.NewReader("y\n"))
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+	if _, err := os.Stat(filepath.Join(dir, "my-app", "src", "App.tsx")); err != nil {
+		t.Errorf("expected the pull to proceed after confirmation: %v", err)
+	}
+}
+
+func TestExtractSourceArchive_RejectsPathTraversal(t *testing.T) {
+	for _, name := range []string{
+		"../escaped.txt",
+		"src/../../escaped.txt",
+		"/etc/passwd",
+		"nested/../../../escaped.txt",
+	} {
+		dir := t.TempDir()
+		dest := filepath.Join(dir, "app")
+		if err := os.MkdirAll(dest, 0o755); err != nil {
+			t.Fatalf("mkdir dest: %v", err)
+		}
+		archive := tarGz(t, map[string]string{name: "pwned", "src/App.tsx": "app"})
+
+		if _, err := extractSourceArchive(dest, archive); err == nil {
+			t.Errorf("expected entry %q to be rejected", name)
+		} else if !strings.Contains(err.Error(), "refusing to extract") {
+			t.Errorf("expected a refusal for %q, got: %v", name, err)
+		}
+		// Rejection happens before anything is written.
+		if _, err := os.Stat(filepath.Join(dest, "src", "App.tsx")); !os.IsNotExist(err) {
+			t.Errorf("expected nothing extracted from an archive containing %q", name)
+		}
+		if _, err := os.Stat(filepath.Join(dir, "escaped.txt")); !os.IsNotExist(err) {
+			t.Errorf("entry %q escaped the target directory", name)
+		}
+	}
+}
+
+func TestExtractSourceArchive_SkipsSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "app")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatalf("mkdir dest: %v", err)
+	}
+	secret := filepath.Join(dir, "secret.txt")
+	if err := os.WriteFile(secret, []byte("secret"), 0o644); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+
+	written, err := extractSourceArchive(dest, tarGzWithSymlink(t, secret))
+	if err != nil {
+		t.Fatalf("extractSourceArchive: %v", err)
+	}
+	if len(written) != 1 || written[0] != "src/App.tsx" {
+		t.Errorf("expected only the regular file extracted, got %v", written)
+	}
+	if _, err := os.Lstat(filepath.Join(dest, "link.txt")); !os.IsNotExist(err) {
+		t.Error("expected symlink entries to be skipped")
+	}
+}
+
+func TestExtractSourceArchive_RejectsNonGzipBody(t *testing.T) {
+	dest := t.TempDir()
+	if _, err := extractSourceArchive(dest, []byte("not a gzip archive")); err == nil {
+		t.Fatal("expected an error for a non-gzip body")
+	}
+}
+
+// Round-trips what push builds through what pull extracts.
+func TestSourceArchive_PushBuildToPullExtractRoundTrip(t *testing.T) {
+	src := t.TempDir()
+	seedFile(t, src, "package.json", `{"name":"my-app"}`)
+	seedFile(t, src, "src/App.tsx", "export default function App() {}")
+	seedFile(t, src, "src/components/DataGrid.tsx", "grid")
+	seedFile(t, src, "node_modules/react/index.js", "dep")
+	seedFile(t, src, ".env", "SECRET=1")
+
+	encoded, err := buildSourceArchive(src)
+	if err != nil {
+		t.Fatalf("buildSourceArchive: %v", err)
+	}
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	dest := filepath.Join(t.TempDir(), "pulled")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatalf("mkdir dest: %v", err)
+	}
+	written, err := extractSourceArchive(dest, raw)
+	if err != nil {
+		t.Fatalf("extractSourceArchive: %v", err)
+	}
+
+	want := []string{"package.json", "src/App.tsx", "src/components/DataGrid.tsx"}
+	if strings.Join(written, ",") != strings.Join(want, ",") {
+		t.Errorf("round trip changed the file set: got %v, want %v", written, want)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "src", "components", "DataGrid.tsx"))
+	if err != nil || string(got) != "grid" {
+		t.Errorf("nested file did not survive the round trip: %q (%v)", got, err)
+	}
+}

--- a/internal/cmd/apps_push.go
+++ b/internal/cmd/apps_push.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
@@ -64,6 +65,11 @@ same app too.
 				return fmt.Errorf("entrypoint %q not found among uploaded files; pass --entrypoint or check your build produced it", entrypoint)
 			}
 
+			sourceArchive, err := buildSourceArchive(dir)
+			if err != nil {
+				return err
+			}
+
 			link, err := readAppLink(dir)
 			if err != nil {
 				return err
@@ -77,20 +83,19 @@ same app too.
 			var app customApp
 			updated := false
 			if !notYetCreated {
-				payload := map[string]any{
-					"files":      files,
-					"entrypoint": entrypoint,
-				}
-				if name != "" {
-					payload["name"] = name
-				}
-				if description != "" {
-					payload["description"] = description
+				payload := client.CustomAppRequest{
+					Files:         files,
+					Entrypoint:    &entrypoint,
+					SourceArchive: optionalString(sourceArchive),
+					Name:          optionalString(name),
+					Description:   optionalString(description),
 				}
 				err := c.RawPatch(ctx, "/v1/platform/custom-apps/"+link.AppID, payload, &app)
 				switch {
 				case err == nil:
 					updated = true
+				case isSourceArchiveRejection(err):
+					return sourceArchiveRejectionError(err)
 				case client.IsConflict(err):
 					conflictName := name
 					if conflictName == "" {
@@ -123,15 +128,17 @@ same app too.
 				if appName == "" {
 					appName = filepath.Base(filepath.Clean(dir))
 				}
-				payload := map[string]any{
-					"name":       appName,
-					"files":      files,
-					"entrypoint": entrypoint,
-				}
-				if description != "" {
-					payload["description"] = description
+				payload := client.CustomAppRequest{
+					Name:          &appName,
+					Files:         files,
+					Entrypoint:    &entrypoint,
+					SourceArchive: optionalString(sourceArchive),
+					Description:   optionalString(description),
 				}
 				if err := c.RawPost(ctx, "/v1/platform/custom-apps", payload, &app); err != nil {
+					if isSourceArchiveRejection(err) {
+						return sourceArchiveRejectionError(err)
+					}
 					if client.IsForbidden(err) {
 						return fmt.Errorf("this workspace doesn't support custom apps — ask a workspace admin to enable them, then try again")
 					}
@@ -183,6 +190,25 @@ same app too.
 	cmd.Flags().StringVar(&entrypoint, "entrypoint", "dist/bundle.js", "Path (relative to the current directory) of the file to render")
 	cmd.Flags().BoolVar(&noBuild, "no-build", false, "Skip building before uploading, even if package.json has a \"build\" script")
 	return cmd
+}
+
+func optionalString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func isSourceArchiveRejection(err error) bool {
+	if !client.IsBadRequest(err) {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "source archive") || strings.Contains(msg, "source_archive")
+}
+
+func sourceArchiveRejectionError(err error) error {
+	return fmt.Errorf("the server rejected this app's source archive: %w\nRe-run with a smaller source directory, or report this if it persists", err)
 }
 
 func runAppsBuildCmd(dir string) error {

--- a/internal/cmd/apps_push_test.go
+++ b/internal/cmd/apps_push_test.go
@@ -315,3 +315,131 @@ func TestAppsPush_NoBuildSkipsAutomaticBuild(t *testing.T) {
 		t.Error("--no-build must not run the package.json \"build\" script")
 	}
 }
+
+func TestAppsPush_UploadsSourceArchiveOnCreate(t *testing.T) {
+	var postBody map[string]any
+
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/v1/platform/custom-apps":
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &postBody)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(customApp{ID: "app_new", Name: "my-app", Entrypoint: "dist/bundle.js"})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	seedAppDir(t, dir)
+	seedFile(t, dir, "src/App.tsx", "export default function App() {}")
+	seedFile(t, dir, "node_modules/react/index.js", "dep")
+	seedFile(t, dir, ".env", "LANGSMITH_API_KEY=lsv2_secret")
+	t.Chdir(dir)
+
+	captureStdout(t, func() {
+		cmd := newAppsCmd()
+		cmd.SetArgs([]string{"push", "--name", "my-app"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	encoded, ok := postBody["source_archive"].(string)
+	if !ok || encoded == "" {
+		t.Fatalf("expected source_archive in the create payload, got %v", keysOfAny(postBody))
+	}
+	entries := untarBase64(t, encoded)
+	if _, ok := entries["src/App.tsx"]; !ok {
+		t.Errorf("expected source files in the archive, got %v", keysOf(entries))
+	}
+	for _, unwanted := range []string{"node_modules/react/index.js", ".env", "dist/bundle.js"} {
+		if _, ok := entries[unwanted]; ok {
+			t.Errorf("%q must not be uploaded in the source archive", unwanted)
+		}
+	}
+	// The runnable-files upload is unchanged and still carries the bundle.
+	files, ok := postBody["files"].(map[string]any)
+	if !ok || files["dist/bundle.js"] == nil {
+		t.Errorf("expected the files map to still carry dist/bundle.js, got %v", postBody["files"])
+	}
+}
+
+func TestAppsPush_UploadsSourceArchiveOnUpdate(t *testing.T) {
+	var patchBody map[string]any
+
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "PATCH" && r.URL.Path == "/v1/platform/custom-apps/app_existing":
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &patchBody)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(customApp{ID: "app_existing", Name: "my-app", Entrypoint: "dist/bundle.js"})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	seedAppDir(t, dir)
+	seedFile(t, dir, "src/App.tsx", "export default function App() {}")
+	if err := writeAppLink(dir, appLink{AppID: "app_existing", Name: "my-app"}); err != nil {
+		t.Fatalf("seed link: %v", err)
+	}
+	t.Chdir(dir)
+
+	captureStdout(t, func() {
+		cmd := newAppsCmd()
+		cmd.SetArgs([]string{"push"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	encoded, ok := patchBody["source_archive"].(string)
+	if !ok || encoded == "" {
+		t.Fatalf("expected source_archive in the update payload, got %v", keysOfAny(patchBody))
+	}
+	if _, ok := untarBase64(t, encoded)["src/App.tsx"]; !ok {
+		t.Error("expected the update archive to carry the source")
+	}
+	// --name was not passed, so it must stay absent rather than blank.
+	if _, present := patchBody["name"]; present {
+		t.Errorf("expected no name in the update payload, got %v", patchBody["name"])
+	}
+}
+
+func TestAppsPush_SurfacesBackendSourceArchiveRejection(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": "source archive exceeds the maximum size"})
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	seedAppDir(t, dir)
+	seedFile(t, dir, "src/App.tsx", "app")
+	t.Chdir(dir)
+
+	cmd := newAppsCmd()
+	cmd.SetArgs([]string{"push", "--name", "my-app"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected the backend 400 to surface as an error")
+	}
+	if !strings.Contains(err.Error(), "source archive") {
+		t.Errorf("expected a source-archive-specific message, got: %v", err)
+	}
+}
+
+func keysOfAny(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/cmd/templates/agents-md/_common.md
+++ b/internal/cmd/templates/agents-md/_common.md
@@ -6,6 +6,27 @@ exports `render(data, root, metadata)`; keep that shape, the sandbox depends
 on it. `data` is normally `{}`; call `window.langsmith.setData(patch)` if you
 need to push a mutation out for the host to persist.
 
+## context.md — the handoff file
+
+Keep a `context.md` at the app root and treat it as this app's memory. On a
+fresh `langsmith apps pull` it's the first thing to read; before every
+`langsmith apps push` it's the last thing to update. It rides along in the
+source archive automatically — it's just a root file — so what you write there
+is where the next developer's agent starts instead of from scratch.
+
+Update it as you work, not as a write-up at the end:
+
+- What the app does, and who it's for.
+- The key files and how they fit together — where data is fetched, where it's rendered.
+- Decisions and why, especially the ones the code doesn't explain on its own.
+- Dead ends already ruled out, so nobody burns a day re-trying them.
+- Anything non-obvious about the data or API you hit: which project or dataset,
+  filters that matter, fields that are usually empty, endpoints that were slower
+  or shaped differently than the docs suggest.
+
+It's shared, not secret — no API keys, tokens, or customer data. Nothing
+enforces this; it only pays off if you keep it current.
+
 ## Calling the LangSmith API
 
 ```ts


### PR DESCRIPTION
- init scaffolds new subdir (sluggified name, --force replaces existing contents)
- push uploads source_archive (Gzip tarball, base64-encoded)
- hardcoded denylist (.gitignore is additive)
- 50 MB cap client-side, backend 400s surfaced cleanly

- apps pull <id-or-name>:
  - name resolved via list, client fetches raw gzip, extracts into new dir (non-empty dir gated), runnable-files untouched

- AGENTS.md mandates live/updated context.md