### PR TITLE
fix(cmd): return validation errors to Cobra

### DIFF
--- a/internal/cmd/evaluator.go
+++ b/internal/cmd/evaluator.go
@@ -62,7 +62,7 @@ Examples:
   langsmith evaluator get --session-id <session-id>
   langsmith evaluator get accuracy --session-id <session-id>`,
 		Args: cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			name := ""
 			if len(args) > 0 {
 				name = args[0]
@@ -93,10 +93,7 @@ Examples:
 			}
 
 			if len(matching) == 0 {
-				output.OutputJSON(map[string]any{
-					"error": "no matching evaluators found",
-				}, "")
-				return
+				return outputJSONError(fmt.Errorf("no matching evaluators found"), nil)
 			}
 
 			var data []map[string]any
@@ -128,6 +125,7 @@ Examples:
 			} else {
 				output.OutputJSON(data, outputFile)
 			}
+			return nil
 		},
 	}
 
@@ -208,12 +206,11 @@ func newEvaluatorUploadCmd() *cobra.Command {
 		Use:   "upload EVALUATOR_FILE",
 		Short: "Upload an evaluator function to LangSmith",
 		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			evaluatorFile := args[0]
 
 			if err := validateEvaluatorTargetFlags(targetDataset, targetProject); err != nil {
-				output.OutputJSON(map[string]any{"error": err.Error()}, "")
-				return
+				return outputJSONError(err, nil)
 			}
 
 			c := MustGetClient()
@@ -292,11 +289,8 @@ func newEvaluatorUploadCmd() *cobra.Command {
 			existing := findEvaluator(*rules, name, datasetID, projectID)
 			if existing != nil {
 				if !replace {
-					output.OutputJSON(map[string]any{
-						"error": fmt.Sprintf("Evaluator '%s' already exists (use --replace to overwrite)", name),
-						"id":    existing.ID,
-					}, "")
-					return
+					err := fmt.Errorf("evaluator %q already exists (use --replace to overwrite)", name)
+					return outputJSONError(err, map[string]any{"id": existing.ID})
 				}
 				if !yes {
 					fmt.Fprintf(os.Stderr, "Replace existing evaluator '%s'? [y/N] ", name)
@@ -327,6 +321,7 @@ func newEvaluatorUploadCmd() *cobra.Command {
 				"name":   name,
 				"target": targetLabel,
 			}, "")
+			return nil
 		},
 	}
 
@@ -374,7 +369,7 @@ Examples:
     --prompt prompt.json --schema schema.json --model-config model.json
   langsmith evaluator create-llm --name relevance --project my-app \
     --hub-ref my-org/relevance:latest --model-config model.json`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			c := MustGetClient()
 			ctx := context.Background()
 
@@ -399,8 +394,7 @@ Examples:
 					ExitError("aborted")
 				}
 				if existing != nil {
-					output.OutputJSON(map[string]any{"error": err.Error(), "id": existing.ID}, "")
-					return
+					return outputJSONError(err, map[string]any{"id": existing.ID})
 				}
 				ExitErrorf("%v", err)
 			}
@@ -421,6 +415,7 @@ Examples:
 				"status": "created", "type": "llm",
 				"id": result["id"], "name": name, "target": targetLabel,
 			}, "")
+			return nil
 		},
 	}
 
@@ -449,7 +444,7 @@ func newEvaluatorDeleteCmd() *cobra.Command {
 		Use:   "delete NAME",
 		Short: "Delete an evaluator rule by its display name",
 		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
 			c := MustGetClient()
@@ -468,8 +463,7 @@ func newEvaluatorDeleteCmd() *cobra.Command {
 			}
 
 			if len(matching) == 0 {
-				output.OutputJSON(map[string]any{"error": fmt.Sprintf("Evaluator '%s' not found", name)}, "")
-				return
+				return outputJSONError(fmt.Errorf("evaluator %q not found", name), nil)
 			}
 
 			if !yes {
@@ -494,6 +488,7 @@ func newEvaluatorDeleteCmd() *cobra.Command {
 				"name":   name,
 				"count":  deleted,
 			}, "")
+			return nil
 		},
 	}
 

