### PR TITLE
fix: page `issues list` server-side via the generated SDK

### DIFF
--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 
@@ -66,6 +67,7 @@ func newProjectIssuesListCmd() *cobra.Command {
 		status     string
 		priority   string
 		limit      int
+		offset     int
 		outputFile string
 	)
 
@@ -74,14 +76,21 @@ func newProjectIssuesListCmd() *cobra.Command {
 		Short: "List issues for a tracing project",
 		Long: `List forge issues associated with a tracing project.
 
-Fetches issues from the Issues Board for the specified project. Results
-can be filtered by status (open/closed) and priority (high/medium/low).
+Fetches issues from the Issues Board for the specified project. Results can be
+filtered by status (open/fixing/watching/completed/ignored) and priority
+(urgent/high/medium/low).
+
+Paging is server-side: --limit is the page size (max 500) and --offset skips
+that many issues. To read a board larger than one page, advance --offset by
+--limit until a request returns fewer rows than the limit.
+
 Output is JSON by default; pass --format pretty for a human-readable table.
 
 Examples:
   langsmith project issues list --project my-app
   langsmith project issues list --project my-app --status open
   langsmith project issues list --project my-app --priority high --limit 10
+  langsmith project issues list --project my-app --limit 100 --offset 100
   langsmith project issues list --project my-app --format pretty`,
 		Run: func(cmd *cobra.Command, args []string) {
 			c := MustGetClient()
@@ -92,25 +101,32 @@ Examples:
 				ExitError("--project is required (or set LANGSMITH_PROJECT)")
 			}
 
-			path := fmt.Sprintf("/api/v1/platform/issues?session_name=%s", urlEscape(projectName))
+			params := langsmith.IssueListParams{
+				SessionName: langsmith.F(projectName),
+			}
 			if status != "" {
-				path += "&status=" + urlEscape(status)
+				params.Status = langsmith.F(langsmith.IssueListParamsStatus(status))
 			}
 			if priority != "" {
 				sev := priorityToSeverity(priority)
 				if sev >= 0 {
-					path += fmt.Sprintf("&severity=%d", sev)
+					params.Severity = langsmith.F(langsmith.IssueListParamsSeverity(sev))
 				}
 			}
+			// Both are server-side; the server clamps limit to 500 and rejects
+			// a non-positive limit or negative offset.
+			if limit > 0 {
+				params.Limit = langsmith.F(int64(limit))
+			}
+			if offset > 0 {
+				params.Offset = langsmith.F(int64(offset))
+			}
 
-			var issues []forgeIssue
-			if err := c.RawGet(ctx, path, &issues); err != nil {
+			page, err := c.SDK.Issues.List(ctx, params)
+			if err != nil {
 				ExitErrorf("listing issues: %v", err)
 			}
-
-			if limit > 0 && len(issues) > limit {
-				issues = issues[:limit]
-			}
+			issues := page.Items
 
 			fmt_ := GetFormat()
 
@@ -118,33 +134,30 @@ Examples:
 				columns := []string{"NAME", "SEVERITY", "STATUS", "TAGS", "CREATED"}
 				var rows [][]string
 				for _, issue := range issues {
-					sevLabel := severityLabels[issue.Severity]
+					sevLabel := severityLabels[int(issue.Severity)]
 					if sevLabel == "" {
 						sevLabel = fmt.Sprintf("%d", issue.Severity)
 					}
 					rows = append(rows, []string{
 						truncate(issue.Name, 60),
 						sevLabel,
-						issue.Status,
+						string(issue.Status),
 						strings.Join(issue.Tags, ", "),
-						formatIssueTime(issue.CreatedAt),
+						formatIssueTimestamp(issue.CreatedAt),
 					})
 				}
 				output.OutputTable(columns, rows, fmt.Sprintf("Issues for %s", projectName))
 			} else {
-				data := []map[string]any{}
-				for _, issue := range issues {
-					data = append(data, issueToMap(issue))
-				}
-				output.OutputJSON(data, outputFile)
+				output.OutputJSON(json.RawMessage(page.JSON.RawJSON()), outputFile)
 			}
 		},
 	}
 
 	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
