### PR TITLE
fix(output): propagate serialization and write failures

### DIFF
--- a/internal/cmd/apps_delete.go
+++ b/internal/cmd/apps_delete.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +37,7 @@ func newAppsDeleteCmd() *cobra.Command {
 			if err := c.RawDelete(ctx, "/api/v1/platform/custom-apps/"+id, nil); err != nil {
 				return fmt.Errorf("deleting custom app %s: %w", id, err)
 			}
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status": "deleted",
 				"app_id": id,
 				"name":   name,

--- a/internal/cmd/apps_dev.go
+++ b/internal/cmd/apps_dev.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
-	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -122,7 +121,7 @@ func runAppsDev(ctx context.Context, c *client.Client, dir, entrypoint string, n
 	if !noOpen {
 		_ = openBrowser(previewURL)
 	}
-	output.OutputJSON(map[string]any{
+	outputJSON(map[string]any{
 		"status": "serving",
 		"url":    previewURL,
 	}, "")

--- a/internal/cmd/apps_init.go
+++ b/internal/cmd/apps_init.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -164,7 +163,7 @@ Installs dependencies as the last step, so you can cd in and run
 				return err
 			}
 			fmt.Fprintf(os.Stderr, "Next: cd %s && langsmith apps dev.\n", slug)
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status":   "scaffolded",
 				"dir":      dir,
 				"name":     name,

--- a/internal/cmd/apps_list.go
+++ b/internal/cmd/apps_list.go
@@ -53,7 +53,7 @@ func newAppsListCmd() *cobra.Command {
 					"updated_at":  a.UpdatedAt,
 				})
 			}
-			output.OutputJSON(data, outputFile)
+			outputJSON(data, outputFile)
 			return nil
 		},
 	}

