### PR TITLE
Atomically replace LangSmith CLI config files

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,16 +104,40 @@ func (c *Config) SaveTo(path string) error {
 		return fmt.Errorf("encoding config JSON: %w", err)
 	}
 
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, ".langsmith-config-*")
 	if err != nil {
-		return fmt.Errorf("opening config for write: %w", err)
+		return fmt.Errorf("creating temporary config: %w", err)
 	}
-	defer f.Close()
+	tmpPath := f.Name()
+	cleanup := func() {
+		_ = os.Remove(tmpPath)
+	}
 	if _, err := f.Write(buf.Bytes()); err != nil {
+		closeErr := f.Close()
+		cleanup()
+		if closeErr != nil {
+			return fmt.Errorf("writing config: %v (closing temporary config: %v)", err, closeErr)
+		}
 		return fmt.Errorf("writing config: %w", err)
 	}
 	if err := f.Chmod(0600); err != nil {
+		_ = f.Close()
+		cleanup()
 		return fmt.Errorf("setting config permissions: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		cleanup()
+		return fmt.Errorf("syncing temporary config: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("closing temporary config: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("replacing config: %w", err)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -96,6 +96,31 @@ func TestSaveToRoundTripAndPermissions(t *testing.T) {
 	}
 }
 
+func TestSaveToFailureLeavesDestinationAndCleansTemporaryFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.Mkdir(path, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	err := (&Config{Profiles: map[string]Profile{"prod": {APIKey: "new"}}}).SaveTo(path)
+	if err == nil {
+		t.Fatal("expected replacement of directory to fail")
+	}
+	if info, statErr := os.Stat(path); statErr != nil || !info.IsDir() {
+		t.Fatalf("destination was changed after failed replacement: info=%v err=%v", info, statErr)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if len(entry.Name()) >= len(".langsmith-config-") && entry.Name()[:len(".langsmith-config-")] == ".langsmith-config-" {
+			t.Fatalf("temporary config file was not removed: %s", entry.Name())
+		}
+	}
+}
+
 func TestResolveProfile(t *testing.T) {
 	cfg := &Config{
 		CurrentProfile: "current",


### PR DESCRIPTION
## Summary

Closes #228

Configuration saves no longer truncate the live credentials file before the replacement is known to be complete.

## What changed

- Encode the complete config before opening any destination file.
- Create a temporary file in the destination directory with owner-only permissions.
- Check write, chmod, fsync, close, and rename errors.
- Atomically rename the completed temporary file over the destination.
- Remove temporary files on every failure path.
- Preserve the required final mode of `0600`.

A failed write or replacement therefore leaves the previous credentials/configuration intact, and readers never observe a partially written JSON file.

## Tests

- Failed replacement leaves the destination unchanged.
- Temporary files are removed after failure.
- Existing round-trip and `0600` permission coverage remains green.
- `go test ./...`
- `go test -race ./internal/config`
- `go vet ./...`
- `make build`
