### PR TITLE
fix: validate --status and --priority before sending, bump SDK to v0.25.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/itchyny/gojq v0.12.15
-	github.com/langchain-ai/langsmith-go v0.25.2
+	github.com/langchain-ai/langsmith-go v0.25.4
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/langchain-ai/langsmith-go v0.18.2 h1:/Hs4KoJ2nqsPahFZz47RpXmdPZL/NkL8
 github.com/langchain-ai/langsmith-go v0.18.2/go.mod h1:2NXq2u8YbQkpP9BaKG7RKs0g0ZoCeqVzAZsBu7nr58Y=
 github.com/langchain-ai/langsmith-go v0.25.2 h1:jHy1p02zT9a4m3TySTuB+dv0oT4Mfp7haHb8CCQELHU=
 github.com/langchain-ai/langsmith-go v0.25.2/go.mod h1:I8S3n3i7P/EdlMOoJXUeuD6+XBrkopJ6LByZxHq5rGA=
+github.com/langchain-ai/langsmith-go v0.25.4 h1:PyNaofnvqJRGBXRYloX9Zk40ajBbr8JtKki3KUzeYoM=
+github.com/langchain-ai/langsmith-go v0.25.4/go.mod h1:I8S3n3i7P/EdlMOoJXUeuD6+XBrkopJ6LByZxHq5rGA=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=

--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -32,6 +32,29 @@ type forgeIssue struct {
 	Traces           json.RawMessage `json:"traces"`
 }
 
+// issueStatuses renders the valid --status values in error messages. It is not
+// the validator: that is the SDK's IsKnown, so if the API gains a status before
+// this list is updated the filter still works and only the message is stale —
+// the reverse would reject a filter the server supports.
+var issueStatuses = []langsmith.IssueListParamsStatus{
+	langsmith.IssueListParamsStatusOpen,
+	langsmith.IssueListParamsStatusFixing,
+	langsmith.IssueListParamsStatusWatching,
+	langsmith.IssueListParamsStatusCompleted,
+	langsmith.IssueListParamsStatusIgnored,
+}
+
+func issueStatusList() string {
+	names := make([]string, len(issueStatuses))
+	for i, s := range issueStatuses {
+		names[i] = string(s)
+	}
+	return strings.Join(names, ", ")
+}
+
+// issuePriorities mirrors the keys priorityToSeverity accepts, for its message.
+var issuePriorities = []string{"urgent", "high", "medium", "low"}
+
 var severityLabels = map[int]string{
 	0: "URGENT",
 	1: "HIGH",
@@ -104,14 +127,23 @@ Examples:
 			params := langsmith.IssueListParams{
 				SessionName: langsmith.F(projectName),
 			}
+			// Validate both filters before sending: an unknown --status used to
+			// cost a round-trip and return a server 400, and an unknown
+			// --priority was dropped silently, returning the whole unfiltered
+			// list with exit 0.
 			if status != "" {
-				params.Status = langsmith.F(langsmith.IssueListParamsStatus(status))
+				st := langsmith.IssueListParamsStatus(status)
+				if !st.IsKnown() {
+					ExitErrorf("invalid --status %q: must be one of %s", status, issueStatusList())
+				}
+				params.Status = langsmith.F(st)
 			}
 			if priority != "" {
 				sev := priorityToSeverity(priority)
-				if sev >= 0 {
-					params.Severity = langsmith.F(langsmith.IssueListParamsSeverity(sev))
+				if sev < 0 {
+					ExitErrorf("invalid --priority %q: must be one of %s", priority, strings.Join(issuePriorities, ", "))
 				}
+				params.Severity = langsmith.F(langsmith.IssueListParamsSeverity(sev))
 			}
 			// Both are server-side; the server clamps limit to 500 and rejects
 			// a non-positive limit or negative offset.

--- a/internal/cmd/issues_list_paging_test.go
+++ b/internal/cmd/issues_list_paging_test.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
+
+	langsmith "github.com/langchain-ai/langsmith-go"
 )
 
 // These assert the query the server actually receives from `issues list`.
@@ -174,5 +177,58 @@ func TestIssuesList_JSONOutputStaysArrayWithGreppedKeys(t *testing.T) {
 	}
 	if rows[0]["name"] != "Agent retries failed tool call" {
 		t.Errorf("name = %v", rows[0]["name"])
+	}
+}
+
+// The validation added alongside the v0.25.4 bump calls ExitErrorf, which
+// os.Exit(1)s, so the failure path itself is not unit-testable in-process (no
+// test in this package asserts on an ExitError path). These cover the inputs
+// that drive the decision; the exit behavior is verified by running the binary.
+
+// Pins the SDK requirement: before v0.25.4 the generated enum omitted `fixing`
+// and `watching`, so validating with IsKnown would have rejected two filters the
+// API accepts. This test fails against the older SDK.
+func TestIsKnownAcceptsEveryStatusWeAdvertise(t *testing.T) {
+	for _, s := range issueStatuses {
+		if !s.IsKnown() {
+			t.Errorf("IssueListParamsStatus(%q).IsKnown() = false; SDK too old or list wrong", s)
+		}
+	}
+}
+
+func TestIssueStatusListNamesEveryStatus(t *testing.T) {
+	got := issueStatusList()
+	for _, s := range issueStatuses {
+		if !strings.Contains(got, string(s)) {
+			t.Errorf("issueStatusList() = %q, missing %q", got, s)
+		}
+	}
+}
+
+// `closed` is the one that matters: the help text advertised it for a long time
+// and the API never accepted it. Previously it cost a round-trip and a 400.
+func TestIsKnownRejectsInvalidStatuses(t *testing.T) {
+	for _, s := range []string{"closed", "bogus", "", "Open", "OPEN", "fixing "} {
+		if langsmith.IssueListParamsStatus(s).IsKnown() {
+			t.Errorf("IsKnown() accepted %q", s)
+		}
+	}
+}
+
+// priorityToSeverity returning a negative value is what now triggers a fast
+// failure. It used to skip the filter, returning the whole unfiltered list.
+func TestPriorityToSeverityRejectsUnknown(t *testing.T) {
+	for _, p := range []string{"bogus", "", "critical", "URGENT!"} {
+		if got := priorityToSeverity(p); got >= 0 {
+			t.Errorf("priorityToSeverity(%q) = %d, want negative", p, got)
+		}
+	}
+}
+
+func TestPriorityToSeverityMapsEveryAdvertisedPriority(t *testing.T) {
+	for _, p := range issuePriorities {
+		if got := priorityToSeverity(p); got < 0 {
+			t.Errorf("priorityToSeverity(%q) = %d, but it is advertised as valid", p, got)
+		}
 	}
 }


