### PR TITLE
fix(cli): make documented time-window examples actually run

### DIFF
--- a/internal/cmd/filters.go
+++ b/internal/cmd/filters.go
@@ -63,14 +63,14 @@ func resolveStartTime(since string, lastNMinutes int) time.Time {
 		return time.Now().UTC().Add(-time.Duration(lastNMinutes) * time.Minute)
 	}
 	if since != "" {
-		t, err := time.Parse(time.RFC3339, since)
-		if err != nil {
-			t, err = time.Parse("2006-01-02T15:04:05", since)
-			if err != nil {
-				ExitErrorf("invalid --since timestamp: %s", since)
+		// Date-only is accepted so --since matches --before (parseFlexTime) and
+		// the "RFC3339 or YYYY-MM-DD" contract the flag help advertises.
+		for _, layout := range []string{time.RFC3339, "2006-01-02T15:04:05", "2006-01-02"} {
+			if t, err := time.Parse(layout, since); err == nil {
+				return t
 			}
 		}
-		return t
+		ExitErrorf("invalid --since timestamp: %s", since)
 	}
 	return time.Now().UTC().Add(-7 * 24 * time.Hour)
 }

--- a/internal/cmd/filters_test.go
+++ b/internal/cmd/filters_test.go
@@ -371,6 +371,17 @@ func TestResolveStartTime_Since(t *testing.T) {
 	}
 }
 
