### PR TITLE
fix: prefix hand-written request paths with /api for single-origin self-hosted

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -211,7 +211,7 @@ func (c *Client) RawDelete(ctx context.Context, path string, result any) error {
 // FetchCustomAppSource returns the stored .tar.gz bytes for a custom app.
 // The response is binary, so it bypasses the JSON-decoding raw helpers.
 func (c *Client) FetchCustomAppSource(ctx context.Context, appID string) ([]byte, error) {
-	path := "/v1/platform/custom-apps/" + url.PathEscape(appID) + "/source"
+	path := "/api/v1/platform/custom-apps/" + url.PathEscape(appID) + "/source"
 	resp, err := c.doHTTP(ctx, http.MethodGet, path, nil, nil)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/api_path_prefix_test.go
+++ b/internal/cmd/api_path_prefix_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// barePath matches a string literal that looks like a LangSmith API path without
+// the /api prefix, e.g. "/v1/platform/issues/%s" or "/runs/rules".
+var barePath = regexp.MustCompile(`"(/(?:v1|v2|runs|repos|commits|feedback|sessions|threads|traces)[a-zA-Z0-9/%{}._?=&-]*)"`)
+
+// The generated SDK emits paths under /api, but the CLI also builds paths itself
+// for endpoints the SDK does not cover yet and passes them to the Raw* helpers.
+// Single-origin self-hosted deployments serve the API under /api and have no
+// route for a bare /v1 or /v2, so a hand-written path without the prefix 404s
+// there while working fine against cloud — which is how the previous round of
+// these went unnoticed.
+func TestHandWrittenPathsCarryAPIPrefix(t *testing.T) {
+	t.Parallel()
+
+	root := ".." // internal/
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, m := range barePath.FindAllStringSubmatch(string(src), -1) {
+			t.Errorf("%s: request path %q is missing the /api prefix; single-origin "+
+				"self-hosted serves the API under /api and has no route for the bare form. "+
+				"Use \"/api%s\" (or the SDK, if it covers this endpoint).", path, m[1], m[1])
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+}

--- a/internal/cmd/apps_crud_test.go
+++ b/internal/cmd/apps_crud_test.go
@@ -87,10 +87,10 @@ func TestAppsDelete_SkipsConfirmationWithYes(t *testing.T) {
 	var sawDelete bool
 	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == "GET" && r.URL.Path == "/v1/platform/custom-apps":
+		case r.Method == "GET" && r.URL.Path == "/api/v1/platform/custom-apps":
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode([]customApp{{ID: id, Name: "one"}})
-		case r.Method == "DELETE" && r.URL.Path == "/v1/platform/custom-apps/"+id:
+		case r.Method == "DELETE" && r.URL.Path == "/api/v1/platform/custom-apps/"+id:
 			sawDelete = true
 			w.WriteHeader(http.StatusNoContent)
 		default:
@@ -119,7 +119,7 @@ func TestAppsDelete_ResolvesNameToID(t *testing.T) {
 	var deletePath string
 	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == "GET" && r.URL.Path == "/v1/platform/custom-apps":
+		case r.Method == "GET" && r.URL.Path == "/api/v1/platform/custom-apps":
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode([]customApp{
 				{ID: "44444444-4444-4444-4444-444444444444", Name: "other"},
@@ -141,7 +141,7 @@ func TestAppsDelete_ResolvesNameToID(t *testing.T) {
 			t.Fatalf("execute: %v", err)
 		}
 	})
-	if deletePath != "/v1/platform/custom-apps/"+id {
+	if deletePath != "/api/v1/platform/custom-apps/"+id {
 		t.Errorf("expected the name resolved to its ID before deleting, got %q", deletePath)
 	}
 	if !strings.Contains(out, `"name": "My App"`) {

--- a/internal/cmd/apps_delete.go
+++ b/internal/cmd/apps_delete.go
@@ -35,7 +35,7 @@ func newAppsDeleteCmd() *cobra.Command {
 				}
 			}
 
-			if err := c.RawDelete(ctx, "/v1/platform/custom-apps/"+id, nil); err != nil {
+			if err := c.RawDelete(ctx, "/api/v1/platform/custom-apps/"+id, nil); err != nil {
 				return fmt.Errorf("deleting custom app %s: %w", id, err)
 			}
 			output.OutputJSON(map[string]any{

--- a/internal/cmd/apps_list.go
+++ b/internal/cmd/apps_list.go
@@ -18,7 +18,7 @@ func newAppsListCmd() *cobra.Command {
 			ctx := cmd.Context()
 
 			var apps []customApp
-			if err := c.RawGet(ctx, "/v1/platform/custom-apps", &apps); err != nil {
+			if err := c.RawGet(ctx, "/api/v1/platform/custom-apps", &apps); err != nil {
 				return fmt.Errorf("listing custom apps: %w", err)
 			}
 

--- a/internal/cmd/apps_pull.go
+++ b/internal/cmd/apps_pull.go
@@ -98,7 +98,7 @@ The target directory is replaced, not merged. Run "npm install" after.`,
 // resolveCustomApp accepts an app ID or name.
 func resolveCustomApp(ctx context.Context, c *client.Client, nameOrID string) (*customApp, error) {
 	var apps []customApp
-	if err := c.RawGet(ctx, "/v1/platform/custom-apps", &apps); err != nil {
+	if err := c.RawGet(ctx, "/api/v1/platform/custom-apps", &apps); err != nil {
 		return nil, fmt.Errorf("looking up custom app %q: %w", nameOrID, err)
 	}
 

--- a/internal/cmd/apps_pull_test.go
+++ b/internal/cmd/apps_pull_test.go
@@ -65,12 +65,12 @@ func tarGzWithSymlink(t *testing.T, target string) []byte {
 func appsSourceServer(t *testing.T, apps []customApp, source map[string][]byte) *http.ServeMux {
 	t.Helper()
 	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/platform/custom-apps", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/platform/custom-apps", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(apps)
 	})
-	mux.HandleFunc("/v1/platform/custom-apps/", func(w http.ResponseWriter, r *http.Request) {
-		id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v1/platform/custom-apps/"), "/source")
+	mux.HandleFunc("/api/v1/platform/custom-apps/", func(w http.ResponseWriter, r *http.Request) {
+		id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/platform/custom-apps/"), "/source")
 		archive, ok := source[id]
 		if !ok {
 			w.Header().Set("Content-Type", "application/json")
@@ -116,7 +116,7 @@ func TestAppsPull_ResolvesNameToIDAndExtracts(t *testing.T) {
 		}
 	})
 
-	if sourcePath != "/v1/platform/custom-apps/"+testAppID+"/source" {
+	if sourcePath != "/api/v1/platform/custom-apps/"+testAppID+"/source" {
 		t.Errorf("expected the name to resolve to an ID before fetching source, got %q", sourcePath)
 	}
 

--- a/internal/cmd/apps_push.go
+++ b/internal/cmd/apps_push.go
@@ -90,7 +90,7 @@ same app too.
 					Name:          optionalString(name),
 					Description:   optionalString(description),
 				}
-				err := c.RawPatch(ctx, "/v1/platform/custom-apps/"+link.AppID, payload, &app)
+				err := c.RawPatch(ctx, "/api/v1/platform/custom-apps/"+link.AppID, payload, &app)
 				switch {
 				case err == nil:
 					updated = true
@@ -135,7 +135,7 @@ same app too.
 					SourceArchive: optionalString(sourceArchive),
 					Description:   optionalString(description),
 				}
-				if err := c.RawPost(ctx, "/v1/platform/custom-apps", payload, &app); err != nil {
+				if err := c.RawPost(ctx, "/api/v1/platform/custom-apps", payload, &app); err != nil {
 					if isSourceArchiveRejection(err) {
 						return sourceArchiveRejectionError(err)
 					}

--- a/internal/cmd/apps_push_test.go
+++ b/internal/cmd/apps_push_test.go
@@ -26,7 +26,7 @@ func TestAppsPush_CreatesAndWritesLink(t *testing.T) {
 
 	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == "POST" && r.URL.Path == "/v1/platform/custom-apps":
+		case r.Method == "POST" && r.URL.Path == "/api/v1/platform/custom-apps":
 			sawPost = true
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &postBody)
@@ -79,7 +79,7 @@ func TestAppsPush_UpdatesWhenAlreadyLinked(t *testing.T) {
 
 	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == "POST" && r.URL.Path == "/v1/platform/custom-apps":
+		case r.Method == "POST" && r.URL.Path == "/api/v1/platform/custom-apps":
 			sawPost = true
 		case r.Method == "PATCH":
 			sawPatch = true
@@ -117,7 +117,7 @@ func TestAppsPush_UpdatesWhenAlreadyLinked(t *testing.T) {
 	if !sawPatch {
 		t.Fatal("expected PATCH to update the existing app")
 	}
-	if patchPath != "/v1/platform/custom-apps/app_existing" {
+	if patchPath != "/api/v1/platform/custom-apps/app_existing" {
 		t.Errorf("unexpected PATCH path: %s", patchPath)
 	}
 }
@@ -128,7 +128,7 @@ func TestAppsPush_CreatesWhenLinkedButNotYetCreated(t *testing.T) {
 
 	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == "POST" && r.URL.Path == "/v1/platform/custom-apps":
+		case r.Method == "POST" && r.URL.Path == "/api/v1/platform/custom-apps":
 			sawPost = true
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &postBody)
@@ -185,12 +185,12 @@ func TestAppsPush_RecreatesWhenLinkedAppWasDeleted(t *testing.T) {
 
 	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == "PATCH" && r.URL.Path == "/v1/platform/custom-apps/app_deleted":
+		case r.Method == "PATCH" && r.URL.Path == "/api/v1/platform/custom-apps/app_deleted":
 			sawPatch = true
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
 			_ = json.NewEncoder(w).Encode(map[string]string{"error": "custom app not found"})
-		case r.Method == "POST" && r.URL.Path == "/v1/platform/custom-apps":
+		case r.Method == "POST" && r.URL.Path == "/api/v1/platform/custom-apps":
 			sawPost = true
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &postBody)
@@ -264,7 +264,7 @@ func TestAppsPush_ErrorsWhenEntrypointMissing(t *testing.T) {
 
 func TestAppsPush_BuildsFromPackageJSONByDefault(t *testing.T) {
 	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "POST" && r.URL.Path == "/v1/platform/custom-apps" {
+		if r.Method == "POST" && r.URL.Path == "/api/v1/platform/custom-apps" {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(customApp{ID: "app_new", Name: "my-app", Entrypoint: "dist/bundle.js"})
 			return
@@ -321,7 +321,7 @@ func TestAppsPush_UploadsSourceArchiveOnCreate(t *testing.T) {
 
 	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == "POST" && r.URL.Path == "/v1/platform/custom-apps":
+		case r.Method == "POST" && r.URL.Path == "/api/v1/platform/custom-apps":
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &postBody)
 			w.Header().Set("Content-Type", "application/json")
@@ -372,7 +372,7 @@ func TestAppsPush_UploadsSourceArchiveOnUpdate(t *testing.T) {
 
 	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == "PATCH" && r.URL.Path == "/v1/platform/custom-apps/app_existing":
+		case r.Method == "PATCH" && r.URL.Path == "/api/v1/platform/custom-apps/app_existing":
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &patchBody)
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/cmd/evaluator.go
+++ b/internal/cmd/evaluator.go
@@ -310,10 +310,10 @@ func newEvaluatorUploadCmd() *cobra.Command {
 
 			var result map[string]any
 			if existing != nil {
-				if err := c.RawPatch(ctx, fmt.Sprintf("/runs/rules/%s", existing.ID), payload, &result); err != nil {
+				if err := c.RawPatch(ctx, fmt.Sprintf("/api/v1/runs/rules/%s", existing.ID), payload, &result); err != nil {
 					ExitErrorf("replacing evaluator: %v", err)
 				}
-			} else if err := c.RawPost(ctx, "/runs/rules", payload, &result); err != nil {
+			} else if err := c.RawPost(ctx, "/api/v1/runs/rules", payload, &result); err != nil {
 				ExitErrorf("uploading evaluator: %v", err)
 			}
 
@@ -407,10 +407,10 @@ Examples:
 
 			var result map[string]any
 			if existing != nil {
-				if err := c.RawPatch(ctx, fmt.Sprintf("/runs/rules/%s", existing.ID), payload, &result); err != nil {
+				if err := c.RawPatch(ctx, fmt.Sprintf("/api/v1/runs/rules/%s", existing.ID), payload, &result); err != nil {
 					ExitErrorf("replacing LLM evaluator: %v", err)
 				}
-			} else if err := c.RawPost(ctx, "/runs/rules", payload, &result); err != nil {
+			} else if err := c.RawPost(ctx, "/api/v1/runs/rules", payload, &result); err != nil {
 				ExitErrorf("creating LLM evaluator: %v", err)
 			}
 			targetLabel := "project"
@@ -483,7 +483,7 @@ func newEvaluatorDeleteCmd() *cobra.Command {
 
 			deleted := 0
 			for _, rule := range matching {
-				if err := c.RawDelete(ctx, fmt.Sprintf("/runs/rules/%s", rule.ID), nil); err != nil {
+				if err := c.RawDelete(ctx, fmt.Sprintf("/api/v1/runs/rules/%s", rule.ID), nil); err != nil {
 					ExitErrorf("deleting evaluator %s: %v", rule.ID, err)
 				}
 				deleted++

--- a/internal/cmd/evaluator_test.go
+++ b/internal/cmd/evaluator_test.go
@@ -762,7 +762,7 @@ func TestEvaluatorUploadReplacePatchesExistingCodeEvaluator(t *testing.T) {
 					},
 				},
 			})
-		case r.URL.Path == "/runs/rules/existing-rule" && r.Method == "PATCH":
+		case r.URL.Path == "/api/v1/runs/rules/existing-rule" && r.Method == "PATCH":
 			if err := json.NewDecoder(r.Body).Decode(&patchBody); err != nil {
 				t.Fatalf("decoding patch body: %v", err)
 			}
@@ -771,7 +771,7 @@ func TestEvaluatorUploadReplacePatchesExistingCodeEvaluator(t *testing.T) {
 				"display_name": "accuracy",
 				"session_id":   "project-1",
 			})
-		case r.URL.Path == "/runs/rules/existing-rule" && r.Method == "DELETE":
+		case r.URL.Path == "/api/v1/runs/rules/existing-rule" && r.Method == "DELETE":
 			sawDelete = true
 			http.Error(w, "delete should not be called", http.StatusInternalServerError)
 		default:
@@ -866,7 +866,7 @@ func TestEvaluatorCreateLLMReplacePatchesExistingEvaluator(t *testing.T) {
 					},
 				},
 			})
-		case r.URL.Path == "/runs/rules/existing-rule" && r.Method == "PATCH":
+		case r.URL.Path == "/api/v1/runs/rules/existing-rule" && r.Method == "PATCH":
 			if err := json.NewDecoder(r.Body).Decode(&patchBody); err != nil {
 				t.Fatalf("decoding patch body: %v", err)
 			}
@@ -875,7 +875,7 @@ func TestEvaluatorCreateLLMReplacePatchesExistingEvaluator(t *testing.T) {
 				"display_name": "relevance",
 				"session_id":   "project-1",
 			})
-		case r.URL.Path == "/runs/rules/existing-rule" && r.Method == "DELETE":
+		case r.URL.Path == "/api/v1/runs/rules/existing-rule" && r.Method == "DELETE":
 			sawDelete = true
 			http.Error(w, "delete should not be called", http.StatusInternalServerError)
 		default:

--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -92,7 +92,7 @@ Examples:
 				ExitError("--project is required (or set LANGSMITH_PROJECT)")
 			}
 
-			path := fmt.Sprintf("/v1/platform/issues?session_name=%s", urlEscape(projectName))
+			path := fmt.Sprintf("/api/v1/platform/issues?session_name=%s", urlEscape(projectName))
 			if status != "" {
 				path += "&status=" + urlEscape(status)
 			}
@@ -230,7 +230,7 @@ Examples:
 				ExitErrorf("resolving project %q: %v", projectName, err)
 			}
 
-			path := fmt.Sprintf("/v1/platform/sessions/%s/issue-events?look_back_minutes=%d&limit=%d",
+			path := fmt.Sprintf("/api/v1/platform/sessions/%s/issue-events?look_back_minutes=%d&limit=%d",
 				sessionID, lookBackMinutes, limit)
 
 			var events []issueEvent
@@ -380,7 +380,7 @@ Examples:
 				}}
 			}
 
-			path := fmt.Sprintf("/v1/platform/issues/%s", issueID)
+			path := fmt.Sprintf("/api/v1/platform/issues/%s", issueID)
 
 			var issue forgeIssue
 			if err := c.RawPatch(ctx, path, body, &issue); err != nil {
@@ -562,7 +562,7 @@ Examples:
 				body["comment"] = comment
 			}
 
-			path := fmt.Sprintf("/v1/platform/issues/%s/runs", issueID)
+			path := fmt.Sprintf("/api/v1/platform/issues/%s/runs", issueID)
 			if err := c.RawPost(ctx, path, body, nil); err != nil {
 				ExitErrorf("linking run: %v", err)
 			}
@@ -588,7 +588,7 @@ func newProjectIssuesRunsRemoveCmd() *cobra.Command {
 			c := MustGetClient()
 			ctx := context.Background()
 
-			path := fmt.Sprintf("/v1/platform/issues/%s/runs/%s", issueID, runID)
+			path := fmt.Sprintf("/api/v1/platform/issues/%s/runs/%s", issueID, runID)
 			if err := c.RawDelete(ctx, path, nil); err != nil {
 				ExitErrorf("unlinking run: %v", err)
 			}
@@ -700,7 +700,7 @@ Examples:
 				"assertions": parsed,
 			}
 
-			path := fmt.Sprintf("/v1/platform/issues/%s/proposed-examples", issueID)
+			path := fmt.Sprintf("/api/v1/platform/issues/%s/proposed-examples", issueID)
 			var result map[string]any
 			if err := c.RawPost(ctx, path, body, &result); err != nil {
 				ExitErrorf("proposing example: %v", err)

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -188,7 +188,7 @@ Examples:
 				body["page_size"] = pageSize
 
 				var result map[string]any
-				if err := c.RawPost(ctx, "/v2/traces/messages", body, &result); err != nil {
+				if err := c.RawPost(ctx, "/api/v2/traces/messages", body, &result); err != nil {
 					ExitErrorf("%v", err)
 				}
 
@@ -236,7 +236,7 @@ Examples:
 				body["page_size"] = pageSize
 
 				var result map[string]any
-				if err := c.RawPost(ctx, "/v2/traces/messages", body, &result); err != nil {
+				if err := c.RawPost(ctx, "/api/v2/traces/messages", body, &result); err != nil {
 					ExitErrorf("%v", err)
 				}
 

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -94,7 +94,7 @@ func TestTraceMessages_Success(t *testing.T) {
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"id": "sess-123", "name": "my-project"},
 			})
-		case r.URL.Path == "/v2/traces/messages" && r.Method == "POST":
+		case r.URL.Path == "/api/v2/traces/messages" && r.Method == "POST":
 			var body map[string]any
 			_ = json.NewDecoder(r.Body).Decode(&body)
 
@@ -166,7 +166,7 @@ func TestTraceMessages_PassesFilterAndRunType(t *testing.T) {
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"id": "sess-456", "name": "test-proj"},
 			})
-		case r.URL.Path == "/v2/traces/messages":
+		case r.URL.Path == "/api/v2/traces/messages":
 			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -214,7 +214,7 @@ func TestTraceMessages_PrettyFormat(t *testing.T) {
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"id": "sess-pretty", "name": "my-project"},
 			})
-		case r.URL.Path == "/v2/traces/messages":
+		case r.URL.Path == "/api/v2/traces/messages":
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"items": []map[string]any{
@@ -314,7 +314,7 @@ func TestTraceMessages_Pagination(t *testing.T) {
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"id": "sess-pag", "name": "pag-proj"},
 			})
-		case r.URL.Path == "/v2/traces/messages":
+		case r.URL.Path == "/api/v2/traces/messages":
 			var body map[string]any
 			_ = json.NewDecoder(r.Body).Decode(&body)
 			pageCount++
@@ -399,7 +399,7 @@ func TestTraceMessages_PaginationStopsAtLimit(t *testing.T) {
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"id": "sess-lim", "name": "lim-proj"},
 			})
-		case r.URL.Path == "/v2/traces/messages":
+		case r.URL.Path == "/api/v2/traces/messages":
 			var body map[string]any
 			_ = json.NewDecoder(r.Body).Decode(&body)
 			pageCount++
@@ -457,7 +457,7 @@ func TestTraceMessages_CursorFlag_SinglePage(t *testing.T) {
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"id": "sess-cur", "name": "cur-proj"},
 			})
-		case r.URL.Path == "/v2/traces/messages":
+		case r.URL.Path == "/api/v2/traces/messages":
 			callCount++
 			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
 			w.Header().Set("Content-Type", "application/json")
@@ -515,7 +515,7 @@ func TestTraceMessages_CursorFlag_EmptyCursorIsFirstPage(t *testing.T) {
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"id": "sess-first", "name": "first-proj"},
 			})
-		case r.URL.Path == "/v2/traces/messages":
+		case r.URL.Path == "/api/v2/traces/messages":
 			callCount++
 			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
 			w.Header().Set("Content-Type", "application/json")
@@ -565,7 +565,7 @@ func TestTraceMessages_BeforeFlag(t *testing.T) {
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"id": "sess-bef", "name": "bef-proj"},
 			})
-		case r.URL.Path == "/v2/traces/messages":
+		case r.URL.Path == "/api/v2/traces/messages":
 			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -600,7 +600,7 @@ func TestTraceMessages_FeedbackStats(t *testing.T) {
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"id": "sess-fb", "name": "fb-proj"},
 			})
-		case r.URL.Path == "/v2/traces/messages" && r.Method == "POST":
+		case r.URL.Path == "/api/v2/traces/messages" && r.Method == "POST":
 			// API returns feedback_stats directly on each trace
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -673,7 +673,7 @@ func TestTraceMessages_EmptyResult(t *testing.T) {
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"id": "sess-789", "name": "empty-proj"},
 			})
-		case r.URL.Path == "/v2/traces/messages":
+		case r.URL.Path == "/api/v2/traces/messages":
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"items": []any{},

--- a/internal/cmd/prompt.go
+++ b/internal/cmd/prompt.go
@@ -544,7 +544,7 @@ func newPromptTagListCmd() *cobra.Command {
 			ctx := context.Background()
 
 			var tags []repoTag
-			path := fmt.Sprintf("/repos/%s/%s/tags", owner, repo)
+			path := fmt.Sprintf("/api/v1/repos/%s/%s/tags", owner, repo)
 			if err := c.RawGet(ctx, path, &tags); err != nil {
 				ExitErrorf("listing tags for %s/%s: %v", owner, repo, err)
 			}
@@ -603,7 +603,7 @@ func newPromptTagCreateCmd() *cobra.Command {
 				"commit_id": commitID,
 			}
 			var tag repoTag
-			path := fmt.Sprintf("/repos/%s/%s/tags", owner, repo)
+			path := fmt.Sprintf("/api/v1/repos/%s/%s/tags", owner, repo)
 			if err := c.RawPost(ctx, path, body, &tag); err != nil {
 				ExitErrorf("creating tag %q: %v", tagName, err)
 			}
@@ -646,7 +646,7 @@ func newPromptTagUpdateCmd() *cobra.Command {
 				"commit_id": commitID,
 			}
 			var tag repoTag
-			path := fmt.Sprintf("/repos/%s/%s/tags", owner, repo)
+			path := fmt.Sprintf("/api/v1/repos/%s/%s/tags", owner, repo)
 			if err := c.RawPost(ctx, path, body, &tag); err != nil {
 				ExitErrorf("updating tag %q: %v", tagName, err)
 			}

--- a/internal/cmd/skill.go
+++ b/internal/cmd/skill.go
@@ -88,7 +88,7 @@ Use --copy to copy instead of symlink.`,
 				canonicalDir = filepath.Join(".agents", "skills", skillName)
 			}
 
-			apiPath := fmt.Sprintf("/v1/platform/hub/repos/-/%s/directories", skillName)
+			apiPath := fmt.Sprintf("/api/v1/platform/hub/repos/-/%s/directories", skillName)
 			var resp directoryResponse
 			if err := c.RawGet(context.Background(), apiPath, &resp); err != nil {
 				return fmt.Errorf("fetching skill %q: %w", skillName, err)

--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -326,7 +326,7 @@ Examples:
 				q.Set("trace_id", traceID)
 			}
 
-			path := fmt.Sprintf("/v2/threads/%s/messages?%s", url.PathEscape(threadID), q.Encode())
+			path := fmt.Sprintf("/api/v2/threads/%s/messages?%s", url.PathEscape(threadID), q.Encode())
 
 			extraHeaders := http.Header{"Accept": {"text/event-stream"}}
 			_, _, _, body, err := c.RawDo(ctx, http.MethodGet, path, nil, extraHeaders)


### PR DESCRIPTION
Follow-up to #216. That bump fixed the SDK-generated paths; this fixes the ones the CLI builds itself.

## Why

The CLI hand-builds request paths for endpoints the SDK doesn't cover yet and passes them to the `Raw*` helpers. Those went out bare, so on single-origin self-hosted — where the API is served under `/api` and there is no route for a bare `/v1` or `/v2` — they 404'd, while working fine against cloud.

That covered the whole `issues` board surface and `trace messages`, which is most of what an agent drives the CLI for on self-hosted.

`flagged.go` already used `/api/v1/feedback`; this brings the remaining 24 literals in line.

| Before | After |
| --- | --- |
| `/v1/platform/...` | `/api/v1/platform/...` |
| `/v2/traces/messages` | `/api/v2/traces/messages` |
| `/v2/threads/{id}/messages` | `/api/v2/threads/{id}/messages` |
| `/runs/rules[/{id}]` | `/api/v1/runs/rules[/{id}]` |
| `/repos/{owner}/{repo}/tags` | `/api/v1/repos/{owner}/{repo}/tags` |

## Verification

Every new form was probed against cloud alongside the bare form it replaces and returns the **same status code**, so cloud behaviour is unchanged:

- `custom-apps` 200/200, `runs/rules` 200/200, `traces/messages` 400/400, `threads/{id}/messages` 400/400, `hub/repos/.../directories` 404/404, `repos/{o}/{r}/tags` 200/200

On self-hosted these resolve via the chart's existing `location /api/v1/platform/`, `location /api/v2/`, and the general `location /api/v1` — no chart change needed.

## Guard test

`TestHandWrittenPathsCarryAPIPrefix` scans non-test sources and fails on any bare API path literal. This failure mode is invisible from cloud, which is how the current batch went unnoticed — worth a test rather than a convention. Verified it fails when a path is reverted and passes when clean.

## Known adjacent issue (not addressed here)

Several of these interpolate user-supplied values into the path with plain `fmt.Sprintf` — issue IDs, thread IDs, and notably `repo owner/name` from CLI args. `client.go` uses `url.PathEscape` for app IDs; the others don't. Worth escaping consistently, but it's a pre-existing concern independent of the prefix and I've left it out to keep this reviewable.

## Test Plan

- [x] `go test ./...` and `make lint` clean
- [x] Each new path form probed against cloud, status matches the bare form
- [x] Guard test verified in both directions (fails on a reverted path, passes clean)
- [x] `langsmith issues list` / `issues get` and `trace messages` against a 0.16 self-hosted instance — the paths this PR actually unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