### PR DESCRIPTION
Follow-up to #238. Bumps the generated SDK and makes both filter flags fail locally instead of silently or remotely.

## `--priority` silently returned the wrong data

This is the one that matters. `priorityToSeverity` returns `-1` for an unknown priority, and the `sev >= 0` guard then skipped setting the filter entirely — so a typo produced an **unfiltered** list with **exit 0**. Verified against a real 82-issue board:

```
--priority high  -> 22 issues
--priority bogus -> 82 issues, exit 0     <- filter silently dropped
```

Wrong results that look right, and the consumer is an agent reading this list to decide whether an issue already exists. A silently-unfiltered board is worse than a loud failure.

## `--status` cost a round-trip to learn it was wrong

Less severe, but it took a request to find out — and the server's 400 listed only three of the five valid statuses (fixed separately in langchain-ai/langchainplus#32575).

## Both now fail before any request

```
invalid --priority "bogus": must be one of urgent, high, medium, low
invalid --status "closed": must be one of open, fixing, watching, completed, ignored
```

## Why the SDK bump is required, not incidental

Status validation authority is the SDK's `IsKnown()`, **not** the local list — if the API gains a status before this list is updated, the filter keeps working and only the message goes stale. The reverse would reject a filter the server supports, which is the failure mode worth avoiding.

That requires **v0.25.4**: earlier releases omitted `fixing` and `watching` from the generated enum (the OpenAPI status enum under-documented the handler; fixed in langchain-ai/langchainplus#32556, released as v0.25.4). Validating against `IsKnown()` before that release would have rejected two filters that work — actively worse than the bug being fixed. `TestIsKnownAcceptsEveryStatusWeAdvertise` pins the requirement and fails against the older SDK.

The bump also clears an unrelated one-patch lag (the pin was v0.25.2 while v0.25.3 was out).

## Test Plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean; full suite passes with 5 new cases
- [x] Verified against a real 82-issue board **from this branch rebased on merged main**, not just on the pre-merge branch:
      - fast-fail messages and exit 1 for both invalid flags
      - every status filter works and partitions the board exactly: `open 33 + fixing 8 + watching 1 + completed 6 + ignored 34 = 82`. `fixing` and `watching` return real data, so the two statuses the spec claimed did not exist are in active use
      - #238's paging still intact: `--limit 40` with `--offset 0/40/80` -> 40/40/2
- [x] `TestIsKnownAcceptsEveryStatusWeAdvertise` fails on the pre-v0.25.4 SDK, so the bump is covered rather than assumed
- [ ] **Not unit-tested: the failure path itself.** `ExitError` calls `os.Exit(1)`, which would kill the test binary, and no test in this package asserts on an `ExitError` path. The new tests cover the inputs that drive the decision (`IsKnown` for every advertised and rejected status, `priorityToSeverity` returning negative for unknown); the exit codes and messages above were verified by running the binary. Adding subprocess re-exec machinery for this seemed disproportionate, but say the word

## Note

This originally rode on #238's branch and I pushed it after that PR had already merged, so it was stranded. Cherry-picked cleanly onto `fe37a49` and re-verified from scratch here rather than trusting the earlier run.