### PR TITLE
feat: sanitize terminal control characters in the output package

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
+	"unicode/utf8"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/xlab/treeprint"
@@ -17,18 +19,18 @@ import (
 func OutputJSON(data any, filePath string) {
 	jsonBytes, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
-		PrintError(fmt.Sprintf("JSON encoding error: %v", err))
+		Errorf("JSON encoding error: %v\n", err)
 		return
 	}
 
 	if filePath != "" {
 		if err := os.WriteFile(filePath, jsonBytes, 0644); err != nil {
-			PrintError(fmt.Sprintf("write error: %v", err))
+			Errorf("write error: %v\n", err)
 			return
 		}
-		fmt.Fprintf(os.Stderr, `{"status": "written", "path": %q}`+"\n", filePath)
+		Errorf(`{"status": "written", "path": %q}`+"\n", filePath)
 	} else {
-		fmt.Println(string(jsonBytes))
+		PrintLines(string(jsonBytes) + "\n")
 	}
 }
 
@@ -37,7 +39,7 @@ func OutputJSONL(items []map[string]any, filePath string) {
 	if filePath != "" {
 		f, err := os.Create(filePath)
 		if err != nil {
-			PrintError(fmt.Sprintf("write error: %v", err))
+			Errorf("write error: %v\n", err)
 			return
 		}
 		defer f.Close()
@@ -46,30 +48,55 @@ func OutputJSONL(items []map[string]any, filePath string) {
 			_, _ = f.Write(line)
 			_, _ = f.WriteString("\n")
 		}
-		fmt.Fprintf(os.Stderr, `{"status": "written", "path": %q, "count": %d}`+"\n", filePath, len(items))
+		Errorf(`{"status": "written", "path": %q, "count": %d}`+"\n", filePath, len(items))
 	} else {
 		for _, item := range items {
 			line, _ := json.Marshal(item)
-			fmt.Println(string(line))
+			PrintLines(string(line) + "\n")
 		}
 	}
 }
 
 // OutputTable prints a table to stdout using tablewriter.
 func OutputTable(columns []string, rows [][]string, title string) {
-	if title != "" {
-		fmt.Println(title)
-		fmt.Println(strings.Repeat("─", len(title)))
-	}
+	TableTo(os.Stdout, columns, rows, title)
+}
 
-	table := tablewriter.NewWriter(os.Stdout)
+func TableTo(w io.Writer, columns []string, rows [][]string, title string) {
+	printTitle(w, title)
+
+	table := newTable(w, sanitizeRow(columns))
+	for _, row := range rows {
+		table.Append(sanitizeRow(row))
+	}
+	table.Render()
+}
+
+func newTable(w io.Writer, columns []string) *tablewriter.Table {
+	table := tablewriter.NewWriter(w)
 	table.SetHeader(columns)
 	table.SetBorder(false)
 	table.SetColumnSeparator("  ")
 	table.SetHeaderLine(true)
 	table.SetAutoWrapText(false)
-	table.AppendBulk(rows)
-	table.Render()
+	return table
+}
+
+func printTitle(w io.Writer, title string) {
+	if title == "" {
+		return
+	}
+	title = SanitizeTerminal(title)
+	Fprintln(w, title)
+	Fprintln(w, strings.Repeat("─", utf8.RuneCountInString(title)))
+}
+
+func sanitizeRow(cells []string) []string {
+	out := make([]string, len(cells))
+	for i, c := range cells {
+		out[i] = SanitizeTerminal(c)
+	}
+	return out
 }
 
 // RunTreeData holds the data needed for tree rendering.
