### PR TITLE
feat: add issues get subcommand

### DIFF
--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -46,11 +46,13 @@ func newProjectIssuesCmd() *cobra.Command {
 
 Examples:
   langsmith project issues list --project my-app
+  langsmith project issues get <issue-id>
   langsmith project issues list --project my-app --status open --priority high
   langsmith project issues events --project my-app`,
 	}
 
 	cmd.AddCommand(newProjectIssuesListCmd())
+	cmd.AddCommand(newProjectIssuesGetCmd())
 	cmd.AddCommand(newProjectIssuesEventsCmd())
 	cmd.AddCommand(newProjectIssuesUpdateCmd())
 	cmd.AddCommand(newProjectIssuesRunsCmd())
@@ -145,6 +147,38 @@ Examples:
 	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum number of issues to return")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 
+	return cmd
+}
+
+func newProjectIssuesGetCmd() *cobra.Command {
+	var outputFile string
+
+	cmd := &cobra.Command{
+		Use:   "get <issue-id>",
+		Short: "Get an issue by ID",
+		Long: `Get full details for a specific issue.
+
+The issue ID is the UUID returned by 'langsmith project issues list'.
+
+Examples:
+  langsmith project issues get <issue-id>
+  langsmith project issues get <issue-id> --output issue.json`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			c := MustGetClient()
+			ctx := context.Background()
+
+			path := fmt.Sprintf("/v1/platform/issues/%s", args[0])
+			var issue forgeIssue
+			if err := c.RawGet(ctx, path, &issue); err != nil {
+				ExitErrorf("getting issue: %v", err)
+			}
+
+			output.OutputJSON(issueToMap(issue), outputFile)
+		},
+	}
+
+	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 	return cmd
 }
 
@@ -395,6 +429,7 @@ func issueToMap(issue forgeIssue) map[string]any {
 		"fix_branch":    issue.FixBranch,
 		"fix_prompt":    issue.FixPrompt,
 		"fix_pr_number": issue.FixPRNumber,
+		"proposed_fix":  issue.ProposedFix,
 		"created_at":    formatTimeISO(issue.CreatedAt),
 		"updated_at":    formatTimeISO(issue.UpdatedAt),
 	}

--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -168,13 +168,12 @@ Examples:
 			c := MustGetClient()
 			ctx := context.Background()
 
-			path := fmt.Sprintf("/v1/platform/issues/%s", args[0])
-			var issue forgeIssue
-			if err := c.RawGet(ctx, path, &issue); err != nil {
+			issue, err := c.SDK.Issues.Get(ctx, args[0])
+			if err != nil {
 				ExitErrorf("getting issue: %v", err)
 			}
 
-			output.OutputJSON(issueToMap(issue), outputFile)
+			output.OutputJSON(json.RawMessage(issue.JSON.RawJSON()), outputFile)
 		},
 	}
 

--- a/internal/cmd/issues_test.go
+++ b/internal/cmd/issues_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"encoding/json"
+	"net/http"
 	"testing"
 )
 
@@ -10,6 +12,7 @@ func TestProjectIssuesCmd_Subcommands(t *testing.T) {
 	cmd := newProjectIssuesCmd()
 	expected := map[string]bool{
 		"list":     false,
+		"get":      false,
 		"events":   false,
 		"update":   false,
 		"runs":     false,
@@ -24,6 +27,62 @@ func TestProjectIssuesCmd_Subcommands(t *testing.T) {
 		if !found {
 			t.Errorf("issues missing subcommand %q", name)
 		}
+	}
+}
+
+func TestProjectIssuesGetCmd(t *testing.T) {
+	var method string
+	var path string
+	proposedFix := "Add the missing command"
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(forgeIssue{
+			ID:          "issue-123",
+			Name:        "Missing issues get command",
+			ProposedFix: &proposedFix,
+		})
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	out := captureStdout(t, func() {
+		cmd := newProjectIssuesGetCmd()
+		cmd.SetArgs([]string{"issue-123"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if method != http.MethodGet {
+		t.Errorf("expected GET request, got %q", method)
+	}
+	if path != "/v1/platform/issues/issue-123" {
+		t.Errorf("expected issue path, got %q", path)
+	}
+
+	var issue map[string]any
+	if err := json.Unmarshal([]byte(out), &issue); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, out)
+	}
+	if issue["id"] != "issue-123" {
+		t.Errorf("expected issue ID in output, got %#v", issue["id"])
+	}
+	if issue["proposed_fix"] != proposedFix {
+		t.Errorf("expected proposed fix in output, got %#v", issue["proposed_fix"])
+	}
+}
+
+func TestProjectIssuesGetCmd_ArgsAndFlags(t *testing.T) {
+	cmd := newProjectIssuesGetCmd()
+	if cmd.Use != "get <issue-id>" {
+		t.Errorf("expected Use=%q, got %q", "get <issue-id>", cmd.Use)
+	}
+	if err := cmd.Args(cmd, nil); err == nil {
+		t.Error("expected missing issue ID to fail argument validation")
+	}
+	if f := cmd.Flags().Lookup("output"); f == nil || f.Shorthand != "o" {
+		t.Errorf("expected --output/-o flag, got %+v", f)
 	}
 }
 


### PR DESCRIPTION
## Description
Adds `langsmith project issues get <issue-id>` for direct issue read-back, including `proposed_fix` in serialized output. It uses the generated Go SDK's existing `Issues.Get` method and preserves the API's original JSON response.

## Test Plan
- [x] Verify the command sends `GET /v1/platform/issues/{id}` and emits the returned proposed fix
- [x] Verify command registration, argument validation, and output flag

Made by [Open SWE](https://openswe.vercel.app/agents/a3205980-ee19-0c4d-ab21-ec3aaf22d470)