--- a/internal/cmd/apps_pull.go
+++ b/internal/cmd/apps_pull.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/langchain-ai/langsmith-cli/internal/client"
-	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -80,7 +79,7 @@ The target directory is replaced, not merged. Run "npm install" after.`,
 
 			fmt.Fprintf(os.Stderr, "Pulled %q into %s (%d files).\n", app.Name, dest, len(written))
 			fmt.Fprintf(os.Stderr, "Next: cd %s && npm install && langsmith apps dev.\n", dirName)
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status": "pulled",
 				"app_id": app.ID,
 				"name":   app.Name,

--- a/internal/cmd/apps_push.go
+++ b/internal/cmd/apps_push.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
-	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -172,7 +171,7 @@ same app too.
 				"entrypoint": app.Entrypoint,
 				"files":      paths,
 			}
-			output.OutputJSON(result, "")
+			outputJSON(result, "")
 
 			workspaceID := app.TenantID
 			if workspaceID == "" {

--- a/internal/cmd/dataset.go
+++ b/internal/cmd/dataset.go
@@ -113,7 +113,7 @@ func newDatasetListCmd() *cobra.Command {
 						"created_at":    formatTimeISO(ds.CreatedAt),
 					})
 				}
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -152,9 +152,9 @@ func newDatasetGetCmd() *cobra.Command {
 
 			fmt_ := GetFormat()
 			if fmt_ == "pretty" {
-				output.PrintOutput(data, "pretty", outputFile)
+				printOutput(data, "pretty", outputFile)
 			} else {
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -188,7 +188,7 @@ func newDatasetCreateCmd() *cobra.Command {
 				ExitErrorf("creating dataset: %v", err)
 			}
 
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status":      "created",
 				"id":          ds.ID,
 				"name":        ds.Name,
@@ -235,7 +235,7 @@ func newDatasetDeleteCmd() *cobra.Command {
 				ExitErrorf("deleting dataset: %v", err)
 			}
 
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status": "deleted",
 				"id":     ds.ID,
 				"name":   ds.Name,
@@ -298,7 +298,7 @@ func newDatasetExportCmd() *cobra.Command {
 				ExitErrorf("writing file: %v", err)
 			}
 
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status":  "exported",
 				"dataset": ds.Name,
 				"count":   len(data),
@@ -390,7 +390,7 @@ func newDatasetUploadCmd() *cobra.Command {
 				}
 			}
 
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status":        "uploaded",
 				"dataset_id":    ds.ID,
 				"dataset_name":  name,

--- a/internal/cmd/evaluator.go
+++ b/internal/cmd/evaluator.go
@@ -93,7 +93,7 @@ Examples:
 			}
 
 			if len(matching) == 0 {
-				output.OutputJSON(map[string]any{
+				outputJSON(map[string]any{
 					"error": "no matching evaluators found",
 				}, "")
 				return
@@ -124,9 +124,9 @@ Examples:
 			}
 
 			if len(data) == 1 {
-				output.OutputJSON(data[0], outputFile)
+				outputJSON(data[0], outputFile)
 			} else {
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -183,7 +183,7 @@ func newEvaluatorListCmd() *cobra.Command {
 						"session_id":    nilStr(rule.SessionID),
 					})
 				}
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -212,7 +212,7 @@ func newEvaluatorUploadCmd() *cobra.Command {
 			evaluatorFile := args[0]
 
 			if err := validateEvaluatorTargetFlags(targetDataset, targetProject); err != nil {
-				output.OutputJSON(map[string]any{"error": err.Error()}, "")
+				outputJSON(map[string]any{"error": err.Error()}, "")
 				return
 			}
 
@@ -292,7 +292,7 @@ func newEvaluatorUploadCmd() *cobra.Command {
 			existing := findEvaluator(*rules, name, datasetID, projectID)
 			if existing != nil {
 				if !replace {
-					output.OutputJSON(map[string]any{
+					outputJSON(map[string]any{
 						"error": fmt.Sprintf("Evaluator '%s' already exists (use --replace to overwrite)", name),
 						"id":    existing.ID,
 					}, "")
@@ -321,7 +321,7 @@ func newEvaluatorUploadCmd() *cobra.Command {
 			if datasetID != "" {
 				targetLabel = "dataset"
 			}
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status": "uploaded",
 				"id":     result["id"],
 				"name":   name,
@@ -399,7 +399,7 @@ Examples:
 					ExitError("aborted")
 				}
 				if existing != nil {
-					output.OutputJSON(map[string]any{"error": err.Error(), "id": existing.ID}, "")
+					outputJSON(map[string]any{"error": err.Error(), "id": existing.ID}, "")
 					return
 				}
 				ExitErrorf("%v", err)
@@ -417,7 +417,7 @@ Examples:
 			if target.datasetID != "" {
 				targetLabel = "dataset"
 			}
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status": "created", "type": "llm",
 				"id": result["id"], "name": name, "target": targetLabel,
 			}, "")
@@ -468,7 +468,7 @@ func newEvaluatorDeleteCmd() *cobra.Command {
 			}
 
 			if len(matching) == 0 {
-				output.OutputJSON(map[string]any{"error": fmt.Sprintf("Evaluator '%s' not found", name)}, "")
+				outputJSON(map[string]any{"error": fmt.Sprintf("Evaluator '%s' not found", name)}, "")
 				return
 			}
 
@@ -489,7 +489,7 @@ func newEvaluatorDeleteCmd() *cobra.Command {
 				deleted++
 			}
 
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status": "deleted",
 				"name":   name,
 				"count":  deleted,

--- a/internal/cmd/example.go
+++ b/internal/cmd/example.go
@@ -133,7 +133,7 @@ func newExampleListCmd() *cobra.Command {
 					}
 					data = append(data, entry)
 				}
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -167,14 +167,14 @@ func newExampleCreateCmd() *cobra.Command {
 			// Parse JSON inputs
 			var parsedInputs map[string]any
 			if err := json.Unmarshal([]byte(inputs), &parsedInputs); err != nil {
-				output.OutputJSON(map[string]any{"error": fmt.Sprintf("Invalid JSON for --inputs: %v", err)}, "")
+				outputJSON(map[string]any{"error": fmt.Sprintf("Invalid JSON for --inputs: %v", err)}, "")
 				return
 			}
 
 			var parsedOutputs map[string]any
 			if outputs != "" {
 				if err := json.Unmarshal([]byte(outputs), &parsedOutputs); err != nil {
-					output.OutputJSON(map[string]any{"error": fmt.Sprintf("Invalid JSON for --outputs: %v", err)}, "")
+					outputJSON(map[string]any{"error": fmt.Sprintf("Invalid JSON for --outputs: %v", err)}, "")
 					return
 				}
 			}
@@ -182,7 +182,7 @@ func newExampleCreateCmd() *cobra.Command {
 			var parsedMetadata map[string]any
 			if metadata != "" {
 				if err := json.Unmarshal([]byte(metadata), &parsedMetadata); err != nil {
-					output.OutputJSON(map[string]any{"error": fmt.Sprintf("Invalid JSON for --metadata: %v", err)}, "")
+					outputJSON(map[string]any{"error": fmt.Sprintf("Invalid JSON for --metadata: %v", err)}, "")
 					return
 				}
 			}
@@ -214,7 +214,7 @@ func newExampleCreateCmd() *cobra.Command {
 				ExitErrorf("creating example: %v", err)
 			}
 
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status":     "created",
 				"id":         ex.ID,
 				"dataset_id": ex.DatasetID,
@@ -262,7 +262,7 @@ func newExampleDeleteCmd() *cobra.Command {
 				ExitErrorf("deleting example: %v", err)
 			}
 
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status": "deleted",
 				"id":     exampleID,
 			}, "")

--- a/internal/cmd/experiment.go
+++ b/internal/cmd/experiment.go
@@ -110,7 +110,7 @@ func newExperimentListCmd() *cobra.Command {
 					}
 					data = append(data, entry)
 				}
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -185,9 +185,9 @@ func newExperimentGetCmd() *cobra.Command {
 
 			fmt_ := GetFormat()
 			if fmt_ == "pretty" {
-				output.PrintOutput(data, "pretty", outputFile)
+				printOutput(data, "pretty", outputFile)
 			} else {
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -422,6 +422,24 @@ func resolveDataset(ctx context.Context, c *client.Client, nameOrID string) (*la
 	return &resp.Items[0], nil
 }
 
+func outputJSON(data any, filePath string) {
+	if err := output.OutputJSON(data, filePath); err != nil {
+		ExitErrorf("writing output: %v", err)
+	}
+}
+
+func outputJSONL(items []map[string]any, filePath string) {
+	if err := output.OutputJSONL(items, filePath); err != nil {
+		ExitErrorf("writing output: %v", err)
+	}
+}
+
+func printOutput(data any, format, filePath string) {
+	if err := output.PrintOutput(data, format, filePath); err != nil {
+		ExitErrorf("writing output: %v", err)
+	}
+}
+
 // formatTimedelta formats a duration as a human-readable string.
 func formatTimedelta(seconds float64) string {
 	if seconds < 1 {

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +12,32 @@ import (
 	"github.com/langchain-ai/langsmith-cli/internal/output"
 	langsmith "github.com/langchain-ai/langsmith-go"
 )
+
+func TestOutputJSONFailureExitsNonZero(t *testing.T) {
+	if path := os.Getenv("LANGSMITH_TEST_INVALID_OUTPUT_PATH"); path != "" {
+		outputJSON(map[string]any{"ok": true}, path)
+		return
+	}
+
+	path := filepath.Join(t.TempDir(), "missing", "output.json")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestOutputJSONFailureExitsNonZero$")
+	cmd.Env = append(os.Environ(), "LANGSMITH_TEST_INVALID_OUTPUT_PATH="+path)
+	combined, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("output failure exited successfully:\n%s", combined)
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok || exitErr.ExitCode() == 0 {
+		t.Fatalf("error = %v, want non-zero process exit", err)
+	}
+	text := string(combined)
+	if !strings.Contains(text, "writing output") || !strings.Contains(text, path) {
+		t.Errorf("missing actionable output error:\n%s", text)
+	}
+	if strings.Contains(text, `"status": "written"`) {
+		t.Errorf("failure printed a success status:\n%s", text)
+	}
+}
 
 // ---------- resolveSessionID ----------
 //

--- a/internal/cmd/hub_delete.go
+++ b/internal/cmd/hub_delete.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +36,7 @@ func newHubDeleteCmd() *cobra.Command {
 			if err := c.SDK.Repos.Directories.Delete(ctx, owner, name); err != nil {
 				return fmt.Errorf("deleting %s/%s: %w", owner, name, err)
 			}
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status": "deleted",
 				"owner":  owner,
 				"repo":   name,

--- a/internal/cmd/hub_get.go
+++ b/internal/cmd/hub_get.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +24,7 @@ func newHubGetCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("getting %s/%s: %w", owner, name, err)
 			}
-			output.OutputJSON(sdkRepoToHubRepo(resp.Repo), "")
+			outputJSON(sdkRepoToHubRepo(resp.Repo), "")
 			return nil
 		},
 	}

--- a/internal/cmd/hub_init.go
+++ b/internal/cmd/hub_init.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -36,7 +35,7 @@ func newHubInitCmd() *cobra.Command {
 				return err
 			}
 			sort.Strings(written)
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status": "scaffolded",
 				"dir":    dir,
 				"type":   repoType,

--- a/internal/cmd/hub_list.go
+++ b/internal/cmd/hub_list.go
@@ -86,7 +86,7 @@ func newHubListCmd() *cobra.Command {
 				return nil
 			}
 
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"total": int(resp.Total),
 				"repos": repos,
 			}, "")

--- a/internal/cmd/hub_pull.go
+++ b/internal/cmd/hub_pull.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/langchain-ai/langsmith-cli/internal/output"
 	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
@@ -70,7 +69,7 @@ func newHubPullCmd() *cobra.Command {
 			if len(linked) > 0 {
 				out["linked_children"] = linked
 			}
-			output.OutputJSON(out, "")
+			outputJSON(out, "")
 			return nil
 		},
 	}

--- a/internal/cmd/hub_push.go
+++ b/internal/cmd/hub_push.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/langchain-ai/langsmith-cli/internal/output"
 	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
@@ -92,7 +91,7 @@ func newHubPushCmd() *cobra.Command {
 				paths = append(paths, k)
 			}
 			sort.Strings(paths)
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status":      "pushed",
 				"owner":       owner,
 				"repo":        name,

--- a/internal/cmd/insights.go
+++ b/internal/cmd/insights.go
@@ -100,7 +100,7 @@ for full details including the executive summary and category breakdown.`,
 				for _, job := range jobs {
 					data = append(data, insightJobToMap(job))
 				}
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -155,7 +155,7 @@ statistics (error rates, latency, costs, token usage, feedback scores).`,
 				printInsightPretty(detail)
 			} else {
 				data := buildInsightDetailJSON(detail)
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}

--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -136,7 +136,7 @@ Examples:
 				for _, issue := range issues {
 					data = append(data, issueToMap(issue))
 				}
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -173,7 +173,7 @@ Examples:
 				ExitErrorf("getting issue: %v", err)
 			}
 
-			output.OutputJSON(json.RawMessage(issue.JSON.RawJSON()), outputFile)
+			outputJSON(json.RawMessage(issue.JSON.RawJSON()), outputFile)
 		},
 	}
 
@@ -283,7 +283,7 @@ Examples:
 					}
 					data = append(data, m)
 				}
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -387,7 +387,7 @@ Examples:
 				ExitErrorf("updating issue: %v", err)
 			}
 
-			output.OutputJSON(issueToMap(issue), outputFile)
+			outputJSON(issueToMap(issue), outputFile)
 		},
 	}
 
@@ -706,7 +706,7 @@ Examples:
 				ExitErrorf("proposing example: %v", err)
 			}
 
-			output.OutputJSON(result, outputFile)
+			outputJSON(result, outputFile)
 		},
 	}
 

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -12,7 +12,6 @@ import (
 	langsmith "github.com/langchain-ai/langsmith-go"
 
 	"github.com/langchain-ai/langsmith-cli/internal/client"
-	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -218,7 +217,7 @@ Examples:
 				if fmt_ == "pretty" {
 					printTraceMessages(combined)
 				} else {
-					output.OutputJSON(combined, outputFile)
+					outputJSON(combined, outputFile)
 				}
 				return
 			}
@@ -274,7 +273,7 @@ Examples:
 			if fmt_ == "pretty" {
 				printTraceMessages(combined)
 			} else {
-				output.OutputJSON(combined, outputFile)
+				outputJSON(combined, outputFile)
 			}
 		},
 	}

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -124,7 +124,7 @@ func newProjectListCmd() *cobra.Command {
 					}
 					data = append(data, entry)
 				}
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}

--- a/internal/cmd/prompt.go
+++ b/internal/cmd/prompt.go
@@ -148,7 +148,7 @@ func newPromptListCmd() *cobra.Command {
 				for _, r := range repos {
 					data = append(data, repoToMap(r))
 				}
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -193,9 +193,9 @@ func newPromptGetCmd() *cobra.Command {
 
 			fmt_ := GetFormat()
 			if fmt_ == "pretty" {
-				output.PrintOutput(data, "pretty", outputFile)
+				printOutput(data, "pretty", outputFile)
 			} else {
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -235,7 +235,7 @@ func newPromptCreateCmd() *cobra.Command {
 				ExitErrorf("creating prompt: %v", err)
 			}
 
-			output.OutputJSON(repoToMap(resp.Repo), "")
+			outputJSON(repoToMap(resp.Repo), "")
 		},
 	}
 
@@ -278,7 +278,7 @@ func newPromptDeleteCmd() *cobra.Command {
 				ExitErrorf("deleting prompt %s/%s: %v", owner, repo, err)
 			}
 
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status": "deleted",
 				"owner":  owner,
 				"repo":   repo,
@@ -332,9 +332,9 @@ func newPromptPullCmd() *cobra.Command {
 
 			fmt_ := GetFormat()
 			if fmt_ == "pretty" {
-				output.PrintOutput(data, "pretty", outputFile)
+				printOutput(data, "pretty", outputFile)
 			} else {
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -397,7 +397,7 @@ func newPromptPushCmd() *cobra.Command {
 				ExitErrorf("pushing commit to %s/%s: %v", owner, repo, err)
 			}
 
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status":      "pushed",
 				"owner":       owner,
 				"repo":        repo,
@@ -485,7 +485,7 @@ func newPromptCommitsCmd() *cobra.Command {
 						"created_at":         formatTimeISO(c.CreatedAt),
 					})
 				}
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -570,7 +570,7 @@ func newPromptTagListCmd() *cobra.Command {
 						"updated_at":  t.UpdatedAt,
 					})
 				}
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -608,7 +608,7 @@ func newPromptTagCreateCmd() *cobra.Command {
 				ExitErrorf("creating tag %q: %v", tagName, err)
 			}
 
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status":      "created",
 				"tag_name":    tag.TagName,
 				"commit_id":   tag.CommitID,
@@ -651,7 +651,7 @@ func newPromptTagUpdateCmd() *cobra.Command {
 				ExitErrorf("updating tag %q: %v", tagName, err)
 			}
 
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status":      "updated",
 				"tag_name":    tag.TagName,
 				"commit_id":   tag.CommitID,

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -81,7 +81,7 @@ func newRunListCmd() *cobra.Command {
 				output.PrintRunsTable(os.Stdout, data, includeMetadata, "Runs")
 			} else {
 				data := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -148,9 +148,9 @@ func newRunGetCmd() *cobra.Command {
 			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
-				output.PrintOutput(data, "pretty", outputFile)
+				printOutput(data, "pretty", outputFile)
 			} else {
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -210,7 +210,7 @@ func newRunExportCmd() *cobra.Command {
 			}
 
 			data := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)
-			output.OutputJSONL(data, outputFile)
+			outputJSONL(data, outputFile)
 		},
 	}
 

--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -170,7 +170,7 @@ func newThreadListCmd() *cobra.Command {
 						"max_start_time": t.MaxStartTime,
 					})
 				}
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -254,7 +254,7 @@ func newThreadGetCmd() *cobra.Command {
 					"run_count": len(extracted),
 					"runs":      extracted,
 				}
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -352,7 +352,7 @@ Examples:
 			if fmt_ == "pretty" {
 				printThreadMessages(result)
 			} else {
-				output.OutputJSON(result, outputFile)
+				outputJSON(result, outputFile)
 			}
 		},
 	}

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -141,13 +142,13 @@ func newTraceListCmd() *cobra.Command {
 							"runs":      extractRunsToMaps(allRuns, includeMetadata, includeIO, includeFeedback),
 						})
 					}
-					output.OutputJSON(result, outputFile)
+					outputJSON(result, outputFile)
 				} else {
 					data := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)
 					if flaggedByTrace != nil {
 						annotateFlagged(data, flaggedByTrace)
 					}
-					output.OutputJSON(data, outputFile)
+					outputJSON(data, outputFile)
 				}
 			}
 		},
@@ -224,7 +225,7 @@ func newTraceGetCmd() *cobra.Command {
 					"run_count": len(runs),
 					"runs":      extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback),
 				}
-				output.OutputJSON(data, outputFile)
+				outputJSON(data, outputFile)
 			}
 		},
 	}
@@ -329,15 +330,28 @@ func newTraceExportCmd() *cobra.Command {
 
 				for _, run := range allRuns {
 					data := extractRunsToMaps([]langsmith.RunSchema{run}, includeMetadata, includeIO, includeFeedback)
-					line, _ := json.Marshal(data[0])
-					_, _ = f.Write(line)
-					_, _ = f.WriteString("\n")
+					line, err := json.Marshal(data[0])
+					if err != nil {
+						_ = f.Close()
+						ExitErrorf("encoding trace %s: %v", tid, err)
+					}
+					line = append(line, '\n')
+					n, err := f.Write(line)
+					if err == nil && n != len(line) {
+						err = io.ErrShortWrite
+					}
+					if err != nil {
+						_ = f.Close()
+						ExitErrorf("writing file %s: %v", fpath, err)
+					}
 				}
-				f.Close()
+				if err := f.Close(); err != nil {
+					ExitErrorf("closing file %s: %v", fpath, err)
+				}
 				exported++
 			}
 
-			output.OutputJSON(map[string]any{
+			outputJSON(map[string]any{
 				"status":     "exported",
 				"count":      exported,
 				"output_dir": outputDir,

--- a/internal/cmd/trace_stats.go
+++ b/internal/cmd/trace_stats.go
@@ -92,7 +92,7 @@ Examples:
 				if hasCompare {
 					result["compare"] = compare
 				}
-				output.OutputJSON(result, outputFile)
+				outputJSON(result, outputFile)
 			}
 			return nil
 		},

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -14,45 +14,86 @@ import (
 
 // OutputJSON writes data as indented JSON to stdout or a file.
 // If filePath is non-empty, writes to file and prints status to stderr.
-func OutputJSON(data any, filePath string) {
+func OutputJSON(data any, filePath string) error {
 	jsonBytes, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
-		PrintError(fmt.Sprintf("JSON encoding error: %v", err))
-		return
+		return fmt.Errorf("encoding JSON: %w", err)
 	}
 
 	if filePath != "" {
-		if err := os.WriteFile(filePath, jsonBytes, 0644); err != nil {
-			PrintError(fmt.Sprintf("write error: %v", err))
-			return
+		if err := os.WriteFile(filePath, jsonBytes, 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", filePath, err)
 		}
-		fmt.Fprintf(os.Stderr, `{"status": "written", "path": %q}`+"\n", filePath)
-	} else {
-		fmt.Println(string(jsonBytes))
+		if _, err := fmt.Fprintf(os.Stderr, `{"status": "written", "path": %q}`+"\n", filePath); err != nil {
+			return fmt.Errorf("writing status: %w", err)
+		}
+		return nil
 	}
+	if err := writeBytes(os.Stdout, append(jsonBytes, '\n')); err != nil {
+		return fmt.Errorf("writing JSON output: %w", err)
+	}
+	return nil
 }
 
 // OutputJSONL writes items as JSONL (one JSON object per line).
-func OutputJSONL(items []map[string]any, filePath string) {
+func OutputJSONL(items []map[string]any, filePath string) error {
+	return outputJSONL(items, filePath, os.Stdout, os.Stderr, func(path string) (io.WriteCloser, error) {
+		return os.Create(path)
+	})
+}
+
+func outputJSONL(
+	items []map[string]any,
+	filePath string,
+	stdout io.Writer,
+	stderr io.Writer,
+	createFile func(string) (io.WriteCloser, error),
+) error {
 	if filePath != "" {
-		f, err := os.Create(filePath)
+		f, err := createFile(filePath)
 		if err != nil {
-			PrintError(fmt.Sprintf("write error: %v", err))
-			return
+			return fmt.Errorf("creating %s: %w", filePath, err)
 		}
-		defer f.Close()
 		for _, item := range items {
-			line, _ := json.Marshal(item)
-			_, _ = f.Write(line)
-			_, _ = f.WriteString("\n")
+			line, err := json.Marshal(item)
+			if err != nil {
+				_ = f.Close()
+				return fmt.Errorf("encoding JSONL: %w", err)
+			}
+			if err := writeBytes(f, append(line, '\n')); err != nil {
+				_ = f.Close()
+				return fmt.Errorf("writing %s: %w", filePath, err)
+			}
 		}
-		fmt.Fprintf(os.Stderr, `{"status": "written", "path": %q, "count": %d}`+"\n", filePath, len(items))
-	} else {
-		for _, item := range items {
-			line, _ := json.Marshal(item)
-			fmt.Println(string(line))
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("closing %s: %w", filePath, err)
+		}
+		if _, err := fmt.Fprintf(stderr, `{"status": "written", "path": %q, "count": %d}`+"\n", filePath, len(items)); err != nil {
+			return fmt.Errorf("writing status: %w", err)
+		}
+		return nil
+	}
+	for _, item := range items {
+		line, err := json.Marshal(item)
+		if err != nil {
+			return fmt.Errorf("encoding JSONL: %w", err)
+		}
+		if err := writeBytes(stdout, append(line, '\n')); err != nil {
+			return fmt.Errorf("writing JSONL output: %w", err)
 		}
 	}
+	return nil
+}
+
+func writeBytes(w io.Writer, data []byte) error {
+	n, err := w.Write(data)
+	if err != nil {
+		return err
+	}
+	if n != len(data) {
+		return io.ErrShortWrite
+	}
+	return nil
 }
 
 // OutputTable prints a table to stdout using tablewriter.
@@ -139,18 +180,25 @@ func addChildren(node treeprint.Tree, parentID string, childrenMap map[string][]
 }
 
 // PrintOutput dispatches to JSON or pretty output.
-func PrintOutput(data any, format string, filePath string) {
+func PrintOutput(data any, format string, filePath string) error {
 	if format == "pretty" {
 		// Pretty mode: just pretty-print JSON to stdout
-		jsonBytes, _ := json.MarshalIndent(data, "", "  ")
-		if filePath != "" {
-			_ = os.WriteFile(filePath, jsonBytes, 0644)
-		} else {
-			fmt.Println(string(jsonBytes))
+		jsonBytes, err := json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			return fmt.Errorf("encoding JSON: %w", err)
 		}
-	} else {
-		OutputJSON(data, filePath)
+		if filePath != "" {
+			if err := os.WriteFile(filePath, jsonBytes, 0o644); err != nil {
+				return fmt.Errorf("writing %s: %w", filePath, err)
+			}
+			return nil
+		}
+		if err := writeBytes(os.Stdout, append(jsonBytes, '\n')); err != nil {
+			return fmt.Errorf("writing JSON output: %w", err)
+		}
+		return nil
 	}
+	return OutputJSON(data, filePath)
 }
 
 // PrintError prints an error to stderr.

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -2,6 +2,8 @@ package output
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,7 +16,9 @@ func TestOutputJSON(t *testing.T) {
 		"id":   "123",
 		"name": "test",
 	}
-	OutputJSON(data, "")
+	if err := OutputJSON(data, ""); err != nil {
+		t.Fatalf("OutputJSON: %v", err)
+	}
 }
 
 func TestOutputJSONToFile(t *testing.T) {
@@ -26,7 +30,9 @@ func TestOutputJSONToFile(t *testing.T) {
 		{"id": "2", "name": "second"},
 	}
 
-	OutputJSON(data, fpath)
+	if err := OutputJSON(data, fpath); err != nil {
+		t.Fatalf("OutputJSON: %v", err)
+	}
 
 	content, err := os.ReadFile(fpath)
 	if err != nil {
@@ -47,7 +53,9 @@ func TestOutputJSONL(t *testing.T) {
 		{"id": "2", "name": "second"},
 	}
 
-	OutputJSONL(items, fpath)
+	if err := OutputJSONL(items, fpath); err != nil {
+		t.Fatalf("OutputJSONL: %v", err)
+	}
 
 	content, err := os.ReadFile(fpath)
 	if err != nil {
@@ -58,6 +66,102 @@ func TestOutputJSONL(t *testing.T) {
 	if len(lines) != 2 {
 		t.Errorf("expected 2 lines, got %d", len(lines))
 	}
+}
+
+func TestOutputJSON_ReturnsMarshalError(t *testing.T) {
+	err := OutputJSON(map[string]any{"unsupported": make(chan int)}, "")
+	if err == nil || !strings.Contains(err.Error(), "encoding JSON") {
+		t.Fatalf("error = %v, want JSON encoding error", err)
+	}
+}
+
+func TestOutputJSON_ReturnsFileError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing", "output.json")
+	err := OutputJSON(map[string]any{"ok": true}, path)
+	if err == nil || !strings.Contains(err.Error(), path) {
+		t.Fatalf("error = %v, want path %q", err, path)
+	}
+}
+
+func TestPrintOutput_ReturnsFileError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing", "output.json")
+	err := PrintOutput(map[string]any{"ok": true}, "pretty", path)
+	if err == nil || !strings.Contains(err.Error(), path) {
+		t.Fatalf("error = %v, want path %q", err, path)
+	}
+}
+
+func TestWriteBytes_ReturnsShortWrite(t *testing.T) {
+	err := writeBytes(shortWriter{}, []byte("complete output"))
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("error = %v, want io.ErrShortWrite", err)
+	}
+}
+
+func TestOutputJSONL_ReturnsWriteErrorWithoutSuccess(t *testing.T) {
+	writeErr := errors.New("disk full")
+	writer := &errorWriteCloser{writeErr: writeErr}
+	var stderr bytes.Buffer
+	err := outputJSONL(
+		[]map[string]any{{"id": "1"}},
+		"output.jsonl",
+		io.Discard,
+		&stderr,
+		func(string) (io.WriteCloser, error) { return writer, nil },
+	)
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("error = %v, want %v", err, writeErr)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("failure must not print success status: %q", stderr.String())
+	}
+	if !writer.closed {
+		t.Error("writer was not closed after write failure")
+	}
+}
+
+func TestOutputJSONL_ReturnsCloseErrorWithoutSuccess(t *testing.T) {
+	closeErr := errors.New("close failed")
+	writer := &errorWriteCloser{closeErr: closeErr}
+	var stderr bytes.Buffer
+	err := outputJSONL(
+		[]map[string]any{{"id": "1"}},
+		"output.jsonl",
+		io.Discard,
+		&stderr,
+		func(string) (io.WriteCloser, error) { return writer, nil },
+	)
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("error = %v, want %v", err, closeErr)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("close failure must not print success status: %q", stderr.String())
+	}
+}
+
+type shortWriter struct{}
+
+func (shortWriter) Write(p []byte) (int, error) {
+	return len(p) - 1, nil
+}
+
+type errorWriteCloser struct {
+	bytes.Buffer
+	writeErr error
+	closeErr error
+	closed   bool
+}
+
+func (w *errorWriteCloser) Write(p []byte) (int, error) {
+	if w.writeErr != nil {
+		return 0, w.writeErr
+	}
+	return w.Buffer.Write(p)
+}
+
+func (w *errorWriteCloser) Close() error {
+	w.closed = true
+	return w.closeErr
 }
 
 func TestFormatDuration(t *testing.T) {


### PR DESCRIPTION
## Summary

- make JSON, JSONL, and pretty JSON output helpers return serialization and I/O errors
- check short writes, file creation, writes, explicit closes, and status-output writes
- emit file-success status only after the data write and close complete successfully
- route every command output call through checked wrappers so failures terminate the CLI non-zero
- fix trace export's separate JSONL implementation to check marshal, write, short-write, and close failures

Closes #224.

## Problem

The shared output helpers previously treated several failure modes as success:

- `OutputJSON` printed marshal/write errors but returned normally
- `OutputJSONL` ignored marshal, write, newline, and deferred-close errors
- `PrintOutput` ignored marshal and `os.WriteFile` errors entirely
- trace export had a second JSONL loop with unchecked marshal/write/close calls

In the JSONL path, the CLI printed `{"status":"written"}` even if an earlier write or the final close failed. Commands therefore exited with status 0 after producing a missing or truncated export.

## Implementation

### Error-returning output APIs

The following internal output functions now return `error`:

```go
OutputJSON(data, path) error
OutputJSONL(items, path) error
PrintOutput(data, format, path) error
```

Errors include operation and path context while retaining the underlying error for `errors.Is`/`errors.As`.

JSON output now checks:

- `json.MarshalIndent`
- file writes
- stdout writes and short writes
- status writes

JSONL output now checks:

- file creation
- each item marshal
- each complete line write, including short writes
- explicit file close
- stdout and status writes

On a write failure, the file is closed best-effort and no success status is printed. On normal completion, close is performed and checked before success is reported.

### Command propagation

All command call sites now use three checked command-layer wrappers. Those wrappers feed output failures through the CLI's existing `ExitErrorf` policy, producing an actionable stderr error and a non-zero process exit. This keeps existing command callbacks and successful output schemas unchanged while ensuring no helper error is ignored.

Most command-file changes in this PR are the mechanical replacement of:

```go
output.OutputJSON(...)
```

with:

```go
outputJSON(...)
```

The wrappers are the only command-layer callers of the error-returning output APIs.

### Trace export

Trace export writes one JSONL file per trace without using the shared JSONL helper because it has per-trace extraction behavior. Its loop now:

- checks every marshal
- writes each JSON object and newline as one checked operation
- detects `io.ErrShortWrite`
- closes the file immediately on failure
- checks the successful final close before incrementing the exported count

The final `count` can no longer include a trace whose file failed to finish writing.

## Behavior

Successful output and status payloads remain unchanged.

On failure, commands now behave like:

```console
$ langsmith ... --output /missing/path/results.json
writing output: writing /missing/path/results.json: ...
$ echo $?
1
```

No `"status": "written"` line is emitted for failed writes or failed closes.

## Tests

Added deterministic coverage for:

- unsupported values causing JSON marshal failure
- invalid/unwritable output paths
- pretty-output file failures
- partial writes returning `io.ErrShortWrite`
- explicit writer failures after file creation
- close failures
- closing a writer after a write failure
- suppression of success status after write or close failure
- subprocess-level confirmation that a command-layer output failure exits non-zero and names the failed path

Existing success tests now assert that the output helpers return `nil`.

Local verification:

- focused output failure tests
- command subprocess exit test
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `make build`
- `git diff --check`

`make lint` was not available locally because `golangci-lint` is not installed.
