### PR TITLE
feat(ci): bump `langchain-ai/homebrew-tap` on new releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,30 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  bump-tap:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: "Iv23liMFOFBcPTKFWi3S"
+          private-key: ${{ secrets.LANGCHAIN_ACTIONS_PR_BOT_PRIVATE_KEY }}
+          owner: langchain-ai
+          repositories: homebrew-tap
+
+      - name: Open bump PR against the tap
+        uses: dawidd6/action-homebrew-bump-formula@a0e064e08103c01870c6d1b05168d1b726aab119 # v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          user_name: "langtions-bot[bot]"
+          user_email: "261626216+langtions-bot[bot]@users.noreply.github.com"
+          no_fork: true
+          tap: langchain-ai/homebrew-tap
+          formula: langsmith-cli
+          tag: ${{ github.ref }}


### PR DESCRIPTION
**What's new:** A job (`bump-tap`) that opens a formula bump PR against `langchain-ai/homebrew-tap` when a new release is tagged.

**Why it matters:** Previously, `langchain-ai/homebrew-tap` would poll `langchain-ai/langsmith-cli` once every 24 hours for new releases. This inverts that so that it is a push instead of a pull.

**How it works:** Mints a short-lived `langtions-bot` App token scoped to `homebrew-tap`, then runs `brew bump-formula-pr`. The tap's `test-bot` builds bottles from there.

- `needs: release`: the formula builds from the source tarball, which exists the moment the tag does. The dependency only stops a failed release from bumping the tap.
- App token, not `GITHUB_TOKEN`: PRs opened by `GITHUB_TOKEN` don't trigger workflows, so `test-bot` would never run and no bottles would build.
