### PR TITLE
Prevent trace export filename collisions

### DIFF
--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -292,6 +292,18 @@ func newTraceExportCmd() *cobra.Command {
 				ExitErrorf("%v", err)
 			}
 
+			// Resolve every destination before creating any files. A pattern such as
+			// "trace.jsonl" or {name} can map multiple traces to one path; allowing
+			// os.Create to handle that would silently truncate an earlier export.
+			paths := make(map[string]string, len(rootRuns))
+			for _, root := range rootRuns {
+				fpath := traceExportPath(outputDir, filenamePattern, root)
+				if previous, ok := paths[fpath]; ok {
+					ExitErrorf("filename pattern resolves multiple traces to %s (trace IDs %s and %s); include {trace_id} or another unique placeholder", fpath, previous, root.TraceID)
+				}
+				paths[fpath] = root.TraceID
+			}
+
 			exported := 0
 			for _, root := range rootRuns {
 				tid := root.TraceID
@@ -311,16 +323,7 @@ func newTraceExportCmd() *cobra.Command {
 					ExitErrorf("%v", err)
 				}
 
-				name := root.Name
-				if name == "" {
-					name = "unknown"
-				}
-
-				filename := filenamePattern
-				filename = strings.ReplaceAll(filename, "{trace_id}", tid)
-				filename = strings.ReplaceAll(filename, "{name}", name)
-				filename = filepath.Base(filename)
-				fpath := filepath.Join(outputDir, filename)
+				fpath := traceExportPath(outputDir, filenamePattern, root)
 
 				f, err := os.Create(fpath)
 				if err != nil {
@@ -356,6 +359,16 @@ func newTraceExportCmd() *cobra.Command {
 	cmd.MarkFlagsMutuallyExclusive("project", "project-id")
 
 	return cmd
+}
+
+func traceExportPath(outputDir, pattern string, root langsmith.RunSchema) string {
+	name := root.Name
+	if name == "" {
+		name = "unknown"
+	}
+	filename := strings.ReplaceAll(pattern, "{trace_id}", root.TraceID)
+	filename = strings.ReplaceAll(filename, "{name}", name)
+	return filepath.Join(outputDir, filepath.Base(filename))
 }
 
 // annotateFlagged mutates each run map to add a "flagged_comment" field

--- a/internal/cmd/trace_test.go
+++ b/internal/cmd/trace_test.go
@@ -2,7 +2,27 @@ package cmd
 
 import (
 	"testing"
+
+	langsmith "github.com/langchain-ai/langsmith-go"
 )
+
+func TestTraceExportPathUsesTraceID(t *testing.T) {
+	first := langsmith.RunSchema{TraceID: "trace-1", Name: "same"}
+	second := langsmith.RunSchema{TraceID: "trace-2", Name: "same"}
+	if got := traceExportPath("out", "{trace_id}.jsonl", first); got == traceExportPath("out", "{trace_id}.jsonl", second) {
+		t.Fatal("trace_id pattern should produce unique paths")
+	}
+}
+
+func TestTraceExportPathCollidesForConstantAndNamePatterns(t *testing.T) {
+	first := langsmith.RunSchema{TraceID: "trace-1", Name: "same"}
+	second := langsmith.RunSchema{TraceID: "trace-2", Name: "same"}
+	for _, pattern := range []string{"trace.jsonl", "{name}.jsonl"} {
+		if traceExportPath("out", pattern, first) != traceExportPath("out", pattern, second) {
+			t.Errorf("pattern %q should collide for equal names", pattern)
+		}
+	}
+}
 
 // ==================== Command structure ====================
 


### PR DESCRIPTION
## Summary

Closes #227

Trace export now detects duplicate destination paths before writing any trace files, preventing silent truncation and misleading export counts.

## What changed

- Resolve every root trace's filename up front using the configured `{trace_id}` and `{name}` substitutions.
- Reject duplicate paths before child traces are queried or any output file is created.
- Include the conflicting path and trace IDs in the actionable error; recommend `{trace_id}` or another unique placeholder.
- Reuse the same path resolver during the write phase so collision checking and file creation cannot diverge.

This preserves the existing default `{trace_id}.jsonl` behavior while making constant and non-unique `{name}` patterns fail safely instead of overwriting earlier exports.

## Tests

- Constant and same-name patterns are verified to collide.
- `{trace_id}` patterns are verified to remain unique.
- `go test ./...`
- `go test -race ./internal/cmd`
- `go vet ./...`
- `make build`
