### PR TITLE
fix(filters): scope --cursor to trace messages

### DIFF
--- a/internal/cmd/filters.go
+++ b/internal/cmd/filters.go
@@ -40,7 +40,6 @@ func addCommonFilterFlags(cmd *cobra.Command, f *FilterFlags, includeRunType boo
 	cmd.Flags().IntVar(&f.LastNMinutes, "last-n-minutes", 0, "Only include runs from the last N minutes, e.g. 60 (overrides 7-day default)")
 	cmd.Flags().StringVar(&f.Since, "since", "", "Only include runs after this timestamp, e.g. 2024-01-15T00:00:00Z (overrides 7-day default)")
 	cmd.Flags().StringVar(&f.Before, "before", "", "Only include runs before this timestamp, e.g. 2024-01-15T00:00:00Z (for pagination)")
-	cmd.Flags().StringVar(&f.Cursor, "cursor", "", "Resume from a pagination cursor returned by a previous call; enables single-page mode with cursors.next in output")
 	cmd.Flags().BoolVar(&f.ErrorFlag, "error", false, "Filter for failed runs only")
 	cmd.Flags().BoolVar(&f.NoErrorFlag, "no-error", false, "Filter for successful runs only")
 	cmd.Flags().StringVar(&f.Name, "name", "", "Filter by run name (exact match)")

--- a/internal/cmd/filters_test.go
+++ b/internal/cmd/filters_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
 )
 
 func TestBuildFilterDSL_Empty(t *testing.T) {
@@ -299,6 +301,29 @@ func TestAddCommonFilterFlags_WithoutRunType(t *testing.T) {
 	cmd := newTraceListCmd()
 	if cmd.Flags().Lookup("run-type") != nil {
 		t.Error("trace list should not have --run-type flag")
+	}
+}
+
+func TestAddCommonFilterFlags_CursorOnlyOnTraceMessages(t *testing.T) {
+	tests := []struct {
+		name       string
+		cmd        *cobra.Command
+		wantCursor bool
+	}{
+		{name: "run list", cmd: newRunListCmd()},
+		{name: "run export", cmd: newRunExportCmd()},
+		{name: "trace list", cmd: newTraceListCmd()},
+		{name: "trace export", cmd: newTraceExportCmd()},
+		{name: "trace messages", cmd: newTraceMessagesCmd(), wantCursor: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCursor := tt.cmd.Flags().Lookup("cursor") != nil
+			if gotCursor != tt.wantCursor {
+				t.Errorf("cursor flag present = %t, want %t", gotCursor, tt.wantCursor)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -280,6 +280,7 @@ Examples:
 	}
 
 	addCommonFilterFlags(cmd, &ff, true)
+	cmd.Flags().StringVar(&ff.Cursor, "cursor", "", "Resume from a pagination cursor returned by a previous call; enables single-page mode with cursors.next in output")
 	cmd.Flags().StringVar(&ff.ProjectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 	cmd.MarkFlagsMutuallyExclusive("project", "project-id")


### PR DESCRIPTION
## Summary

- stop registering `--cursor` through the shared run/trace filter helper
- register `--cursor` only on `trace messages`, the command that implements its documented single-page behavior and returns `cursors.next`
- add regression coverage for every command that previously inherited the flag unintentionally

Closes #221.

## Background

`--cursor` was added for `trace messages` external pagination. That command treats an explicitly supplied cursor (including `--cursor ""`) as a request for exactly one page and exposes the server's next cursor in its structured output.

The flag was registered in `addCommonFilterFlags`, however, so it also appeared on:

- `run list`
- `run export`
- `trace list`
- `trace export`

Those commands never read `FilterFlags.Cursor`. They accepted the option successfully and then started their normal automatic pagination from the first page.

## Approach

This change moves only the Cobra flag registration from the shared helper to `newTraceMessagesCmd`. `FilterFlags.Cursor` and the existing `trace messages` request/output implementation remain unchanged.

Scoping the flag matches its original command contract. The other commands automatically collect results up to `--limit` and currently return arrays or write export files; they do not expose page metadata. Wiring the same flag into those paths would give it different semantics or require an output-schema change. They now reject the unsupported option rather than silently ignoring it.

## Behavior

Before:

```console
$ langsmith run list --cursor opaque
# command runs, but `opaque` is ignored
```

After:

```console
$ langsmith run list --cursor opaque
unknown flag: --cursor
```

The supported workflow is preserved:

```console
$ langsmith trace messages --cursor opaque ...
# one page is requested and `cursors.next` is returned
```

## Tests

Added a table-driven regression test asserting that:

- run list/export do not expose `--cursor`
- trace list/export do not expose `--cursor`
- trace messages still exposes `--cursor`

Existing trace-message tests continue to verify non-empty and explicitly empty cursor behavior.

Local verification:

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `make build`
- manual check that `run list --cursor opaque` returns `unknown flag: --cursor` and exits non-zero

`make lint` could not run locally because `golangci-lint` is not installed; the other checks above pass.