@@ -85,7 +112,7 @@ type RunTreeData struct {
 // OutputTree prints a trace hierarchy tree.
 func OutputTree(runs []RunTreeData, rootID string) {
 	if len(runs) == 0 {
-		fmt.Println("No runs found")
+		Println("No runs found")
 		return
 	}
 
@@ -120,22 +147,26 @@ func OutputTree(runs []RunTreeData, rootID string) {
 
 	for _, root := range roots {
 		tree := treeprint.New()
-		label := fmt.Sprintf("%s (%s) [%s]", root.Name, root.RunType, FormatDuration(root.DurationMs))
-		tree.SetValue(label)
+		tree.SetValue(treeLabel(root))
 		addChildren(tree, root.ID, childrenMap)
-		fmt.Print(tree.String())
+		PrintLines(tree.String())
 	}
 }
 
 func addChildren(node treeprint.Tree, parentID string, childrenMap map[string][]RunTreeData) {
 	for _, child := range childrenMap[parentID] {
-		label := fmt.Sprintf("%s (%s) [%s]", child.Name, child.RunType, FormatDuration(child.DurationMs))
+		label := treeLabel(child)
 		if child.HasError {
 			label = "ERROR: " + label
 		}
 		childNode := node.AddBranch(label)
 		addChildren(childNode, child.ID, childrenMap)
 	}
+}
+
+func treeLabel(r RunTreeData) string {
+	return fmt.Sprintf("%s (%s) [%s]",
+		SanitizeTerminal(r.Name), SanitizeTerminal(r.RunType), FormatDuration(r.DurationMs))
 }
 
 // PrintOutput dispatches to JSON or pretty output.
@@ -146,49 +177,33 @@ func PrintOutput(data any, format string, filePath string) {
 		if filePath != "" {
 			_ = os.WriteFile(filePath, jsonBytes, 0644)
 		} else {
-			fmt.Println(string(jsonBytes))
+			PrintLines(string(jsonBytes) + "\n")
 		}
 	} else {
 		OutputJSON(data, filePath)
 	}
 }
 
-// PrintError prints an error to stderr.
-func PrintError(msg string) {
-	fmt.Fprintln(os.Stderr, msg)
-}
-
 // PrintRunsTable prints a table of runs in pretty format.
 func PrintRunsTable(w io.Writer, runs []map[string]any, includeMetadata bool, title string) {
-	if title != "" {
-		fmt.Fprintln(w, title)
-		fmt.Fprintln(w, strings.Repeat("─", len(title)))
-	}
+	printTitle(w, title)
 
 	columns := []string{"Time", "Name", "Type", "Trace ID", "Run ID"}
 	if includeMetadata {
 		columns = append(columns, "Duration", "Status", "Tokens")
 	}
 
-	table := tablewriter.NewWriter(w)
-	table.SetHeader(columns)
-	table.SetBorder(false)
-	table.SetColumnSeparator("  ")
-	table.SetHeaderLine(true)
-	table.SetAutoWrapText(false)
+	table := newTable(w, columns)
 
 	for _, r := range runs {
 		timeStr := "N/A"
-		if st, ok := r["start_time"].(string); ok && st != "" {
-			if len(st) > 19 {
-				timeStr = st[11:19]
+		if st, ok := r["start_time"].(string); ok {
+			if clock := clockTime(st); clock != "" {
+				timeStr = clock
 			}
 		}
 
-		name := getStr(r, "name")
-		if len(name) > 40 {
-			name = name[:40]
-		}
+		name := TruncateRunes(getStr(r, "name"), 40)
 
 		traceID := getStr(r, "trace_id")
 
@@ -234,9 +249,18 @@ func FormatDuration(ms *int64) string {
 
 func getStr(m map[string]any, key string) string {
 	if v, ok := m[key].(string); ok {
-		return v
+		return SanitizeTerminal(v)
 	}
 	return "N/A"
+}
+
+func clockTime(s string) string {
+	for _, layout := range []string{time.RFC3339Nano, "2006-01-02T15:04:05.999999999", "2006-01-02T15:04:05"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.Format("15:04:05")
+		}
+	}
+	return ""
 }
 
 func toInt64Ptr(v any) *int64 {

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestOutputJSON(t *testing.T) {
@@ -118,4 +119,94 @@ func TestOutputTree(t *testing.T) {
 
 func int64Ptr(v int64) *int64 {
 	return &v
+}
+
+const hostileTitle = "Runs\x1b]52;c;cHduZWQ=\x07"
+
+func TestOutputTableSanitizesTitleColumnsAndCells(t *testing.T) {
+	out := captureStdout(t, func() {
+		OutputTable(
+			[]string{"Name\x1b[2K", "Value"},
+			[][]string{{"row\rone", "line\ntwo"}},
+			hostileTitle,
+		)
+	})
+	assertNoControlChars(t, out)
+	if !strings.Contains(out, "cHduZWQ=") {
+		t.Errorf("expected escape payload to remain visible as text: %q", out)
+	}
+}
+
+func TestOutputTableUnderlineCountsRunes(t *testing.T) {
+	out := captureStdout(t, func() {
+		OutputTable([]string{"A"}, [][]string{{"b"}}, "Café")
+	})
+	lines := strings.Split(out, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected a title and an underline: %q", out)
+	}
+	if got, want := utf8.RuneCountInString(lines[1]), 4; got != want {
+		t.Errorf("underline is %d runes, want %d: %q", got, want, lines[1])
+	}
+}
+
+func TestOutputTreeSanitizesLabels(t *testing.T) {
+	runs := []RunTreeData{
+		{ID: "root", Name: "parent\x1b[2K", RunType: "chain\r"},
+		{ID: "child", ParentRunID: "root", Name: "kid\nfaked", RunType: "llm", HasError: true},
+	}
+	out := captureStdout(t, func() {
+		OutputTree(runs, "root")
+	})
+	assertNoControlChars(t, out)
+	if strings.Count(out, "\n") != 2 {
+		t.Errorf("expected exactly one line per run, got %q", out)
+	}
+}
+
+func TestPrintRunsTableSanitizesValues(t *testing.T) {
+	var buf bytes.Buffer
+	runs := []map[string]any{{
+		"name":     "run\x1b]52;c;cHduZWQ=\x07",
+		"run_type": "chain\r",
+		"trace_id": "t\x1b1",
+		"run_id":   "r\n1",
+		"status":   "ok\x1b",
+	}}
+	PrintRunsTable(&buf, runs, true, hostileTitle)
+	assertNoControlChars(t, buf.String())
+}
+
+func TestPrintRunsTableTruncatesNameByRunes(t *testing.T) {
+	var buf bytes.Buffer
+	name := strings.Repeat("é", 50)
+	PrintRunsTable(&buf, []map[string]any{{"name": name}}, false, "")
+	out := buf.String()
+	if !utf8.ValidString(out) {
+		t.Fatalf("truncation split a character: %q", out)
+	}
+	if strings.Contains(out, strings.Repeat("é", 41)) {
+		t.Errorf("name was not truncated to 40 runes: %q", out)
+	}
+	if !strings.Contains(out, strings.Repeat("é", 40)) {
+		t.Errorf("expected 40 runes of the name: %q", out)
+	}
+}
+
+func TestPrintRunsTableFormatsStartTime(t *testing.T) {
+	var buf bytes.Buffer
+	PrintRunsTable(&buf, []map[string]any{{"start_time": "2024-01-02T03:04:05.123456+00:00"}}, false, "")
+	if !strings.Contains(buf.String(), "03:04:05") {
+		t.Errorf("expected clock time from start_time: %q", buf.String())
+	}
+}
+
+func TestPrintRunsTableRejectsUnparseableStartTime(t *testing.T) {
+	var buf bytes.Buffer
+	PrintRunsTable(&buf, []map[string]any{{"start_time": "éééééééééééé"}}, false, "")
+	out := buf.String()
+	assertNoControlChars(t, out)
+	if !strings.Contains(out, "N/A") {
+		t.Errorf("expected N/A for an unparseable start_time: %q", out)
+	}
 }

--- a/internal/output/print.go
+++ b/internal/output/print.go
@@ -1,0 +1,125 @@
+// Package output renders CLI output. Printf, Println, Fprintf, Fprintln, Errorf
+// and Errorln sanitize every string-like argument, so text from the API cannot
+// act on the terminal or forge lines; format strings are kept as written. The
+// table and tree renderers sanitize the values they are given.
+package output
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func Printf(format string, args ...any) {
+	writeRaw(os.Stdout, fmt.Sprintf(format, sanitizeArgs(args)...))
+}
+
+func Println(args ...any) {
+	writeRaw(os.Stdout, fmt.Sprintln(sanitizeArgs(args)...))
+}
+
+func Fprintf(w io.Writer, format string, args ...any) {
+	writeRaw(w, fmt.Sprintf(format, sanitizeArgs(args)...))
+}
+
+func Fprintln(w io.Writer, args ...any) {
+	writeRaw(w, fmt.Sprintln(sanitizeArgs(args)...))
+}
+
+// PrintLines writes multi-line text to stdout, keeping its line breaks and
+// sanitizing everything else. The newline is the only control character it keeps.
+func PrintLines(s string) {
+	FprintLines(os.Stdout, s)
+}
+
+// FprintLines writes multi-line text to w, keeping its line breaks.
+func FprintLines(w io.Writer, s string) {
+	writeRaw(w, sanitizeLines(s))
+}
+
+// PrintProxied writes s to stdout unsanitized. Only for output another program
+// produced, where the escape sequences are that program's own. Never for API text.
+func PrintProxied(s string) {
+	writeRaw(os.Stdout, s)
+}
+
+// FprintProxied writes s to w unsanitized. Same contract as PrintProxied.
+func FprintProxied(w io.Writer, s string) {
+	writeRaw(w, s)
+}
+
+func Errorf(format string, args ...any) {
+	writeRaw(os.Stderr, fmt.Sprintf(format, sanitizeArgs(args)...))
+}
+
+func Errorln(args ...any) {
+	writeRaw(os.Stderr, fmt.Sprintln(sanitizeArgs(args)...))
+}
+
+func sanitizeArgs(args []any) []any {
+	out := make([]any, len(args))
+	for i, a := range args {
+		switch v := a.(type) {
+		case string:
+			out[i] = SanitizeTerminal(v)
+		case error:
+			out[i] = SanitizeTerminal(v.Error())
+		case fmt.Stringer:
+			out[i] = SanitizeTerminal(v.String())
+		default:
+			out[i] = a
+		}
+	}
+	return out
+}
+
+func writeRaw(w io.Writer, s string) {
+	_, _ = io.WriteString(w, s)
+}
+
+const replacementChar = '\ufffd'
+
+// SanitizeTerminal replaces every control character a terminal would act on,
+// tabs and newlines included, with a visible placeholder. Idempotent.
+func SanitizeTerminal(s string) string {
+	if !strings.ContainsFunc(s, isTerminalControl) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if isTerminalControl(r) {
+			b.WriteRune(replacementChar)
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func isTerminalControl(r rune) bool {
+	return r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f)
+}
+
+func sanitizeLines(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = SanitizeTerminal(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func TruncateRunes(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	count := 0
+	for i := range s {
+		if count == max {
+			return s[:i]
+		}
+		count++
+	}
+	return s
+}

--- a/internal/output/print_test.go
+++ b/internal/output/print_test.go
@@ -1,0 +1,233 @@
+package output
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestSanitizeTerminal(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain ascii", "hello world", "hello world"},
+		{"empty", "", ""},
+		{"escape", "a\x1bb", "a\ufffdb"},
+		{"osc52 clipboard write", "\x1b]52;c;aGVsbG8=\x07", "\ufffd]52;c;aGVsbG8=\ufffd"},
+		{"csi cursor move", "safe\x1b[2Kforged", "safe\ufffd[2Kforged"},
+		{"carriage return overwrite", "real\rfake", "real\ufffdfake"},
+		{"newline", "one\ntwo", "one\ufffdtwo"},
+		{"tab", "a\tb", "a\ufffdb"},
+		{"null", "a\x00b", "a\ufffdb"},
+		{"delete", "a\x7fb", "a\ufffdb"},
+		{"c1 csi", "a\u009bb", "a\ufffdb"},
+		{"c1 range boundaries", "\u0080\u009f", "\ufffd\ufffd"},
+		{"space preserved", "a b", "a b"},
+		{"latin1 letter preserved", "café", "café"},
+		{"cjk preserved", "中文", "中文"},
+		{"emoji preserved", "ok \U0001F600", "ok \U0001F600"},
+		{"box drawing preserved", "─├└", "─├└"},
+		{"existing replacement char preserved", "a\ufffdb", "a\ufffdb"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SanitizeTerminal(tt.in); got != tt.want {
+				t.Errorf("SanitizeTerminal(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeTerminalIsIdempotent(t *testing.T) {
+	in := "\x1b]52;c;x\x07line\nend"
+	once := SanitizeTerminal(in)
+	if twice := SanitizeTerminal(once); twice != once {
+		t.Errorf("second pass changed output: %q then %q", once, twice)
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"shorter than max", "abc", 10, "abc"},
+		{"exactly max", "abc", 3, "abc"},
+		{"ascii truncated", "abcdef", 3, "abc"},
+		{"multibyte not split", "héllo", 3, "hél"},
+		{"emoji not split", "ab\U0001F600cd", 3, "ab\U0001F600"},
+		{"zero max", "abc", 0, ""},
+		{"negative max", "abc", -1, ""},
+		{"empty input", "", 5, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TruncateRunes(tt.in, tt.max); got != tt.want {
+				t.Errorf("TruncateRunes(%q, %d) = %q, want %q", tt.in, tt.max, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintfSanitizesStringArgs(t *testing.T) {
+	got := captureStdout(t, func() {
+		Printf("  [%s] %s\n", "user", "hi\x1b]52;c;aGk=\x07there")
+	})
+	want := "  [user] hi\ufffd]52;c;aGk=\ufffdthere\n"
+	if got != want {
+		t.Errorf("Printf = %q, want %q", got, want)
+	}
+}
+
+func TestPrintfKeepsFormatStringLiterals(t *testing.T) {
+	got := captureStdout(t, func() {
+		Printf("a\tb\nc\n")
+	})
+	if got != "a\tb\nc\n" {
+		t.Errorf("Printf mangled its format string: %q", got)
+	}
+}
+
+func TestPrintfKeepsNonStringVerbs(t *testing.T) {
+	got := captureStdout(t, func() {
+		Printf("%d items in %.1fs (%v)\n", 3, 1.5, true)
+	})
+	if got != "3 items in 1.5s (true)\n" {
+		t.Errorf("Printf = %q", got)
+	}
+}
+
+func TestPrintfSanitizesErrorArgs(t *testing.T) {
+	got := captureStdout(t, func() {
+		Printf("failed: %v\n", errors.New("boom\x1b[2K"))
+	})
+	if got != "failed: boom\ufffd[2K\n" {
+		t.Errorf("Printf = %q", got)
+	}
+}
+
+func TestPrintfHandlesNilError(t *testing.T) {
+	var err error
+	got := captureStdout(t, func() {
+		Printf("err=%v\n", err)
+	})
+	if got != "err=<nil>\n" {
+		t.Errorf("Printf = %q", got)
+	}
+}
+
+func TestPrintfSanitizesStringerArgs(t *testing.T) {
+	got := captureStdout(t, func() {
+		Printf("took %v\n", time.Duration(0))
+	})
+	if got != "took 0s\n" {
+		t.Errorf("Printf = %q", got)
+	}
+}
+
+func TestPrintlnSanitizesArgs(t *testing.T) {
+	got := captureStdout(t, func() {
+		Println("safe", "bad\rline")
+	})
+	if got != "safe bad\ufffdline\n" {
+		t.Errorf("Println = %q", got)
+	}
+}
+
+func TestPrintlnNoArgs(t *testing.T) {
+	got := captureStdout(t, func() {
+		Println()
+	})
+	if got != "\n" {
+		t.Errorf("Println() = %q", got)
+	}
+}
+
+func TestErrorfWritesSanitizedToStderr(t *testing.T) {
+	got := captureStderr(t, func() {
+		Errorf("api error: %v\n", errors.New("nope\x1b"))
+	})
+	if got != "api error: nope\ufffd\n" {
+		t.Errorf("Errorf = %q", got)
+	}
+}
+
+func TestErrorlnWritesSanitizedToStderr(t *testing.T) {
+	got := captureStderr(t, func() {
+		Errorln("bad\x1bvalue")
+	})
+	if got != "bad\ufffdvalue\n" {
+		t.Errorf("Errorln = %q", got)
+	}
+}
+
+func TestErrorlnSanitizesPreformattedMessage(t *testing.T) {
+	got := captureStderr(t, func() {
+		Errorln("server said: reset\x1b[1;1H")
+	})
+	if got != "server said: reset\ufffd[1;1H\n" {
+		t.Errorf("Errorln = %q", got)
+	}
+}
+
+func TestPrintLinesKeepsLineBreaksAndSanitizesTheRest(t *testing.T) {
+	got := captureStdout(t, func() {
+		PrintLines("{\n  \"name\": \"a\x1b]52;c;x\x07b\"\n}\n")
+	})
+	want := "{\n  \"name\": \"a\ufffd]52;c;x\ufffdb\"\n}\n"
+	if got != want {
+		t.Errorf("PrintLines = %q, want %q", got, want)
+	}
+}
+
+func TestPrintLinesReplacesCarriageReturn(t *testing.T) {
+	got := captureStdout(t, func() {
+		PrintLines("real\rfake\n")
+	})
+	if got != "real\ufffdfake\n" {
+		t.Errorf("PrintLines = %q", got)
+	}
+}
+
+func TestPrintLinesAddsNoTrailingNewline(t *testing.T) {
+	got := captureStdout(t, func() {
+		PrintLines("no newline here")
+	})
+	if got != "no newline here" {
+		t.Errorf("PrintLines = %q", got)
+	}
+}
+
+func TestFprintLinesWritesToWriter(t *testing.T) {
+	var buf bytes.Buffer
+	FprintLines(&buf, "line one\nline\x1btwo\n")
+	if buf.String() != "line one\nline\ufffdtwo\n" {
+		t.Errorf("FprintLines = %q", buf.String())
+	}
+}
+
+func TestPrintProxiedPassesBytesThrough(t *testing.T) {
+	proxied := "\x1b[32mok\x1b[0m\n"
+	got := captureStdout(t, func() {
+		PrintProxied(proxied)
+	})
+	if got != proxied {
+		t.Errorf("PrintProxied altered its input: %q", got)
+	}
+}
+
+func TestFprintProxiedPassesBytesThrough(t *testing.T) {
+	var buf bytes.Buffer
+	proxied := "progress\rdone\x1b[K"
+	FprintProxied(&buf, proxied)
+	if buf.String() != proxied {
+		t.Errorf("FprintProxied altered its input: %q", buf.String())
+	}
+}

--- a/internal/output/testutil_test.go
+++ b/internal/output/testutil_test.go
@@ -1,0 +1,57 @@
+package output
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+	"unicode/utf8"
+)
+
+// captureStdout redirects os.Stdout during fn and returns what was written.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	return capture(t, &os.Stdout, fn)
+}
+
+// captureStderr redirects os.Stderr during fn and returns what was written.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	return capture(t, &os.Stderr, fn)
+}
+
+func capture(t *testing.T, target **os.File, fn func()) string {
+	t.Helper()
+	old := *target
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	*target = w
+
+	fn()
+
+	w.Close()
+	*target = old
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("reading captured output: %v", err)
+	}
+	return buf.String()
+}
+
+func assertNoControlChars(t *testing.T, out string) {
+	t.Helper()
+	for _, r := range out {
+		if r == '\n' {
+			continue
+		}
+		if isTerminalControl(r) {
+			t.Fatalf("output contains control char %U: %q", r, out)
+		}
+	}
+	if !utf8.ValidString(out) {
+		t.Fatalf("output is not valid UTF-8: %q", out)
+	}
+}


### PR DESCRIPTION
## Description

Text returned by the API is printed to the terminal as-is, so control characters in it are acted on by the terminal rather than displayed. This adds a printing API to `internal/output` that replaces those characters with a visible placeholder, and makes the existing renderers use it. Pretty output now shows `U+FFFD` in their place; JSON output is unchanged.

Key changes:
- New printers: `Printf`, `Println`, `Fprintf`, `Fprintln`, `Errorf`, `Errorln`.
- `PrintLines`/`FprintLines` for multi-line text such as encoded JSON.
- `PrintProxied`/`FprintProxied` for output another program produced, where escape sequences must pass through untouched.
- `OutputTable`, `OutputTree` and `PrintRunsTable` sanitize their titles, headers and cells; table rendering moved into a shared `TableTo` that takes a writer.
- `TruncateRunes` replaces the byte slice that shortened long run names, which could cut a multi-byte character in half.
- `start_time` is parsed instead of byte-sliced at fixed offsets, so an unexpected value renders as `N/A`.
- Titles underline to their rune count instead of their byte length.
- Dropped `PrintError`, which had no callers.