### PR TITLE
fix: move two of our templates to v2 APIs

### DIFF
--- a/internal/cmd/templates/coding-agent-dashboard/src/api.ts
+++ b/internal/cmd/templates/coding-agent-dashboard/src/api.ts
@@ -119,17 +119,17 @@ export async function fetchProjectStats(sessionId: string, windowDays: number): 
 // for anything but "what happened most recently."
 export async function fetchRecentRuns(sessionId: string, windowDays: number) {
   await sleep(INTER_QUERY_GAP_MS);
-  const resp = await callWithRetry<RunsQueryResponse>('POST /api/v1/runs/query', {
+  const resp = await callWithRetry<RunsQueryResponse>('POST /api/v2/runs/query', {
     body: {
-      session: [sessionId],
+      project_ids: [sessionId],
       filter: CODING_FILTER,
-      start_time: windowStart(windowDays),
+      min_start_time: windowStart(windowDays),
       is_root: true,
-      limit: RECENT_RUNS_LIMIT,
-      select: ['id', 'name', 'error', 'start_time', 'end_time', 'total_tokens', 'total_cost', 'extra'],
+      page_size: RECENT_RUNS_LIMIT,
+      selects: ['ID', 'NAME', 'ERROR', 'START_TIME', 'END_TIME', 'TOTAL_TOKENS', 'TOTAL_COST', 'EXTRA'],
     },
   });
-  return resp?.runs ?? [];
+  return resp?.items ?? [];
 }
 
 // What fraction of the most recent root runs in this window are coding-agent
@@ -140,16 +140,16 @@ export async function fetchRecentRuns(sessionId: string, windowDays: number) {
 // whole-window rate.
 export async function fetchCodingShare(sessionId: string, windowDays: number): Promise<CodingShare> {
   await sleep(INTER_QUERY_GAP_MS);
-  const resp = await callWithRetry<RunsQueryResponse>('POST /api/v1/runs/query', {
+  const resp = await callWithRetry<RunsQueryResponse>('POST /api/v2/runs/query', {
     body: {
-      session: [sessionId],
-      start_time: windowStart(windowDays),
+      project_ids: [sessionId],
+      min_start_time: windowStart(windowDays),
       is_root: true,
-      limit: RECENT_RUNS_LIMIT,
-      select: ['id', 'extra'],
+      page_size: RECENT_RUNS_LIMIT,
+      selects: ['ID', 'EXTRA'],
     },
   });
-  const runs = resp?.runs ?? [];
+  const runs = resp?.items ?? [];
   const coding = runs.filter((r) => r.extra?.metadata?.ls_agent_purpose === 'coding').length;
   return { coding, total: runs.length };
 }

--- a/internal/cmd/templates/coding-agent-dashboard/src/types.ts
+++ b/internal/cmd/templates/coding-agent-dashboard/src/types.ts
@@ -3,7 +3,7 @@ export interface Project {
   name: string;
 }
 
-// Fields selected from POST /api/v1/runs/query for the recent-runs table.
+// Fields selected from POST /v2/runs/query for the recent-runs table.
 // Custom metadata lives at extra.metadata; token/cost totals roll up onto
 // root runs.
 export interface Run {
@@ -18,8 +18,8 @@ export interface Run {
 }
 
 export interface RunsQueryResponse {
-  runs: Run[];
-  cursor?: string | null;
+  items: Run[];
+  next_cursor?: string | null;
 }
 
 // Field names mirror `schemas.RunStats` in smith-backend/app/schemas.py.

--- a/internal/cmd/templates/experiment-comparison/src/api.ts
+++ b/internal/cmd/templates/experiment-comparison/src/api.ts
@@ -1,6 +1,55 @@
 // All access goes through window.langsmith.call (the sandbox has no network).
 // See AGENTS.md for the operations and shapes.
-import type { Dataset, ExampleWithRuns, Experiment, FeedbackConfigSchema } from './types';
+import type { Dataset, ExampleWithRuns, Experiment, ExperimentRun, FeedbackConfigSchema } from './types';
+
+const COMPARISON_SELECTS = [
+  'PROJECT_ID',
+  'OUTPUTS',
+  'ERROR',
+  'START_TIME',
+  'END_TIME',
+  'TOTAL_TOKENS',
+  'TOTAL_COST',
+  'FEEDBACK_STATS',
+];
+
+interface V2RunResponse {
+  project_id?: string;
+  outputs?: Record<string, unknown> | null;
+  error?: string | null;
+  start_time?: string;
+  end_time?: string | null;
+  total_tokens?: number | null;
+  total_cost?: number | null;
+  feedback_stats?: Record<string, Record<string, unknown>> | null;
+}
+
+interface V2ExampleWithRuns {
+  id: string;
+  name?: string | null;
+  inputs: Record<string, unknown> | null;
+  outputs?: Record<string, unknown> | null;
+  runs: V2RunResponse[];
+}
+
+interface V2ComparisonResponse {
+  items: V2ExampleWithRuns[];
+  next_cursor: string | null;
+}
+
+function toExperimentRun(run: V2RunResponse): ExperimentRun {
+  return {
+    session_id: run.project_id ?? '',
+    outputs: run.outputs ?? null,
+    outputs_preview: null,
+    error: run.error ?? null,
+    start_time: run.start_time ?? '',
+    end_time: run.end_time ?? null,
+    total_tokens: run.total_tokens ?? null,
+    total_cost: run.total_cost ?? null,
+    feedback_stats: run.feedback_stats ?? null,
+  };
+}
 
 export async function fetchDatasets(
   search = '',
@@ -40,9 +89,16 @@ export async function fetchComparison(
   sessionIds: string[],
   limit = 25
 ): Promise<ExampleWithRuns[]> {
-  return window.langsmith.call(`POST /api/v1/datasets/${datasetId}/runs`, {
-    body: { session_ids: sessionIds, limit, offset: 0 },
-  }) as Promise<ExampleWithRuns[]>;
+  const resp = (await window.langsmith.call(`POST /api/v2/datasets/${datasetId}/experiment-runs`, {
+    body: { experiment_ids: sessionIds, page_size: limit, selects: COMPARISON_SELECTS },
+  })) as V2ComparisonResponse;
+  return (resp?.items ?? []).map((ex) => ({
+    id: ex.id,
+    name: ex.name ?? '',
+    inputs: ex.inputs ?? null,
+    outputs: ex.outputs ?? null,
+    runs: (ex.runs ?? []).map(toExperimentRun),
+  }));
 }
 
 // is_lower_score_better per feedback key, so score deltas honor direction.

--- a/internal/cmd/templates/experiment-comparison/src/types.ts
+++ b/internal/cmd/templates/experiment-comparison/src/types.ts
@@ -18,7 +18,7 @@ export interface ExperimentRun {
   start_time: string;
   end_time: string | null;
   total_tokens: number | null;
-  total_cost: string | null;
+  total_cost: number | null;
   feedback_stats: Record<string, Record<string, unknown>> | null;
 }
 


### PR DESCRIPTION
a few API calls in coding-agent-dashboard and experiment-comparison were using v1 APIs when they could be using v2 APIs

Tested by generating both templates and running against prod data