### PR TITLE
fix(apps): stage pulls before replacing destination

### DIFF
--- a/internal/cmd/apps_pull.go
+++ b/internal/cmd/apps_pull.go
@@ -60,23 +60,32 @@ The target directory is replaced, not merged. Run "npm install" after.`,
 			if err := confirmSourceDirReplace(cmd, dest, force); err != nil {
 				return err
 			}
-			if err := os.RemoveAll(dest); err != nil {
-				return fmt.Errorf("clearing %s: %w", dest, err)
-			}
-			if err := os.MkdirAll(dest, 0o755); err != nil {
-				return fmt.Errorf("creating %s: %w", dest, err)
-			}
 
-			written, err := extractSourceArchive(dest, archive)
+			staging, err := os.MkdirTemp(cwd, "."+dirName+".pull-*")
+			if err != nil {
+				return fmt.Errorf("creating staging directory: %w", err)
+			}
+			stagingOwned := true
+			defer func() {
+				if stagingOwned {
+					_ = os.RemoveAll(staging)
+				}
+			}()
+
+			written, err := extractSourceArchive(staging, archive)
 			if err != nil {
 				return err
 			}
 			if len(written) == 0 {
 				return fmt.Errorf("the stored source archive for %q is empty", app.Name)
 			}
-			if err := writeAppLink(dest, appLink{AppID: app.ID, Name: app.Name}); err != nil {
+			if err := writeAppLink(staging, appLink{AppID: app.ID, Name: app.Name}); err != nil {
 				return err
 			}
+			if err := replaceStagedApp(staging, dest); err != nil {
+				return err
+			}
+			stagingOwned = false
 
 			fmt.Fprintf(os.Stderr, "Pulled %q into %s (%d files).\n", app.Name, dest, len(written))
 			fmt.Fprintf(os.Stderr, "Next: cd %s && npm install && langsmith apps dev.\n", dirName)
@@ -162,6 +171,50 @@ func confirmSourceDirReplace(cmd *cobra.Command, dest string, force bool) error 
 	_, _ = fmt.Fscanln(cmd.InOrStdin(), &confirm)
 	if ans := strings.ToLower(strings.TrimSpace(confirm)); ans != "y" && ans != "yes" {
 		return errors.New("aborted: pass --force to replace the directory")
+	}
+	return nil
+}
+
+// replaceStagedApp replaces dest with a complete staged directory. Keeping the
+// old directory under a sibling backup until the staged rename succeeds makes
+// extraction and validation failures non-destructive, while the rollback keeps
+// the original directory recoverable if the replacement rename itself fails.
+func replaceStagedApp(staging, dest string) error {
+	parent := filepath.Dir(dest)
+	backup, err := os.MkdirTemp(parent, ".app-backup-*")
+	if err != nil {
+		return fmt.Errorf("creating replacement backup: %w", err)
+	}
+	if err := os.Remove(backup); err != nil {
+		return fmt.Errorf("preparing replacement backup: %w", err)
+	}
+
+	destExists := false
+	if _, err := os.Lstat(dest); err == nil {
+		destExists = true
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("checking destination %s: %w", dest, err)
+	}
+
+	if destExists {
+		if err := os.Rename(dest, backup); err != nil {
+			return fmt.Errorf("backing up %s: %w", dest, err)
+		}
+	}
+
+	if err := os.Rename(staging, dest); err != nil {
+		if destExists {
+			if rollbackErr := os.Rename(backup, dest); rollbackErr != nil {
+				return fmt.Errorf("installing staged app: %v (rollback failed: %w)", err, rollbackErr)
+			}
+		}
+		return fmt.Errorf("installing staged app: %w", err)
+	}
+
+	if destExists {
+		if err := os.RemoveAll(backup); err != nil {
+			return fmt.Errorf("removing replacement backup %s: %w", backup, err)
+		}
 	}
 	return nil
 }

--- a/internal/cmd/apps_pull_test.go
+++ b/internal/cmd/apps_pull_test.go
@@ -209,6 +209,76 @@ func TestAppsPull_SurfacesNoSourceArchive404(t *testing.T) {
 	}
 }
 
+func TestAppsPull_InvalidArchivePreservesExistingDestination(t *testing.T) {
+	mux := appsSourceServer(t,
+		[]customApp{{ID: testAppID, Name: "my-app"}},
+		map[string][]byte{testAppID: []byte("not a gzip archive")},
+	)
+	srv := newTestServer(t, mux.ServeHTTP)
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	seedFile(t, dir, "my-app/src/App.tsx", "known-good")
+	seedFile(t, dir, "my-app/keep.txt", "keep this")
+
+	cmd := newAppsCmd()
+	cmd.SetArgs([]string{"pull", "my-app", "--force"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not a valid gzip") {
+		t.Fatalf("expected invalid archive error, got %v", err)
+	}
+	for rel, want := range map[string]string{
+		"src/App.tsx": "known-good",
+		"keep.txt":    "keep this",
+	} {
+		got, readErr := os.ReadFile(filepath.Join(dir, "my-app", filepath.FromSlash(rel)))
+		if readErr != nil || string(got) != want {
+			t.Errorf("existing %s was not preserved: %q (%v)", rel, got, readErr)
+		}
+	}
+	if entries, readErr := os.ReadDir(dir); readErr != nil {
+		t.Fatalf("read working directory: %v", readErr)
+	} else {
+		for _, entry := range entries {
+			if strings.Contains(entry.Name(), ".pull-") {
+				t.Errorf("staging directory leaked after failure: %s", entry.Name())
+			}
+		}
+	}
+}
+
+func TestAppsPull_UnsafeArchivePreservesExistingDestination(t *testing.T) {
+	archive := tarGz(t, map[string]string{
+		"../escaped.txt": "must not extract",
+		"src/App.tsx":    "new app",
+	})
+	mux := appsSourceServer(t,
+		[]customApp{{ID: testAppID, Name: "my-app"}},
+		map[string][]byte{testAppID: archive},
+	)
+	srv := newTestServer(t, mux.ServeHTTP)
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	seedFile(t, dir, "my-app/src/App.tsx", "known-good")
+
+	cmd := newAppsCmd()
+	cmd.SetArgs([]string{"pull", "my-app", "--force"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "refusing to extract") {
+		t.Fatalf("expected unsafe archive error, got %v", err)
+	}
+	got, readErr := os.ReadFile(filepath.Join(dir, "my-app", "src", "App.tsx"))
+	if readErr != nil || string(got) != "known-good" {
+		t.Errorf("existing app was not preserved: %q (%v)", got, readErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "escaped.txt")); !os.IsNotExist(statErr) {
+		t.Errorf("unsafe archive wrote outside destination: %v", statErr)
+	}
+}
+
 func TestAppsPull_RefusesNonEmptyDirWithoutForce(t *testing.T) {
 	archive := tarGz(t, map[string]string{"src/App.tsx": "fresh"})
 	mux := appsSourceServer(t,


### PR DESCRIPTION
## Summary

- extract pulled app source into a temporary sibling directory
- validate the complete archive and write `.langsmith/app.json` before touching the destination
- replace the destination only after staging succeeds
- keep a rollback backup if the final rename fails
- clean up staging directories on all pre-install failures

Closes #225.

## Problem

`apps pull` previously performed these operations in this order:

1. confirm replacement;
2. remove the existing app directory;
3. create the replacement directory;
4. validate and extract the downloaded archive;
5. write the app link.

Any invalid gzip/base64 payload, unsafe archive entry, empty archive, extraction I/O failure, or app-link write failure could therefore destroy a known-good local app and leave no complete replacement.

## Implementation

The command now creates a temporary sibling directory named like `.<app>.pull-*` and performs all validation/extraction/link writing there. The existing destination remains untouched while these operations run.

Once staging is complete, `replaceStagedApp`:

1. moves an existing destination to a temporary sibling backup;
2. renames the complete staging directory into the destination path;
3. rolls the backup back into place if the staged rename fails;
4. removes the backup only after the replacement succeeds.

The staging directory is removed by deferred cleanup whenever ownership has not been transferred to the replacement operation. A failed archive never reaches the replacement phase.

## Behavior

With an existing app and an invalid server archive:

```console
$ langsmith apps pull my-app --force
the stored source archive is not a valid gzip file: ...
```

The command fails, the old app files remain unchanged, and no temporary staging directory is left behind.

With a valid archive, the destination is still replaced rather than merged: files removed upstream do not remain locally, while the complete new app and `.langsmith/app.json` are installed together.

## Tests

Added regression coverage for:

- malformed archive with an existing destination preserves all old files
- unsafe traversal archive with an existing destination preserves all old files
- traversal entries never escape the working directory
- staging directories are cleaned after invalid-archive failure
- existing successful `--force` replacement still removes stale files
- confirmed non-empty replacement continues to work
- normal name resolution and app-link creation remain intact

The existing lower-level extraction tests continue to cover path validation, symlink skipping, non-gzip bodies, and push-to-pull archive round trips.

Local verification:

- focused `apps pull` regression tests
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `make build`
- `git diff --check`

`make lint` was not available locally because `golangci-lint` is not installed.
