### PR TITLE
fix(thread): select thread_id so thread list returns threads

### DIFF
--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -169,6 +169,18 @@ func toV2Params(p langsmith.RunQueryParams, selects []langsmith.RunQueryV2Params
 	return v2
 }
 
+// threadListSelect and threadListSelectV2 add thread_id to the base select
+// sets. `thread list` groups runs by thread_id, so omitting it yields zero
+// threads rather than an error; the base sets leave it out because no other
+// command reads it.
+func threadListSelect() []langsmith.RunQueryParamsSelect {
+	return append(buildRunSelect(true, false), langsmith.RunQueryParamsSelectThreadID)
+}
+
+func threadListSelectV2() []langsmith.RunQueryV2ParamsSelect {
+	return append(buildRunSelectV2(true, false), langsmith.RunQueryV2ParamsSelectThreadID)
+}
+
 // buildRunSelectV2 returns the v2 select-field set covering the same base
 // fields used by the downstream RunSchema pipeline plus the optional groups
 // requested by the include flags.

--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -86,11 +86,11 @@ func newThreadListCmd() *cobra.Command {
 			if rawFilter != "" {
 				params.Filter = langsmith.F(rawFilter)
 			}
-			if sel := buildRunSelect(true, false); sel != nil {
+			if sel := threadListSelect(); sel != nil {
 				params.Select = langsmith.F(sel)
 			}
 
-			runs, err := queryRunsAuto(ctx, c, params, buildRunSelectV2(true, false), sessionID, math.MaxInt32, 0)
+			runs, err := queryRunsAuto(ctx, c, params, threadListSelectV2(), sessionID, math.MaxInt32, 0)
 			if err != nil {
 				ExitErrorf("querying runs: %v", err)
 			}

--- a/internal/cmd/thread_test.go
+++ b/internal/cmd/thread_test.go
@@ -2,7 +2,51 @@ package cmd
 
 import (
 	"testing"
+
+	langsmith "github.com/langchain-ai/langsmith-go"
 )
+
+// ==================== Select fields ====================
+
+// thread list groups runs by thread_id. If the field is missing from the
+// select set the query succeeds and returns runs with an empty ThreadID, so
+// the command reports zero threads with exit code 0 instead of failing.
+func TestThreadListSelect_IncludesThreadID(t *testing.T) {
+	var found bool
+	for _, f := range threadListSelect() {
+		if f == langsmith.RunQueryParamsSelectThreadID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("threadListSelect() must include thread_id; without it thread list returns zero threads")
+	}
+}
+
+func TestThreadListSelectV2_IncludesThreadID(t *testing.T) {
+	var found bool
+	for _, f := range threadListSelectV2() {
+		if f == langsmith.RunQueryV2ParamsSelectThreadID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("threadListSelectV2() must include THREAD_ID; without it thread list returns zero threads")
+	}
+}
+
+// The base select sets feed every other run query; thread_id belongs only to
+// the thread-list variants, so a regression there is visible here too.
+func TestThreadListSelect_ExtendsBaseSet(t *testing.T) {
+	if len(threadListSelect()) != len(buildRunSelect(true, false))+1 {
+		t.Error("threadListSelect() should be the base v1 set plus thread_id")
+	}
+	if len(threadListSelectV2()) != len(buildRunSelectV2(true, false))+1 {
+		t.Error("threadListSelectV2() should be the base v2 set plus THREAD_ID")
+	}
+}
 
 // ==================== Command structure ====================
 


### PR DESCRIPTION
## Description

`thread list` returns **zero threads** on `main`. Against the same project at the same moment:

| | `v0.2.42` | `main` |
|---|---|---|
| `thread list` | 3 threads | `null` / empty table, exit 0 |

**Cause.** `thread list` groups root runs by `thread_id` (`thread.go`). #203 started sending an explicit field selection on both API paths — `buildRunSelect(true, false)` for v1 and `buildRunSelectV2(true, false)` for v2 — and neither base set includes `thread_id`. Runs came back with an empty `ThreadID`, so the `if tid != ""` guard skipped every one and `threadsMap` stayed empty. Before #203 the command sent no `Select` at all, so v1 returned full runs including `thread_id`.

Both paths were affected, so this is not v2-specific — but every deployment reporting `>= 0.16` (all SaaS regions report `0.17.x`) takes the v2 path, so in practice `thread list` is broken everywhere.

**Fix.** Two thread-list-specific select helpers that extend the base sets with `thread_id` (`thread_id` on v1, `THREAD_ID` on v2). Scoped to `thread list` rather than added to the shared base sets, since no other command reads the field.

The silent-empty shape is the dangerous part: a wrong answer with a success exit code. The added tests assert the field is present on both paths and that each set is exactly the base plus one.

## Test Plan

- [x] Three new tests fail without the fix and pass with it (verified by reverting the helpers)
- [x] `thread list` byte-identical to the `v0.2.42` baseline on the v2 path
- [x] `thread list` correct on the v1 path via an `/info`-rewriting proxy