-	cmd.Flags().StringVar(&status, "status", "", "Filter by status: open or closed")
-	cmd.Flags().StringVar(&priority, "priority", "", "Filter by priority: high, medium, or low")
-	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum number of issues to return")
+	cmd.Flags().StringVar(&status, "status", "", "Filter by status: open, fixing, watching, completed, or ignored")
+	cmd.Flags().StringVar(&priority, "priority", "", "Filter by priority: urgent, high, medium, or low")
+	cmd.Flags().IntVar(&limit, "limit", 50, "Page size (server-side; max 500)")
+	cmd.Flags().IntVar(&offset, "offset", 0, "Number of issues to skip (server-side; for paging)")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 
 	return cmd
@@ -490,14 +503,14 @@ func formatIssueTime(t time.Time) string {
 	return t.Format("2006-01-02 15:04")
 }
 
-func urlEscape(s string) string {
-	s = strings.ReplaceAll(s, "%", "%25")
-	s = strings.ReplaceAll(s, " ", "%20")
-	s = strings.ReplaceAll(s, "&", "%26")
-	s = strings.ReplaceAll(s, "=", "%3D")
-	s = strings.ReplaceAll(s, "+", "%2B")
-	s = strings.ReplaceAll(s, "#", "%23")
-	return s
+// formatIssueTimestamp renders an RFC3339 timestamp string from the SDK, which
+// types these fields as strings rather than time.Time.
+func formatIssueTimestamp(s string) string {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return "N/A"
+	}
+	return formatIssueTime(t)
 }
 
 func truncate(s string, n int) string {

--- a/internal/cmd/issues_list_paging_test.go
+++ b/internal/cmd/issues_list_paging_test.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+// These assert the query the server actually receives from `issues list`.
+//
+// Only TestIssuesList_SendsLimitAndOffsetToServer is a regression test: the
+// command used to build its own query string and apply --limit client-side, so
+// neither param reached the server and a board larger than one page was
+// unreachable. The rest characterize behavior that the move to the generated
+// SDK had to preserve, and would catch a future switch to the typed status
+// constants (which omit `fixing` and `watching`) silently dropping a filter.
+func TestIssuesList_SendsLimitAndOffsetToServer(t *testing.T) {
+	var got url.Values
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	})
+	if _, err := executeCommand(t, "--api-key", "test-key", "--api-url", ts.URL,
+		"project", "issues", "list",
+		"--project", "my-app", "--limit", "200", "--offset", "400",
+	); err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+
+	if got.Get("limit") != "200" {
+		t.Errorf("limit not sent to server: got %q, want %q", got.Get("limit"), "200")
+	}
+	if got.Get("offset") != "400" {
+		t.Errorf("offset not sent to server: got %q, want %q", got.Get("offset"), "400")
+	}
+	if got.Get("session_name") != "my-app" {
+		t.Errorf("session_name: got %q, want %q", got.Get("session_name"), "my-app")
+	}
+}
+
+// offset defaults to 0 and is omitted rather than sent as offset=0.
+func TestIssuesList_OmitsOffsetWhenUnset(t *testing.T) {
+	var got url.Values
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	})
+	if _, err := executeCommand(t, "--api-key", "test-key", "--api-url", ts.URL,
+		"project", "issues", "list", "--project", "my-app"); err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+
+	if got.Has("offset") {
+		t.Errorf("offset should be omitted when unset, got %q", got.Get("offset"))
+	}
+}
+
+// `fixing` and `watching` are valid server-side but were missing from the
+// OpenAPI status enum, so the generated SDK constant set omits them. The command
+// converts the raw flag value, which must still reach the wire unaltered.
+func TestIssuesList_SendsNonConstantStatuses(t *testing.T) {
+	for _, status := range []string{"open", "fixing", "watching", "completed", "ignored"} {
+		t.Run(status, func(t *testing.T) {
+			var got url.Values
+			ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				got = r.URL.Query()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte("[]"))
+			})
+			if _, err := executeCommand(t, "--api-key", "test-key", "--api-url", ts.URL,
+				"project", "issues", "list",
+				"--project", "my-app", "--status", status,
+			); err != nil {
+				t.Fatalf("command failed: %v", err)
+			}
+
+			if got.Get("status") != status {
+				t.Errorf("status not sent verbatim: got %q, want %q", got.Get("status"), status)
+			}
+		})
+	}
+}
+
+// --priority maps to the numeric severity the API expects.
+func TestIssuesList_MapsPriorityToSeverity(t *testing.T) {
+	for priority, want := range map[string]string{
+		"urgent": "0",
+		"high":   "1",
+		"medium": "2",
+		"low":    "3",
+	} {
+		t.Run(priority, func(t *testing.T) {
+			var got url.Values
+			ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				got = r.URL.Query()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte("[]"))
+			})
+			if _, err := executeCommand(t, "--api-key", "test-key", "--api-url", ts.URL,
+				"project", "issues", "list",
+				"--project", "my-app", "--priority", priority,
+			); err != nil {
+				t.Fatalf("command failed: %v", err)
+			}
+
+			if got.Get("severity") != want {
+				t.Errorf("severity for %s: got %q, want %q", priority, got.Get("severity"), want)
+			}
+		})
+	}
+}
+
+// Project names carry spaces and punctuation, and encoding moved from a
+// hand-rolled replacer to the SDK's query encoder. Pins the round-trip.
+func TestIssuesList_EncodesProjectNameWithSpecialChars(t *testing.T) {
+	const project = "my app/v2?x=1&y=2"
+
+	var got url.Values
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	})
+	if _, err := executeCommand(t, "--api-key", "test-key", "--api-url", ts.URL,
+		"project", "issues", "list", "--project", project); err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+
+	if got.Get("session_name") != project {
+		t.Errorf("session_name round-trip: got %q, want %q", got.Get("session_name"), project)
+	}
+}
+
+// The Engine issues-agent redirects this command's JSON to a file and reads it
+// with `jq -r '.[] | [.id, .status, .name] | @tsv'`, so the output must stay a
+// bare array of objects carrying those keys. Moving to the SDK replaced a
+// hand-built map with raw response passthrough; this pins the shape jq needs.
+func TestIssuesList_JSONOutputStaysArrayWithGreppedKeys(t *testing.T) {
+	const body = `[{"id":"11111111-1111-1111-1111-111111111111",` +
+		`"session_id":"22222222-2222-2222-2222-222222222222",` +
+		`"name":"Agent retries failed tool call","status":"open","severity":1,` +
+		`"tags":["regression"],"created_at":"2026-07-30T12:00:00Z"}]`
+
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+
+	out := captureStdout(t, func() {
+		if _, err := executeCommand(t, "--api-key", "test-key", "--api-url", ts.URL,
+			"--format", "json", "project", "issues", "list", "--project", "my-app",
+		); err != nil {
+			t.Fatalf("command failed: %v", err)
+		}
+	})
+
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("output is not a JSON array: %v\noutput: %s", err, out)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d: %s", len(rows), out)
+	}
+	for _, key := range []string{"id", "status", "name"} {
+		if _, ok := rows[0][key]; !ok {
+			t.Errorf("key %q missing from JSON output; Engine's jq depends on it: %s", key, out)
+		}
+	}
+	if rows[0]["status"] != "open" {
+		t.Errorf("status = %v, want open", rows[0]["status"])
+	}
+	if rows[0]["name"] != "Agent retries failed tool call" {
+		t.Errorf("name = %v", rows[0]["name"])
+	}
+}