+// --before accepts date-only via parseFlexTime and the flag help advertises
+// "RFC3339 or YYYY-MM-DD", so --since must accept it too.
+func TestResolveStartTime_SinceAcceptsDateOnly(t *testing.T) {
+	for _, in := range []string{"2024-01-15", "2024-01-15T10:00:00", "2024-01-15T10:00:00Z"} {
+		st := resolveStartTime(in, 0)
+		if st.Year() != 2024 || st.Month() != time.January || st.Day() != 15 {
+			t.Errorf("resolveStartTime(%q) = %v, want 2024-01-15", in, st)
+		}
+	}
+}
+
 func TestResolveStartTime_LastNMinutesTakesPrecedence(t *testing.T) {
 	before := time.Now().UTC().Add(-61 * time.Minute)
 	st := resolveStartTime("2024-01-15T10:00:00Z", 60)

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -108,13 +108,15 @@ Each trace in the response contains a list of conversation groups:
   - "message" groups contain a single normalized message (human, ai, system, tool)
   - "tool_interaction" groups contain an AI message with tool calls and their results
 
-Requires --project. Results are paginated internally (default limit: 10, max: 100).
+Requires --project and an explicit start time (--since or --last-n-minutes);
+unlike the read/query commands this one has no implicit time window. Results
+are paginated internally (default limit: 10, max: 100).
 
 Examples:
-  langsmith trace messages --project my-chatbot --limit 5
-  langsmith trace messages --project my-chatbot --filter "eq(status, \"error\")"
-  langsmith trace messages --project my-chatbot --since 2024-01-15T00:00:00Z
-  langsmith trace messages --project my-chatbot --trace-ids <id1,id2>`,
+  langsmith trace messages --project my-chatbot --last-n-minutes 60 --limit 5
+  langsmith trace messages --project my-chatbot --last-n-minutes 60 --filter "eq(status, \"error\")"
+  langsmith trace messages --project my-chatbot --since <YYYY-MM-DDTHH:MM:SSZ>
+  langsmith trace messages --project my-chatbot --last-n-minutes 1440 --trace-ids <id1,id2>`,
 		Run: func(cmd *cobra.Command, args []string) {
 			defaultLimit := 10
 			if ff.Limit == 0 {

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -109,8 +109,8 @@ Each trace in the response contains a list of conversation groups:
   - "tool_interaction" groups contain an AI message with tool calls and their results
 
 Requires --project and an explicit start time (--since or --last-n-minutes);
-unlike the read/query commands this one has no implicit time window. Results
-are paginated internally (default limit: 10, max: 100).
+unlike the read/query commands this one has no implicit time window.
+Default limit: 10, max: 100.
 
 Examples:
   langsmith trace messages --project my-chatbot --last-n-minutes 60 --limit 5

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -10,6 +10,27 @@ import (
 
 // ==================== Command structure ====================
 
+// trace messages rejects invocations without --since/--last-n-minutes, so every
+// example in its help text must carry one. Three examples did not, which is
+// where callers copying the help got commands that always exit 1.
+func TestTraceMessagesCmd_HelpExamplesHaveStartTime(t *testing.T) {
+	cmd := newTraceMessagesCmd()
+	var examples int
+	for _, line := range strings.Split(cmd.Long, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "langsmith trace messages") {
+			continue
+		}
+		examples++
+		if !strings.Contains(line, "--since") && !strings.Contains(line, "--last-n-minutes") {
+			t.Errorf("help example lacks a start time (always exits 1): %q", line)
+		}
+	}
+	if examples == 0 {
+		t.Fatal("no help examples found; the assertion above would vacuously pass")
+	}
+}
+
 func TestTraceMessagesCmd_UseField(t *testing.T) {
 	cmd := newTraceMessagesCmd()
 	if cmd.Use != "messages" {

--- a/internal/cmd/trace_stats.go
+++ b/internal/cmd/trace_stats.go
@@ -58,7 +58,7 @@ to fetch a second time window side-by-side for trend comparison.
 Examples:
   langsmith trace stats --project my-app
   langsmith trace stats --project my-app --last-n-minutes 120
-  langsmith trace stats --project my-app --since 2025-01-10 --compare-since 2025-01-03 --compare-before 2025-01-10
+  langsmith trace stats --project my-app --since <YYYY-MM-DD> --compare-since <YYYY-MM-DD> --compare-before <YYYY-MM-DD>
   langsmith trace stats --project my-app --filter 'eq(status, "error")'`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := MustGetClient()


### PR DESCRIPTION
## Description

Four documented examples exit 1 as written. Found while testing the unreleased commits — none of this is a regression; it all reproduces on `v0.2.42`.

**`trace messages --help` — 3 of its 4 examples fail.** The command requires `--since` or `--last-n-minutes` (`min_start_time` is mandatory on `POST /v2/traces/messages`), but three examples omit it:

```
langsmith trace messages --project my-chatbot --limit 5
langsmith trace messages --project my-chatbot --filter "eq(status, \"error\")"
langsmith trace messages --project my-chatbot --trace-ids <id1,id2>
```

All three → `trace messages requires an explicit start time`.

**Its 4th example is now stale too.** `--since 2024-01-15T00:00:00Z` spans 924 days and trips SmithDB's 401-day cap (`time_range duration exceeds maximum of 401 days`). Any hardcoded absolute date rots this way, so it becomes a `<YYYY-MM-DDTHH:MM:SSZ>` placeholder rather than a date that expires again next year. Same treatment for the `trace stats` example dates.

**`trace stats --since <date>` is rejected despite being documented.** The flag help says *"RFC3339 or YYYY-MM-DD"* and `parseFlexTime` exists to parse exactly that — but only `--before` uses it. `--since` goes through the shared `resolveStartTime`, which accepted RFC3339 and `2006-01-02T15:04:05` and nothing else, so within one command `--before 2025-01-10` worked and `--since 2025-01-10` errored.

`resolveStartTime` now accepts date-only, making the two symmetric and the flag help true. This is strictly widening — every previously-valid input still parses — but it does affect `trace list`, `run list`, and `trace messages`, which share the helper. Flagging that explicitly in case you'd rather narrow the docs than widen the parser.

# Test Plan
- [x] Executed against prod (`0.17.1`) with the built binary:

| | exit |
|---|---|
| all 4 `trace messages` help examples | 0 |
| `trace stats --since 2026-07-20` (date-only) | 0 |
| `trace stats --since 2026-07-20T00:00:00Z` (RFC3339, unchanged) | 0 |
| `trace list --since 2026-07-20` | 0 |
| `run list --since 2026-07-20` | 0 |
| `trace stats --since not-a-date` | 1, `invalid --since timestamp: not-a-date` |