--- a/internal/cmd/evaluator_test.go
+++ b/internal/cmd/evaluator_test.go
@@ -730,6 +730,142 @@ func TestEvaluatorListCmd_VerifiesAPIKeyHeader(t *testing.T) {
 	}
 }
 
+func TestEvaluatorUpload_InvalidTargetReturnsError(t *testing.T) {
+	var runErr error
+	out := captureStdout(t, func() {
+		cmd := newEvaluatorUploadCmd()
+		cmd.SetArgs([]string{"eval.py", "--name", "accuracy", "--function", "check"})
+		runErr = cmd.Execute()
+	})
+	if runErr == nil {
+		t.Fatal("expected invalid target to return an error")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("structured error is not JSON: %v\n%s", err, out)
+	}
+	if payload["error"] != runErr.Error() {
+		t.Errorf("payload error = %q, command error = %q", payload["error"], runErr)
+	}
+}
+
+func TestEvaluatorUpload_DuplicateReturnsError(t *testing.T) {
+	evaluatorFile := t.TempDir() + "/eval.py"
+	if err := os.WriteFile(evaluatorFile, []byte("def check(run, example):\n    return {\"score\": 1}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var mutationRequested bool
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sessions":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "project-1", "name": "my-project"}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/runs/rules":
+			_ = json.NewEncoder(w).Encode([]testRule{{
+				ID: "existing-rule", DisplayName: "accuracy", SessionID: "project-1",
+				CodeEvaluators: []testCodeEval{{Code: "def perform_eval(): pass", Language: "python"}},
+			}})
+		default:
+			mutationRequested = true
+			http.Error(w, "unexpected mutation", http.StatusInternalServerError)
+		}
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	var runErr error
+	out := captureStdout(t, func() {
+		cmd := newEvaluatorUploadCmd()
+		cmd.SetArgs([]string{
+			evaluatorFile, "--name", "accuracy", "--function", "check", "--project", "my-project",
+		})
+		runErr = cmd.Execute()
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "already exists") {
+		t.Fatalf("error = %v, want duplicate error", runErr)
+	}
+	if mutationRequested {
+		t.Fatal("duplicate evaluator should not trigger a mutation")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("structured error is not JSON: %v\n%s", err, out)
+	}
+	if payload["id"] != "existing-rule" || payload["error"] != runErr.Error() {
+		t.Errorf("unexpected duplicate payload: %#v", payload)
+	}
+}
+
+func TestEvaluatorCreateLLM_DuplicateReturnsError(t *testing.T) {
+	modelConfigPath := t.TempDir() + "/model.json"
+	if err := os.WriteFile(modelConfigPath, []byte(`{"type":"chat","config":{"model":"test-model"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sessions":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "project-1", "name": "my-project"}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/runs/rules":
+			_ = json.NewEncoder(w).Encode([]testRule{{
+				ID: "existing-rule", DisplayName: "relevance", SessionID: "project-1",
+				Evaluators: []testLLMEval{{Structured: testLLMStructured{HubRef: "my-org/relevance:latest"}}},
+			}})
+		default:
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+		}
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	var runErr error
+	out := captureStdout(t, func() {
+		cmd := newEvaluatorCreateLLMCmd()
+		cmd.SetArgs([]string{
+			"--name", "relevance", "--project", "my-project",
+			"--hub-ref", "my-org/relevance:latest", "--model-config", modelConfigPath,
+		})
+		runErr = cmd.Execute()
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "already exists") {
+		t.Fatalf("error = %v, want duplicate error", runErr)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("structured error is not JSON: %v\n%s", err, out)
+	}
+	if payload["id"] != "existing-rule" || payload["error"] != runErr.Error() {
+		t.Errorf("unexpected duplicate payload: %#v", payload)
+	}
+}
+
+func TestEvaluatorDelete_NotFoundReturnsError(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/runs/rules" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("[]"))
+			return
+		}
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	var runErr error
+	out := captureStdout(t, func() {
+		cmd := newEvaluatorDeleteCmd()
+		cmd.SetArgs([]string{"missing", "--yes"})
+		runErr = cmd.Execute()
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "not found") {
+		t.Fatalf("error = %v, want not-found error", runErr)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("structured error is not JSON: %v\n%s", err, out)
+	}
+	if payload["error"] != runErr.Error() {
+		t.Errorf("payload error = %q, command error = %q", payload["error"], runErr)
+	}
+}
+
 func TestEvaluatorUploadReplacePatchesExistingCodeEvaluator(t *testing.T) {
 	evaluatorFile := t.TempDir() + "/eval.py"
 	if err := os.WriteFile(
@@ -791,7 +927,9 @@ func TestEvaluatorUploadReplacePatchesExistingCodeEvaluator(t *testing.T) {
 		_ = cmd.Flags().Set("sampling-rate", "0.5")
 		_ = cmd.Flags().Set("replace", "true")
 		_ = cmd.Flags().Set("yes", "true")
-		cmd.Run(cmd, []string{evaluatorFile})
+		if err := cmd.RunE(cmd, []string{evaluatorFile}); err != nil {
+			t.Fatalf("upload evaluator: %v", err)
+		}
 	})
 
 	if sawDelete {
@@ -896,7 +1034,9 @@ func TestEvaluatorCreateLLMReplacePatchesExistingEvaluator(t *testing.T) {
 		_ = cmd.Flags().Set("sampling-rate", "0.5")
 		_ = cmd.Flags().Set("replace", "true")
 		_ = cmd.Flags().Set("yes", "true")
-		cmd.Run(cmd, nil)
+		if err := cmd.RunE(cmd, nil); err != nil {
+			t.Fatalf("create LLM evaluator: %v", err)
+		}
 	})
 
 	if sawDelete {
@@ -977,7 +1117,9 @@ func TestEvaluatorGetCmd_Execute_CodeEvaluator(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		cmd := newEvaluatorGetCmd()
-		cmd.Run(cmd, []string{"accuracy"})
+		if err := cmd.RunE(cmd, []string{"accuracy"}); err != nil {
+			t.Fatalf("get evaluator: %v", err)
+		}
 	})
 
 	var result map[string]any
@@ -1027,7 +1169,9 @@ func TestEvaluatorGetCmd_Execute_LLMEvaluator(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		cmd := newEvaluatorGetCmd()
-		cmd.Run(cmd, []string{"relevance"})
+		if err := cmd.RunE(cmd, []string{"relevance"}); err != nil {
+			t.Fatalf("get evaluator: %v", err)
+		}
 	})
 
 	var result map[string]any
@@ -1059,10 +1203,14 @@ func TestEvaluatorGetCmd_Execute_NotFound(t *testing.T) {
 	cleanup := setupTestEnv(t, ts.URL)
 	defer cleanup()
 
+	var runErr error
 	out := captureStdout(t, func() {
 		cmd := newEvaluatorGetCmd()
-		cmd.Run(cmd, []string{"nonexistent"})
+		runErr = cmd.RunE(cmd, []string{"nonexistent"})
 	})
+	if runErr == nil {
+		t.Fatal("expected not-found error")
+	}
 
 	var result map[string]any
 	if err := json.Unmarshal([]byte(out), &result); err != nil {
@@ -1103,7 +1251,9 @@ func TestEvaluatorGetCmd_Execute_FilterBySessionID(t *testing.T) {
 	out := captureStdout(t, func() {
 		cmd := newEvaluatorGetCmd()
 		_ = cmd.Flags().Set("session-id", "session-abc")
-		cmd.Run(cmd, nil)
+		if err := cmd.RunE(cmd, nil); err != nil {
+			t.Fatalf("get evaluators: %v", err)
+		}
 	})
 
 	var result []map[string]any
@@ -1148,7 +1298,9 @@ func TestEvaluatorGetCmd_Execute_FilterByNameAndSessionID(t *testing.T) {
 	out := captureStdout(t, func() {
 		cmd := newEvaluatorGetCmd()
 		_ = cmd.Flags().Set("session-id", "session-abc")
-		cmd.Run(cmd, []string{"accuracy"})
+		if err := cmd.RunE(cmd, []string{"accuracy"}); err != nil {
+			t.Fatalf("get evaluator: %v", err)
+		}
 	})
 
 	var result map[string]any
@@ -1178,7 +1330,9 @@ func TestEvaluatorGetCmd_Execute_MultipleMatches(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		cmd := newEvaluatorGetCmd()
-		cmd.Run(cmd, []string{"accuracy"})
+		if err := cmd.RunE(cmd, []string{"accuracy"}); err != nil {
+			t.Fatalf("get evaluators: %v", err)
+		}
 	})
 
 	var result []map[string]any

--- a/internal/cmd/example.go
+++ b/internal/cmd/example.go
@@ -160,34 +160,30 @@ func newExampleCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new example in a dataset",
-		Run: func(cmd *cobra.Command, args []string) {
-			c := MustGetClient()
-			ctx := context.Background()
-
+		RunE: func(cmd *cobra.Command, args []string) error {
 			// Parse JSON inputs
 			var parsedInputs map[string]any
 			if err := json.Unmarshal([]byte(inputs), &parsedInputs); err != nil {
-				output.OutputJSON(map[string]any{"error": fmt.Sprintf("Invalid JSON for --inputs: %v", err)}, "")
-				return
+				return outputJSONError(fmt.Errorf("invalid JSON for --inputs: %w", err), nil)
 			}
 
 			var parsedOutputs map[string]any
 			if outputs != "" {
 				if err := json.Unmarshal([]byte(outputs), &parsedOutputs); err != nil {
-					output.OutputJSON(map[string]any{"error": fmt.Sprintf("Invalid JSON for --outputs: %v", err)}, "")
-					return
+					return outputJSONError(fmt.Errorf("invalid JSON for --outputs: %w", err), nil)
 				}
 			}
 
 			var parsedMetadata map[string]any
 			if metadata != "" {
 				if err := json.Unmarshal([]byte(metadata), &parsedMetadata); err != nil {
-					output.OutputJSON(map[string]any{"error": fmt.Sprintf("Invalid JSON for --metadata: %v", err)}, "")
-					return
+					return outputJSONError(fmt.Errorf("invalid JSON for --metadata: %w", err), nil)
 				}
 			}
 
 			// Resolve dataset
+			c := MustGetClient()
+			ctx := context.Background()
 			ds, err := resolveDataset(ctx, c, datasetName)
 			if err != nil {
 				ExitErrorf("%v", err)
@@ -221,6 +217,7 @@ func newExampleCreateCmd() *cobra.Command {
 				"inputs":     ex.Inputs,
 				"outputs":    ex.Outputs,
 			}, "")
+			return nil
 		},
 	}
 

--- a/internal/cmd/example_test.go
+++ b/internal/cmd/example_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"encoding/json"
+	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -157,5 +160,52 @@ func TestExampleDeleteCmd_ExactArgs(t *testing.T) {
 	}
 	if err := cmd.Args(cmd, []string{"ex-id"}); err != nil {
 		t.Errorf("expected no error for 1 arg, got %v", err)
+	}
+}
+
+func TestExampleCreate_InvalidJSONReturnsError(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("validation should fail before API request: %s %s", r.Method, r.URL.Path)
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	tests := []struct {
+		name     string
+		flag     string
+		value    string
+		wantText string
+	}{
+		{name: "inputs", flag: "--inputs", value: "{", wantText: "invalid JSON for --inputs"},
+		{name: "outputs", flag: "--outputs", value: "{", wantText: "invalid JSON for --outputs"},
+		{name: "metadata", flag: "--metadata", value: "{", wantText: "invalid JSON for --metadata"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := []string{"--dataset", "anything", "--inputs", `{}`}
+			if tt.flag == "--inputs" {
+				args[3] = tt.value
+			} else {
+				args = append(args, tt.flag, tt.value)
+			}
+
+			var runErr error
+			out := captureStdout(t, func() {
+				cmd := newExampleCreateCmd()
+				cmd.SetArgs(args)
+				runErr = cmd.Execute()
+			})
+			if runErr == nil || !strings.Contains(runErr.Error(), tt.wantText) {
+				t.Fatalf("error = %v, want %q", runErr, tt.wantText)
+			}
+
+			var payload map[string]any
+			if err := json.Unmarshal([]byte(out), &payload); err != nil {
+				t.Fatalf("structured error is not JSON: %v\n%s", err, out)
+			}
+			if message, _ := payload["error"].(string); !strings.Contains(message, tt.wantText) {
+				t.Errorf("error payload = %q, want %q", message, tt.wantText)
+			}
+		})
 	}
 }

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -422,6 +422,19 @@ func resolveDataset(ctx context.Context, c *client.Client, nameOrID string) (*la
 	return &resp.Items[0], nil
 }
 
+// outputJSONError preserves the structured error payload used by scriptable
+// commands while returning the same error to Cobra so the process exits
+// non-zero. Extra fields may add context such as the conflicting resource ID.
+func outputJSONError(err error, extra map[string]any) error {
+	payload := make(map[string]any, len(extra)+1)
+	for key, value := range extra {
+		payload[key] = value
+	}
+	payload["error"] = err.Error()
+	output.OutputJSON(payload, "")
+	return err
+}
+
 // formatTimedelta formats a duration as a human-readable string.
 func formatTimedelta(seconds float64) string {
 	if seconds < 1 {


### PR DESCRIPTION
## Summary

- return example/evaluator validation and conflict errors through Cobra instead of returning successfully
- preserve the existing structured JSON error payloads for scripts and agents
- centralize the "emit JSON and return the same error" behavior in `outputJSONError`
- cover all matching evaluator paths found in the audit, not only the two reproduction commands

Closes #223.

## Problem

Several commands used a Cobra `Run` callback with this pattern:

```go
output.OutputJSON(map[string]any{"error": message}, "")
return
```

Returning from `Run` signals success to Cobra. The CLI therefore exited with status 0 even though its output said the operation had failed. Shell scripts, CI jobs, and agents could not reliably distinguish these errors from successful operations without parsing command-specific JSON.

## Affected paths

The audit found eight instances sharing this root cause:

### Examples

- malformed `--inputs` JSON
- malformed `--outputs` JSON
- malformed `--metadata` JSON

### Evaluators

- `evaluator get` with no matching rule
- `evaluator upload` with an invalid dataset/project target
- `evaluator upload` when the rule already exists without `--replace`
- `evaluator create-llm` when the rule already exists without `--replace`
- `evaluator delete` when the named rule does not exist

## Implementation

The affected commands now use `RunE` and return errors to Cobra. A small shared helper:

1. builds the structured payload, including optional context such as a conflicting evaluator ID;
2. writes the payload using the existing JSON output helper; and
3. returns the same error to Cobra.

Successful paths return `nil`, so their behavior and output remain unchanged.

Example JSON parsing was also moved before client creation. Malformed local input now fails deterministically without requiring authentication or touching the API.

## Behavior

Before:

```console
$ langsmith --api-key test example create --dataset anything --inputs '{'
{"error":"invalid JSON for --inputs: ..."}
$ echo $?
0
```

After:

```console
$ langsmith example create --dataset anything --inputs '{'
{
  "error": "invalid JSON for --inputs: unexpected end of JSON input"
}
invalid JSON for --inputs: unexpected end of JSON input
$ echo $?
1
```

The JSON payload remains on stdout for machine consumers. The root command prints the returned error on stderr and exits non-zero using its existing error policy.

Conflict payloads continue to include the existing evaluator ID:

```json
{
  "error": "evaluator \"accuracy\" already exists (use --replace to overwrite)",
  "id": "existing-rule"
}
```

## Tests

Added command-level regression tests covering:

- all three malformed example JSON flags
- invalid evaluator target selection
- duplicate code evaluator without `--replace`
- duplicate LLM evaluator without `--replace`
- evaluator get-not-found
- evaluator delete-not-found
- preservation of structured error payloads and contextual IDs
- confirmation that conflicts make no mutation request

Existing successful evaluator execution tests were updated to invoke `RunE` and assert that it returns `nil`.

Local verification:

- focused example/evaluator error tests
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `make build`
- `git diff --check`
- compiled-binary checks confirming both issue reproductions exit with status 1

`make lint` was not available locally because `golangci-lint` is not installed.
