### PR TITLE
fix(issues): send limit to the api and add --offset

### DIFF
--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -96,7 +96,7 @@ Examples:
 			if projectName == "" {
 				ExitError("--project is required (or set LANGSMITH_PROJECT)")
 			}
-			if limit < 0 {
+			if limit <= 0 {
 				ExitError("--limit must be a positive integer")
 			}
 			if offset < 0 {

--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -66,6 +66,7 @@ func newProjectIssuesListCmd() *cobra.Command {
 		status     string
 		priority   string
 		limit      int
+		offset     int
 		outputFile string
 	)
 
@@ -75,13 +76,17 @@ func newProjectIssuesListCmd() *cobra.Command {
 		Long: `List forge issues associated with a tracing project.
 
 Fetches issues from the Issues Board for the specified project. Results
-can be filtered by status (open/closed) and priority (high/medium/low).
+can be filtered by status and priority (high/medium/low).
 Output is JSON by default; pass --format pretty for a human-readable table.
+
+The server returns at most 500 issues per request. Page through larger
+boards with --offset, advancing by --limit until a page comes back short.
 
 Examples:
   langsmith project issues list --project my-app
   langsmith project issues list --project my-app --status open
   langsmith project issues list --project my-app --priority high --limit 10
+  langsmith project issues list --project my-app --limit 500 --offset 500
   langsmith project issues list --project my-app --format pretty`,
 		Run: func(cmd *cobra.Command, args []string) {
 			c := MustGetClient()
@@ -91,10 +96,22 @@ Examples:
 			if projectName == "" {
 				ExitError("--project is required (or set LANGSMITH_PROJECT)")
 			}
+			if limit < 0 {
+				ExitError("--limit must be a positive integer")
+			}
+			if offset < 0 {
+				ExitError("--offset must be a non-negative integer")
+			}
 
 			path := fmt.Sprintf("/api/v1/platform/issues?session_name=%s", urlEscape(projectName))
 			if status != "" {
 				path += "&status=" + urlEscape(status)
+			}
+			if limit > 0 {
+				path += fmt.Sprintf("&limit=%d", limit)
+			}
+			if offset > 0 {
+				path += fmt.Sprintf("&offset=%d", offset)
 			}
 			if priority != "" {
 				sev := priorityToSeverity(priority)
@@ -106,10 +123,6 @@ Examples:
 			var issues []forgeIssue
 			if err := c.RawGet(ctx, path, &issues); err != nil {
 				ExitErrorf("listing issues: %v", err)
-			}
-
-			if limit > 0 && len(issues) > limit {
-				issues = issues[:limit]
 			}
 
 			fmt_ := GetFormat()
@@ -142,9 +155,10 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
-	cmd.Flags().StringVar(&status, "status", "", "Filter by status: open or closed")
+	cmd.Flags().StringVar(&status, "status", "", "Filter by status: open, fixing, watching, completed, or ignored")
 	cmd.Flags().StringVar(&priority, "priority", "", "Filter by priority: high, medium, or low")
-	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum number of issues to return")
+	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum number of issues to return (server caps at 500)")
+	cmd.Flags().IntVar(&offset, "offset", 0, "Number of issues to skip, for paging through boards larger than --limit")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 
 	return cmd

--- a/internal/cmd/issues_test.go
+++ b/internal/cmd/issues_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"testing"
 )
 
@@ -83,6 +84,68 @@ func TestProjectIssuesGetCmd_ArgsAndFlags(t *testing.T) {
 	}
 	if f := cmd.Flags().Lookup("output"); f == nil || f.Shorthand != "o" {
 		t.Errorf("expected --output/-o flag, got %+v", f)
+	}
+}
+
+func TestProjectIssuesListCmd_ForwardsPaginationAndFilters(t *testing.T) {
+	var gotPath string
+	var gotQuery url.Values
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]forgeIssue{})
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	captureStdout(t, func() {
+		cmd := newProjectIssuesListCmd()
+		cmd.SetArgs([]string{
+			"--project", "my app",
+			"--status", "watching",
+			"--priority", "high",
+			"--limit", "200",
+			"--offset", "400",
+		})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if gotPath != "/api/v1/platform/issues" {
+		t.Errorf("expected issues list path, got %q", gotPath)
+	}
+	want := url.Values{
+		"session_name": {"my app"},
+		"status":       {"watching"},
+		"severity":     {"1"},
+		"limit":        {"200"},
+		"offset":       {"400"},
+	}
+	if gotQuery.Encode() != want.Encode() {
+		t.Errorf("unexpected query: got %q, want %q", gotQuery.Encode(), want.Encode())
+	}
+}
+
+func TestProjectIssuesListCmd_Flags(t *testing.T) {
+	cmd := newProjectIssuesListCmd()
+	tests := []struct {
+		name   string
+		defVal string
+	}{
+		{name: "limit", defVal: "50"},
+		{name: "offset", defVal: "0"},
+		{name: "status", defVal: ""},
+	}
+	for _, tc := range tests {
+		flag := cmd.Flags().Lookup(tc.name)
+		if flag == nil {
+			t.Errorf("flag --%s not found", tc.name)
+			continue
+		}
+		if flag.DefValue != tc.defVal {
+			t.Errorf("flag --%s: expected default %q, got %q", tc.name, tc.defVal, flag.DefValue)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

`langsmith project issues list` now sends `limit` and `offset` to the API, and `--status` help lists the real statuses.

## Why

The command never put `limit` on the request path:

```go
path := fmt.Sprintf("/api/v1/platform/issues?session_name=%s", urlEscape(projectName))
if status != "" { path += "&status=" + urlEscape(status) }
// limit never appended
if err := c.RawGet(ctx, path, &issues); ...
if limit > 0 && len(issues) > limit { issues = issues[:limit] } // client-side only
```

The server applied its default (`clampListIssuesLimit` → 50) and the CLI truncated *downward* from there, so `--limit` could only ever return fewer than 50, never more. Measured against prod before the change:

| `--limit` | rows |
|---|---|
| 50 / 100 / 200 / 500 / 1000 | **50 every time** |

The API has supported this all along: `clampListIssuesLimit` accepts up to 500 and the handler parses `offset`. Neither was reachable from the CLI.

`--status` help also advertised `open or closed`. `closed` is not a status; the server rejects it. Valid values are `open`, `fixing`, `watching`, `completed`, and `ignored`.

## Changes

- Append `limit` and `offset` to the request query.
- Add `--offset`, with validation matching the server contract.
- Remove the redundant client-side slice.
- Correct the `--status` help text and long description.
- Add a request-level regression test proving project, status, priority, limit, and offset reach the server.

## Impact

Anything paging a board larger than 50 currently gets a silently truncated view. That matters most for automated consumers that dedup against the issue list, since a truncated read is indistinguishable from "no matching issue" and produces duplicates. Engine is one such consumer; see langchain-ai/langchainplus#32428.

## Test plan

- [x] `gofmt` clean
- [x] `go test ./internal/cmd -count=1`
- [x] Request-level regression test covers `limit`, `offset`, status, priority, and escaped project names
- [ ] Manual paging against a board with more than 50 issues
