### PR TITLE
fix(install): fall back to authenticated gh for release lookup

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -19,17 +19,35 @@ function Get-Architecture {
     }
 }
 
+function Get-LatestVersionViaGitHubCli {
+    try {
+        $tag = & gh api -H "Accept: application/vnd.github+json" "repos/$Repo/releases/latest" --jq ".tag_name" 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            return $null
+        }
+
+        return $tag
+    } catch {
+        return $null
+    }
+}
+
 function Get-LatestVersion {
     $headers = @{
         "Accept" = "application/vnd.github+json"
     }
     if ($env:GITHUB_TOKEN) {
         $headers["Authorization"] = "Bearer $env:GITHUB_TOKEN"
+    } else {
+        $tag = Get-LatestVersionViaGitHubCli
+        if ($tag) {
+            return $tag
+        }
     }
 
     $release = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/$Repo/releases/latest"
     if (-not $release.tag_name) {
-        throw "Failed to determine latest version"
+        throw "Failed to determine latest version. Set GITHUB_TOKEN, run 'gh auth login', or pass -Version."
     }
 
     return $release.tag_name

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,17 +42,12 @@ fi
 if [ -z "$VERSION" ]; then
   API_URL="https://api.github.com/repos/${REPO}/releases/latest"
 
-  # Fall back to an authenticated gh when GITHUB_TOKEN is unset
-  GH_AUTHED=0
-  if [ -z "$GITHUB_TOKEN" ] && command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-    GH_AUTHED=1
-  fi
-
+  # GITHUB_TOKEN, then an authenticated gh, then anonymous
   fetch_latest() {
     if [ -n "$GITHUB_TOKEN" ]; then
       curl -fsSL -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer $GITHUB_TOKEN" "$API_URL"
-    elif [ "$GH_AUTHED" -eq 1 ]; then
+    elif command -v gh >/dev/null 2>&1; then
       gh api -H "Accept: application/vnd.github+json" \
         "repos/${REPO}/releases/latest" 2>/dev/null \
         || curl -fsSL -H "Accept: application/vnd.github+json" "$API_URL"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,6 +5,7 @@
 # Environment variables:
 #   INSTALL_DIR   — directory to install to (default: auto-detect)
 #   VERSION       — specific version to install (default: latest)
+#   GITHUB_TOKEN  — token for the release lookup, to avoid anonymous rate limits
 
 set -e
 
@@ -41,10 +42,20 @@ fi
 if [ -z "$VERSION" ]; then
   API_URL="https://api.github.com/repos/${REPO}/releases/latest"
 
+  # Fall back to an authenticated gh when GITHUB_TOKEN is unset
+  GH_AUTHED=0
+  if [ -z "$GITHUB_TOKEN" ] && command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    GH_AUTHED=1
+  fi
+
   fetch_latest() {
     if [ -n "$GITHUB_TOKEN" ]; then
       curl -fsSL -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer $GITHUB_TOKEN" "$API_URL"
+    elif [ "$GH_AUTHED" -eq 1 ]; then
+      gh api -H "Accept: application/vnd.github+json" \
+        "repos/${REPO}/releases/latest" 2>/dev/null \
+        || curl -fsSL -H "Accept: application/vnd.github+json" "$API_URL"
     else
       curl -fsSL -H "Accept: application/vnd.github+json" "$API_URL"
     fi
@@ -61,7 +72,7 @@ if [ -z "$VERSION" ]; then
 
   if [ -z "$VERSION" ]; then
     echo "Failed to determine latest version (GitHub API unreachable or rate-limited)." >&2
-    echo "Set GITHUB_TOKEN to raise the rate limit, or set VERSION to install a specific release." >&2
+    echo "Set GITHUB_TOKEN, run 'gh auth login', or set VERSION to install a specific release." >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
## What

Resolving the latest release tag falls back to an **anonymous** GitHub API request when `GITHUB_TOKEN` is unset — capped at 60 req/hour per IP. Once exhausted the install dies with `Failed to determine latest version`.

langchain-ai/langsmith-cli#177 fixed this for CI by exporting `GITHUB_TOKEN` to the `installer-smoke` job. End users running the documented `curl -fsSL https://cli.langsmith.com/install.sh | sh` have no equivalent. langchain-ai/langsmith-cli#132 reported this symptom on macOS and was closed as not reproducible, which is what a per-IP intermittent limit looks like.

`gh` is already installed and authenticated on most developer machines, costs nothing when absent, and lifts the limit to 5000/hour.

## How

* **scripts/install.sh** — probe for an authenticated `gh` once (before the retry loop, since `gh auth status` is a network round trip) and use `gh api` when `GITHUB_TOKEN` is unset. Falls through to anonymous `curl` if the `gh` call fails at runtime.
* **scripts/install.ps1** — same order via `Get-LatestVersionViaGitHubCli`, plus an actionable message on the previously bare `Failed to determine latest version` throw.

Order is `GITHUB_TOKEN`, then `gh`, then anonymous. An explicitly set token still wins, so `installer-smoke` — which sets `GITHUB_TOKEN` at job level — short-circuits before the probe and is byte-for-byte unchanged.

The `try/catch` in `install.ps1` is load-bearing, not decoration: under `$PSNativeCommandUseErrorActionPreference = $true` a non-zero `gh` exit raises `NativeCommandExitException`. Since the script is run through `irm | iex` it inherits the user's preference variables, so an *unauthenticated* `gh` would abort the install rather than fall back — strictly worse than not having `gh` installed.

## Testing

Both scripts were exercised through stubbed `gh` / `curl` / `Invoke-RestMethod`, asserting the resolved version **and** the exact call sequence.

`install.sh` — 8 cases: token wins with no wasted `gh` probe; `gh` authenticated; `gh` present but unauthenticated; `gh` failing at call time; `gh` absent; anonymous rate-limited and rescued by `gh`; anonymous rate-limited with no `gh` (still exits 1 cleanly); total failure confirming 1 auth probe against 3 API attempts.

`install.ps1` — 7 equivalent cases, loading the real functions out of the file via the AST rather than a copy. `gh`-absent was verified with `gh` genuinely stripped from `PATH`, not stubbed. The `NativeCommandExitException` case was run against a variant with the `try/catch` removed to confirm it is required:

```
without try/catch:  THREW: NativeCommandExitException   calls=[gh:api]
with try/catch:     result=v9.9.9-anon                  calls=[gh:api, irm:anon]
```

Static checks: `sh -n` and `dash -n` clean; `shellcheck -s sh` reports only the pre-existing `SC2034` for `VERSION_NUM`; `install.ps1` parses clean and PSScriptAnalyzer reports 11 warnings before and after this change (all pre-existing `PSAvoidUsingWriteHost`).

## Evidence

The anonymous GitHub API returned `403` mid-development while fetching an unrelated release, and had to be routed through `gh api` to proceed — the exact failure and the exact remedy this PR implements.

Verified that `cli.langsmith.com/install.sh` is byte-identical to `main`, so this reaches real installs rather than only the repo copy.

Also confirmed `gh api` sends `Accept: */*` by default, so the explicit `-H "Accept: application/vnd.github+json"` is doing real work and is not redundant with the other request paths.

## Not in scope

* `install.ps1` has no retry loop; `install.sh` gained one in langchain-ai/langsmith-cli#177. Worth adding, separate change.
* Pre-existing `VERSION_NUM` dead variable and the `Write-Host` warnings are left alone.

Closes langchain-ai/langsmith-cli#207