### PR DESCRIPTION
`langsmith project issues list` could only ever see the first 50 issues on a board. Rows 51+ were unreachable and there was no way to tell they existed.

## The bug

The command built its own query string and never sent `limit` or `offset`, then sliced client-side:

```go
path := fmt.Sprintf("/api/v1/platform/issues?session_name=%s", urlEscape(projectName))
if status != "" { path += "&status=" + urlEscape(status) }
if priority != "" { path += fmt.Sprintf("&severity=%d", sev) }
// ... no limit, no offset
if limit > 0 && len(issues) > limit {
    issues = issues[:limit]        // truncates what already arrived
}
```

The server defaults to 50, so `--limit` could only ever *shrink* a 50-row response — `--limit 100` silently did nothing while looking server-backed (it's even registered with a default of 50).

## Change

Port to `c.SDK.Issues.List`

- `--limit` and a new `--offset` are real server params.
- Query encoding moves to the SDK, retiring the hand-rolled `urlEscape` (this was its only caller).
- Status/severity use the generated param types.
- `--status` help said "open or closed". `closed` was never valid server-side and 400s. Corrected to the five real values; `--priority` now documents `urgent`, which it always accepted.

**On `fixing` / `watching`:** these are converted from the flag rather than taken from the generated constants, which cover only open/completed/ignored because the OpenAPI enum under-documents the handler. Fixed in langchain-ai/langchainplus#32556. Converting keeps both filters working now and after the SDK is regenerated; a test covers all five so a later switch to the constants can't silently drop them.


## Test Plan

- [x] .