### PR TITLE
fix(example): use native dataset split fields

### DIFF
--- a/internal/cmd/example.go
+++ b/internal/cmd/example.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/langchain-ai/langsmith-cli/internal/output"
 	langsmith "github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/shared"
 	"github.com/spf13/cobra"
 )
 
@@ -65,6 +66,9 @@ func newExampleListCmd() *cobra.Command {
 				Dataset: langsmith.F(ds.ID),
 				Limit:   langsmith.F(pageSize),
 			}
+			if split != "" {
+				params.Splits = langsmith.F([]string{split})
+			}
 			if offset > 0 {
 				params.Offset = langsmith.F(int64(offset))
 			}
@@ -81,31 +85,12 @@ func newExampleListCmd() *cobra.Command {
 			}
 			fmt_ := GetFormat()
 
-			// Filter by split if specified
-			if split != "" {
-				var filtered []langsmith.Example
-				for _, ex := range examples {
-					// The split field may be in metadata
-					if ex.Metadata != nil {
-						if s, ok := ex.Metadata["split"].(string); ok && s == split {
-							filtered = append(filtered, ex)
-						}
-					}
-				}
-				examples = filtered
-			}
-
 			if fmt_ == "pretty" {
 				columns := []string{"ID", "Split", "Created", "Inputs Preview"}
 				var rows [][]string
 				for _, ex := range examples {
 					id := ex.ID
-					splitVal := "N/A"
-					if ex.Metadata != nil {
-						if s, ok := ex.Metadata["split"].(string); ok {
-							splitVal = s
-						}
-					}
+					splitVal := formatExampleSplit(exampleSplit(ex))
 					created := "N/A"
 					if !ex.CreatedAt.IsZero() {
 						created = ex.CreatedAt.Format("2006-01-02")
@@ -129,6 +114,7 @@ func newExampleListCmd() *cobra.Command {
 						"inputs":     ex.Inputs,
 						"outputs":    ex.Outputs,
 						"metadata":   ex.Metadata,
+						"split":      exampleSplit(ex),
 						"created_at": formatTimeISO(ex.CreatedAt),
 					}
 					data = append(data, entry)
@@ -146,6 +132,40 @@ func newExampleListCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("dataset")
 
 	return cmd
+}
+
+// exampleSplit reads native split membership from the SDK's retained response
+// JSON. The current generated Example response does not expose a typed Split
+// field, although the API returns it and the SDK exposes typed split request
+// fields for create and list operations.
+func exampleSplit(ex langsmith.Example) any {
+	var raw struct {
+		Split any `json:"split"`
+	}
+	if err := json.Unmarshal([]byte(ex.JSON.RawJSON()), &raw); err != nil {
+		return nil
+	}
+	return raw.Split
+}
+
+func formatExampleSplit(value any) string {
+	switch split := value.(type) {
+	case string:
+		if split != "" {
+			return split
+		}
+	case []any:
+		values := make([]string, 0, len(split))
+		for _, item := range split {
+			if value, ok := item.(string); ok && value != "" {
+				values = append(values, value)
+			}
+		}
+		if len(values) > 0 {
+			return strings.Join(values, ", ")
+		}
+	}
+	return "N/A"
 }
 
 func newExampleCreateCmd() *cobra.Command {
@@ -201,12 +221,10 @@ func newExampleCreateCmd() *cobra.Command {
 				params.Outputs = langsmith.F(parsedOutputs)
 			}
 			if parsedMetadata != nil {
-				if split != "" {
-					parsedMetadata["split"] = split
-				}
 				params.Metadata = langsmith.F(parsedMetadata)
-			} else if split != "" {
-				params.Metadata = langsmith.F(map[string]any{"split": split})
+			}
+			if split != "" {
+				params.Split = langsmith.F[langsmith.ExampleNewParamsSplitUnion](shared.UnionString(split))
 			}
 
 			ex, err := c.SDK.Examples.New(ctx, params)

--- a/internal/cmd/example_test.go
+++ b/internal/cmd/example_test.go
@@ -1,7 +1,16 @@
 package cmd
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
 	"testing"
+)
+
+const (
+	testExampleDatasetID = "11111111-1111-1111-1111-111111111111"
+	testExampleID        = "22222222-2222-2222-2222-222222222222"
 )
 
 // ==================== Command structure ====================
@@ -157,5 +166,123 @@ func TestExampleDeleteCmd_ExactArgs(t *testing.T) {
 	}
 	if err := cmd.Args(cmd, []string{"ex-id"}); err != nil {
 		t.Errorf("expected no error for 1 arg, got %v", err)
+	}
+}
+
+func TestExampleList_UsesNativeSplitFilterAndOutput(t *testing.T) {
+	var exampleQuery url.Values
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/datasets":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"id": testExampleDatasetID, "name": "my-dataset",
+			}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/examples":
+			exampleQuery = r.URL.Query()
+			if exampleQuery.Get("offset") != "" && exampleQuery.Get("offset") != "0" {
+				_ = json.NewEncoder(w).Encode([]any{})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"id":         testExampleID,
+				"dataset_id": testExampleDatasetID,
+				"name":       "example",
+				"inputs":     map[string]any{"question": "hello"},
+				"metadata":   map[string]any{"split": "metadata-value"},
+				"split":      []string{"test", "validation"},
+			}})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	})
+	defer setupTestEnv(t, srv.URL)()
+	flagOutputFormat = "json"
+
+	out := captureStdout(t, func() {
+		cmd := newExampleListCmd()
+		cmd.SetArgs([]string{"--dataset", "my-dataset", "--split", "test"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if got := exampleQuery["splits"]; len(got) != 1 || got[0] != "test" {
+		t.Fatalf("splits query = %v, want [test]", got)
+	}
+	var result []map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, out)
+	}
+	if len(result) != 1 {
+		t.Fatalf("got %d examples, want 1", len(result))
+	}
+	splits, ok := result[0]["split"].([]any)
+	if !ok || len(splits) != 2 || splits[0] != "test" || splits[1] != "validation" {
+		t.Errorf("native split output = %#v, want [test validation]", result[0]["split"])
+	}
+	metadata, _ := result[0]["metadata"].(map[string]any)
+	if metadata["split"] != "metadata-value" {
+		t.Errorf("metadata was changed or discarded: %#v", metadata)
+	}
+}
+
+func TestExampleCreate_UsesNativeSplitWithoutChangingMetadata(t *testing.T) {
+	var createBody map[string]any
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/datasets":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"id": testExampleDatasetID, "name": "my-dataset",
+			}})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/examples":
+			if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+				t.Fatalf("decode create request: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": testExampleID, "dataset_id": testExampleDatasetID,
+				"name": "example", "inputs": map[string]any{"question": "hello"},
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	captureStdout(t, func() {
+		cmd := newExampleCreateCmd()
+		cmd.SetArgs([]string{
+			"--dataset", "my-dataset",
+			"--inputs", `{"question":"hello"}`,
+			"--metadata", `{"split":"metadata-value","source":"fixture"}`,
+			"--split", "test",
+		})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if createBody["split"] != "test" {
+		t.Errorf("native split = %#v, want test", createBody["split"])
+	}
+	metadata, _ := createBody["metadata"].(map[string]any)
+	if metadata["split"] != "metadata-value" || metadata["source"] != "fixture" {
+		t.Errorf("metadata was changed: %#v", metadata)
+	}
+}
+
+func TestFormatExampleSplit(t *testing.T) {
+	if got := formatExampleSplit([]any{"train", "validation"}); got != "train, validation" {
+		t.Errorf("formatExampleSplit() = %q", got)
+	}
+	if got := formatExampleSplit("test"); got != "test" {
+		t.Errorf("formatExampleSplit() = %q", got)
+	}
+	if got := formatExampleSplit(nil); got != "N/A" {
+		t.Errorf("formatExampleSplit() = %q", got)
+	}
+	if strings.Contains(formatExampleSplit([]any{1, false}), "1") {
+		t.Error("non-string split members should be ignored")
 	}
 }


### PR DESCRIPTION
## Summary

- send `example create --split` through `ExampleNewParams.Split`
- send `example list --split` through `ExampleListParams.Splits` so filtering happens server-side before pagination
- render native split membership from the API response instead of treating `metadata["split"]` as special
- expose native membership as `split` in structured list output
- preserve user metadata unchanged, including an independent metadata key named `split`

Closes #222.

## Problem

The CLI previously modeled dataset split membership as ordinary example metadata:

- create inserted `--split` into `metadata["split"]`
- list fetched unfiltered pages and then compared `metadata["split"]` locally
- the pretty table displayed the metadata value

LangSmith has first-class dataset split fields, and the generated Go SDK already exposes them on both create and list request types. Metadata with the same key is not equivalent to native split membership.

Besides producing examples that are not members of the requested LangSmith split, client-side filtering happened after pagination. A limited page could therefore appear empty even when matching examples existed on later server pages.

## Implementation

### Create

When `--split` is present, the command now sets:

```go
ExampleNewParams.Split = shared.UnionString(split)
```

Metadata is passed through exactly as supplied. In particular, metadata such as `{"split":"source-label"}` is no longer overwritten by `--split test`.

### List and pagination

When `--split test` is present, the command now sets:

```go
ExampleListParams.Splits = []string{"test"}
```

The server applies the split constraint before offset pagination, so `--limit` and `--offset` operate on the matching result set. The old post-fetch metadata filtering loop is removed.

### Output

The API returns native membership in a `split` response property, which can be either a string or a list. The current generated Go `Example` response struct does not expose that property as a typed field, but it retains the original response JSON. The CLI reads only this retained field for presentation; API access still goes entirely through the generated SDK.

- pretty output displays a single split or comma-separated split list
- JSON output includes an additive `split` property
- missing or malformed membership displays as `N/A` in the table and `null` in JSON
- metadata remains available independently under `metadata`

## Behavior change

Before, this command:

```console
langsmith example create \
  --dataset evaluations \
  --inputs '{"question":"hello"}' \
  --metadata '{"split":"source-label"}' \
  --split test
```

sent metadata equivalent to:

```json
{"split":"test"}
```

It now sends native membership and preserves metadata:

```json
{
  "split": "test",
  "metadata": {"split": "source-label"}
}
```

## Tests

Added request-level tests with an HTTP test server that verify:

- list sends `splits=test` on the SDK query, including paginated requests
- list returns the API's native multi-split membership
- metadata named `split` is preserved but not used as membership
- create sends the native `split` body property
- create does not overwrite or discard metadata
- pretty formatting handles string, list, missing, and invalid values

Local verification:

- `go test ./internal/cmd -run 'TestExample(List_UsesNativeSplitFilterAndOutput|Create_UsesNativeSplitWithoutChangingMetadata)|TestFormatExampleSplit'`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `make build`
- `git diff --check`

`make lint` was not available locally because `golangci-lint` is not installed.
