### PR TITLE
fix(install): align install.sh and install.ps1

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,148 +1,395 @@
 #!/usr/bin/env pwsh
+#Requires -Version 5.1
+
+<#
+.SYNOPSIS
+    Installs the langsmith CLI on Windows.
+
+.DESCRIPTION
+    Downloads a langsmith release archive from GitHub, verifies its SHA256 hash
+    against the release checksums.txt, and installs the binary into InstallDir.
+
+    Layout: pure helpers first (functional core), then everything that touches
+    the network or filesystem (imperative shell), then Invoke-Install.
+    scripts/install.sh mirrors this structure function for function; keep the
+    two in step.
+
+.PARAMETER InstallDir
+    Directory to install into. Defaults to
+    $env:LOCALAPPDATA\Programs\langsmith\bin.
+
+.PARAMETER Version
+    Release tag to install, for example v0.4.1. Defaults to the latest release.
+
+.EXAMPLE
+    irm https://cli.langsmith.com/install.ps1 | iex
+
+    Installs the latest release into the default directory.
+
+.EXAMPLE
+    .\install.ps1 -Version v0.4.1 -InstallDir C:\tools\langsmith
+
+    Installs a specific release into a specific directory.
+
+.EXAMPLE
+    & ([scriptblock]::Create((irm https://cli.langsmith.com/install.ps1))) -Version v0.4.1
+
+    Passes parameters while running straight from the web, which
+    'irm ... | iex' cannot do.
+
+.NOTES
+    Set the GITHUB_TOKEN environment variable to authenticate the release
+    lookup and avoid anonymous GitHub API rate limits. An authenticated GitHub
+    CLI ('gh auth login') is used as a fallback when GITHUB_TOKEN is unset.
+
+.LINK
+    https://github.com/langchain-ai/langsmith-cli
+#>
+
 [CmdletBinding()]
 param(
     [string]$InstallDir = "",
     [string]$Version = ""
 )
 
-$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+# Invoke-WebRequest redraws a progress bar per chunk on Windows PowerShell, which
+# costs more than the download itself.
+$ProgressPreference = 'SilentlyContinue'
+if ($PSVersionTable.PSVersion.Major -lt 6) {
+    # Windows PowerShell may still default to TLS 1.0, which api.github.com rejects.
+    [Net.ServicePointManager]::SecurityProtocol =
+        [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+}
 
-$Repo = "langchain-ai/langsmith-cli"
-$Binary = "langsmith.exe"
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
 
-function Get-Architecture {
-    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-    switch ($arch) {
-        "X64" { return "amd64" }
-        "Arm64" { return "arm64" }
-        default { throw "Unsupported architecture: $arch" }
+$Repo = 'langchain-ai/langsmith-cli'
+$CliName = 'langsmith'
+$BinaryName = 'langsmith.exe'
+$ArchiveExt = 'zip'
+$ChecksumsName = 'checksums.txt'
+$ReleaseApiUrl = "https://api.github.com/repos/$Repo/releases/latest"
+$DownloadBaseUrl = "https://github.com/$Repo/releases/download"
+$UserInstallSubdir = 'Programs\langsmith\bin'
+$FetchAttempts = 3
+
+# ---------------------------------------------------------------------------
+# Functional core
+#
+# Pure helpers: every input arrives as a parameter, every result is returned,
+# and nothing here reads the environment or touches disk. The Resolve-* helpers
+# return $null for unsupported values, leaving the error message to the caller.
+# ---------------------------------------------------------------------------
+
+function Resolve-OSName {
+    param([string]$Platform)
+
+    switch ($Platform.ToLowerInvariant()) {
+        'windows' { 'windows' }
+        default { $null }
     }
 }
 
-function Get-LatestVersionViaGitHubCli {
-    try {
-        $tag = & gh api -H "Accept: application/vnd.github+json" "repos/$Repo/releases/latest" --jq ".tag_name" 2>$null
-        if ($LASTEXITCODE -ne 0) {
-            return $null
-        }
+function Resolve-ArchName {
+    param([string]$Machine)
 
-        return $tag
+    switch -Regex ($Machine) {
+        '^(x64|amd64|x86_64)$' { 'amd64' }
+        '^(arm64|aarch64)$' { 'arm64' }
+        default { $null }
+    }
+}
+
+function Resolve-ArchiveName {
+    param([string]$OSName, [string]$ArchName)
+
+    "${CliName}_${OSName}_${ArchName}.${ArchiveExt}"
+}
+
+function Resolve-InstallDir {
+    # An explicit override wins, then the per-user location under LocalAppData.
+    param([string]$Override, [string]$LocalAppData, [string]$UserHome)
+
+    if ($Override) {
+        return $Override
+    }
+
+    $root = if ($LocalAppData) { $LocalAppData } else { Join-Path $UserHome 'AppData\Local' }
+    return (Join-Path $root $UserInstallSubdir)
+}
+
+function Resolve-TagName {
+    param([string]$ReleaseJson)
+
+    if (-not $ReleaseJson) {
+        return $null
+    }
+
+    try {
+        $release = $ReleaseJson | ConvertFrom-Json
+    } catch {
+        return $null
+    }
+
+    if ($release -and $release.PSObject.Properties.Name -contains 'tag_name') {
+        return $release.tag_name
+    }
+
+    return $null
+}
+
+function Resolve-ExpectedChecksum {
+    # Compare the whole file-name field. Do not widen to a prefix match: that
+    # would accept the hash of a different, longer asset name.
+    param([string]$ChecksumsText, [string]$ArchiveName)
+
+    foreach ($line in ($ChecksumsText -split "`r?`n")) {
+        $fields = $line.Trim() -split '\s+'
+        # sha256sum marks binary mode with a leading * on the file name.
+        if ($fields.Count -ge 2 -and $fields[1].TrimStart('*') -eq $ArchiveName) {
+            return $fields[0]
+        }
+    }
+
+    return $null
+}
+
+function Format-ComparablePath {
+    param([string]$Path)
+
+    if (-not $Path) {
+        return $null
+    }
+
+    try {
+        return [System.IO.Path]::GetFullPath($Path).TrimEnd('\')
     } catch {
         return $null
     }
 }
 
-function Get-LatestVersion {
-    $headers = @{
-        "Accept" = "application/vnd.github+json"
-    }
-    if ($env:GITHUB_TOKEN) {
-        $headers["Authorization"] = "Bearer $env:GITHUB_TOKEN"
-    } else {
-        $tag = Get-LatestVersionViaGitHubCli
-        if ($tag) {
-            return $tag
-        }
+function Test-PathContainsDir {
+    param([string]$Directory, [string]$PathValue)
+
+    $candidate = Format-ComparablePath -Path $Directory
+    if (-not $candidate) {
+        return $false
     }
 
-    $release = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/$Repo/releases/latest"
-    if (-not $release.tag_name) {
-        throw "Failed to determine latest version. Set GITHUB_TOKEN, run 'gh auth login', or pass -Version."
-    }
-
-    return $release.tag_name
-}
-
-function Test-PathContainsDirectory {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Directory
-    )
-
-    $candidate = [System.IO.Path]::GetFullPath($Directory).TrimEnd('\')
-    foreach ($entry in ($env:PATH -split ';')) {
-        if (-not $entry) {
-            continue
-        }
-
-        try {
-            $normalized = [System.IO.Path]::GetFullPath($entry).TrimEnd('\')
-            if ($normalized -ieq $candidate) {
-                return $true
-            }
-        } catch {
-            continue
+    foreach ($entry in ($PathValue -split ';')) {
+        $normalized = Format-ComparablePath -Path $entry
+        if ($normalized -and $normalized -ieq $candidate) {
+            return $true
         }
     }
 
     return $false
 }
 
-if (-not $InstallDir) {
-    $InstallDir = Join-Path $HOME "AppData\Local\Programs\langsmith\bin"
+function Format-PathInstructions {
+    param([string]$Directory)
+
+    @(
+        ''
+        "Add $Directory to your PATH."
+        'For the current PowerShell session:'
+        "  `$env:PATH = `"$Directory;`$env:PATH`""
+        ''
+        'To persist it for your user account:'
+        "  [Environment]::SetEnvironmentVariable('Path', `"$Directory;`" + [Environment]::GetEnvironmentVariable('Path', 'User'), 'User')"
+    )
 }
 
-if (-not $Version) {
-    $Version = Get-LatestVersion
+# ---------------------------------------------------------------------------
+# Imperative shell
+#
+# Everything below reads the environment, talks to the network, or writes to
+# disk. Write-Host, Write-Warning, and throw stand in for install.sh's log,
+# warn, and die.
+# ---------------------------------------------------------------------------
+
+function Get-PlatformName {
+    # $IsWindows exists only on PowerShell 6+; Windows PowerShell 5.1 is Windows-only.
+    if ($PSVersionTable.PSVersion.Major -lt 6) { return 'windows' }
+    if ($IsWindows) { return 'windows' }
+    if ($IsMacOS) { return 'darwin' }
+    if ($IsLinux) { return 'linux' }
+    return 'unknown'
 }
 
-$Arch = Get-Architecture
-$Archive = "langsmith_windows_${Arch}.zip"
-$BaseUrl = "https://github.com/$Repo/releases/download/$Version"
-$ArchiveUrl = "$BaseUrl/$Archive"
-$ChecksumUrl = "$BaseUrl/checksums.txt"
+function Get-MachineName {
+    try {
+        return [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+    } catch {
+        # RuntimeInformation needs .NET Framework 4.7.1+ on Windows PowerShell.
+        return $env:PROCESSOR_ARCHITECTURE
+    }
+}
 
-Write-Host "Installing langsmith $Version ($Arch)..."
+function Invoke-GitHubRequest {
+    param([string]$Uri, [string]$Token)
 
-$TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("langsmith-install-" + [System.Guid]::NewGuid().ToString("N"))
-New-Item -ItemType Directory -Path $TempDir | Out-Null
+    $headers = @{ 'Accept' = 'application/vnd.github+json' }
+    if ($Token) {
+        $headers['Authorization'] = "Bearer $Token"
+    }
 
-try {
-    $ArchivePath = Join-Path $TempDir $Archive
-    $ChecksumPath = Join-Path $TempDir "checksums.txt"
-    $ExtractDir = Join-Path $TempDir "extract"
+    return (Invoke-WebRequest -Uri $Uri -Headers $headers -UseBasicParsing).Content
+}
 
-    Invoke-WebRequest -Uri $ArchiveUrl -OutFile $ArchivePath
-    Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumPath
+function Invoke-ReleaseApi {
+    # GITHUB_TOKEN, then an authenticated gh, then anonymous.
+    if ($env:GITHUB_TOKEN) {
+        return Invoke-GitHubRequest -Uri $ReleaseApiUrl -Token $env:GITHUB_TOKEN
+    }
 
-    $Expected = Select-String -Path $ChecksumPath -Pattern ([regex]::Escape($Archive)) | ForEach-Object {
-        ($_.Line -split '\s+')[0]
-    } | Select-Object -First 1
-
-    if ($Expected) {
-        $Actual = (Get-FileHash -Algorithm SHA256 -Path $ArchivePath).Hash.ToLowerInvariant()
-        if ($Actual -ne $Expected.ToLowerInvariant()) {
-            throw "Checksum verification failed. Expected $Expected but got $Actual"
+    if (Get-Command gh -ErrorAction SilentlyContinue) {
+        try {
+            $json = & gh api -H 'Accept: application/vnd.github+json' "repos/$Repo/releases/latest" 2>$null
+            if ($LASTEXITCODE -eq 0 -and $json) {
+                return ($json -join "`n")
+            }
+        } catch {
+            # fall through to an anonymous request
         }
     }
 
-    Expand-Archive -Path $ArchivePath -DestinationPath $ExtractDir -Force
+    return Invoke-GitHubRequest -Uri $ReleaseApiUrl
+}
 
-    $SourceBinary = Join-Path $ExtractDir $Binary
-    if (-not (Test-Path $SourceBinary)) {
-        throw "Archive did not contain $Binary"
+function Get-LatestVersion {
+    # Returns the latest release tag, or $null once the retries are spent.
+    for ($attempt = 1; $attempt -le $FetchAttempts; $attempt++) {
+        $tag = $null
+        try {
+            $tag = Resolve-TagName -ReleaseJson (Invoke-ReleaseApi)
+        } catch {
+            $tag = $null
+        }
+
+        if ($tag) {
+            return $tag
+        }
+
+        if ($attempt -lt $FetchAttempts) {
+            Start-Sleep -Seconds $attempt
+        }
     }
 
-    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
-    $TargetBinary = Join-Path $InstallDir $Binary
-    Move-Item -Path $SourceBinary -Destination $TargetBinary -Force
+    return $null
+}
 
-    Write-Host "Installed langsmith to $TargetBinary"
+function Save-RemoteFile {
+    param([string]$Uri, [string]$Path)
 
-    if (-not (Test-PathContainsDirectory -Directory $InstallDir)) {
-        Write-Host ""
-        Write-Host "Add $InstallDir to your PATH."
-        Write-Host "For the current PowerShell session:"
-        Write-Host "  `$env:PATH = `"$InstallDir;`$env:PATH`""
-        Write-Host ""
-        Write-Host "To persist it for your user account:"
-        Write-Host "  [Environment]::SetEnvironmentVariable('Path', `"$InstallDir;`" + [Environment]::GetEnvironmentVariable('Path', 'User'), 'User')"
+    Invoke-WebRequest -Uri $Uri -OutFile $Path -UseBasicParsing
+}
+
+function Get-FileSha256 {
+    param([string]$Path)
+
+    return (Get-FileHash -Algorithm SHA256 -Path $Path).Hash.ToLowerInvariant()
+}
+
+function Confirm-Checksum {
+    param([string]$ArchivePath, [string]$ArchiveName, [string]$ChecksumsPath)
+
+    $expected = Resolve-ExpectedChecksum `
+        -ChecksumsText (Get-Content -Raw -Path $ChecksumsPath) `
+        -ArchiveName $ArchiveName
+
+    if (-not $expected) {
+        Write-Warning "$ArchiveName is not listed in $ChecksumsName; skipping verification"
+        return
     }
 
-    Write-Host ""
-    Write-Host "Run: langsmith --version"
-} finally {
-    if (Test-Path $TempDir) {
-        Remove-Item -Path $TempDir -Recurse -Force
+    $actual = Get-FileSha256 -Path $ArchivePath
+    if ($actual -ne $expected.ToLowerInvariant()) {
+        throw "Checksum verification failed for $ArchiveName`n  Expected: $expected`n  Actual:   $actual"
     }
 }
+
+function Install-ReleaseBinary {
+    param([string]$SourcePath, [string]$Directory)
+
+    New-Item -ItemType Directory -Path $Directory -Force | Out-Null
+    Move-Item -Path $SourcePath -Destination (Join-Path $Directory $BinaryName) -Force
+}
+
+function Invoke-Install {
+    param([string]$InstallDirOverride, [string]$VersionOverride)
+
+    $platform = Get-PlatformName
+    $machine = Get-MachineName
+
+    $osName = Resolve-OSName -Platform $platform
+    if (-not $osName) {
+        throw "Unsupported OS: $platform. Use scripts/install.sh on Linux and macOS."
+    }
+
+    $archName = Resolve-ArchName -Machine $machine
+    if (-not $archName) {
+        throw "Unsupported architecture: $machine"
+    }
+
+    $installDir = Resolve-InstallDir `
+        -Override $InstallDirOverride `
+        -LocalAppData $env:LOCALAPPDATA `
+        -UserHome $HOME
+
+    $releaseTag = $VersionOverride
+    if (-not $releaseTag) {
+        $releaseTag = Get-LatestVersion
+        if (-not $releaseTag) {
+            throw @(
+                'Failed to determine latest version (GitHub API unreachable or rate-limited).'
+                "Set GITHUB_TOKEN, run 'gh auth login', or pass -Version to install a specific release."
+            ) -join "`n"
+        }
+    }
+
+    $archiveName = Resolve-ArchiveName -OSName $osName -ArchName $archName
+    $archiveUrl = "$DownloadBaseUrl/$releaseTag/$archiveName"
+    $checksumsUrl = "$DownloadBaseUrl/$releaseTag/$ChecksumsName"
+
+    Write-Host "Installing $CliName $releaseTag ($osName/$archName)..."
+
+    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("langsmith-install-" + [System.Guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Path $tempDir | Out-Null
+
+    try {
+        $archivePath = Join-Path $tempDir $archiveName
+        $checksumsPath = Join-Path $tempDir $ChecksumsName
+        $extractDir = Join-Path $tempDir 'extract'
+
+        Save-RemoteFile -Uri $archiveUrl -Path $archivePath
+        Save-RemoteFile -Uri $checksumsUrl -Path $checksumsPath
+        Confirm-Checksum -ArchivePath $archivePath -ArchiveName $archiveName -ChecksumsPath $checksumsPath
+        Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
+
+        $sourceBinary = Join-Path $extractDir $BinaryName
+        if (-not (Test-Path $sourceBinary)) {
+            throw "Archive did not contain $BinaryName"
+        }
+
+        Install-ReleaseBinary -SourcePath $sourceBinary -Directory $installDir
+        Write-Host "Installed $CliName to $(Join-Path $installDir $BinaryName)"
+
+        if (-not (Test-PathContainsDir -Directory $installDir -PathValue $env:PATH)) {
+            Format-PathInstructions -Directory $installDir | ForEach-Object { Write-Host $_ }
+        }
+
+        Write-Host ''
+        Write-Host "Run: $CliName --version"
+    } finally {
+        if (Test-Path $tempDir) {
+            Remove-Item -Path $tempDir -Recurse -Force
+        }
+    }
+}
+
+Invoke-Install -InstallDirOverride $InstallDir -VersionOverride $Version

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,137 +1,263 @@
 #!/bin/sh
-# Install script for langsmith CLI
-# Usage: curl -sSL https://raw.githubusercontent.com/langchain-ai/langsmith-cli/main/scripts/install.sh | sh
+# Install script for the langsmith CLI.
+#
+# Usage:
+#   curl -fsSL https://cli.langsmith.com/install.sh | sh
 #
 # Environment variables:
-#   INSTALL_DIR   — directory to install to (default: auto-detect)
-#   VERSION       — specific version to install (default: latest)
-#   GITHUB_TOKEN  — token for the release lookup, to avoid anonymous rate limits
+#   INSTALL_DIR   directory to install into (default: /usr/local/bin when writable,
+#                 otherwise $HOME/.local/bin)
+#   VERSION       release tag to install, e.g. v0.4.1 (default: latest release)
+#   GITHUB_TOKEN  token for the release lookup, to avoid anonymous rate limits
+#
+# Layout: pure helpers first (functional core), then everything that touches the
+# network or filesystem (imperative shell), then main. scripts/install.ps1
+# mirrors this structure function for function; keep the two in step.
 
-set -e
+set -eu
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
 
 REPO="langchain-ai/langsmith-cli"
-BINARY="langsmith"
+CLI_NAME="langsmith"
+BINARY_NAME="langsmith"
+ARCHIVE_EXT="tar.gz"
+CHECKSUMS_NAME="checksums.txt"
+RELEASE_API_URL="https://api.github.com/repos/${REPO}/releases/latest"
+DOWNLOAD_BASE_URL="https://github.com/${REPO}/releases/download"
+SYSTEM_INSTALL_DIR="/usr/local/bin"
+USER_INSTALL_SUBDIR=".local/bin"
+FETCH_ATTEMPTS=3
 
-# Detect OS
-OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-case "$OS" in
-  linux)  OS="linux" ;;
-  darwin) OS="darwin" ;;
-  *)      echo "Unsupported OS: $OS" >&2; exit 1 ;;
-esac
+# ---------------------------------------------------------------------------
+# Functional core
+#
+# Pure helpers: every input arrives as an argument or on stdin, every result
+# goes to stdout, and nothing here reads the environment or touches disk. The
+# resolve_* helpers print nothing and return non-zero when a value is
+# unsupported, leaving the error message to the caller.
+# ---------------------------------------------------------------------------
 
-# Detect architecture
-ARCH="$(uname -m)"
-case "$ARCH" in
-  x86_64|amd64)  ARCH="amd64" ;;
-  arm64|aarch64) ARCH="arm64" ;;
-  *)             echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
-esac
+# Map `uname -s` onto a goreleaser OS name.
+resolve_os() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    linux) printf 'linux' ;;
+    darwin) printf 'darwin' ;;
+    *) return 1 ;;
+  esac
+}
 
-# Determine install directory
-if [ -z "$INSTALL_DIR" ]; then
-  # Try /usr/local/bin first, fall back to ~/.local/bin
-  if [ -w /usr/local/bin ]; then
-    INSTALL_DIR="/usr/local/bin"
+# Map `uname -m` onto a goreleaser arch name.
+resolve_arch() {
+  case "$1" in
+    x86_64 | amd64) printf 'amd64' ;;
+    arm64 | aarch64) printf 'arm64' ;;
+    *) return 1 ;;
+  esac
+}
+
+# resolve_archive_name <os> <arch>
+resolve_archive_name() {
+  printf '%s_%s_%s.%s' "$CLI_NAME" "$1" "$2" "$ARCHIVE_EXT"
+}
+
+# resolve_install_dir <override> <system_dir_writable: yes|no> <home>
+#
+# An explicit override wins, then the system directory when the caller found it
+# writable, then the per-user fallback.
+resolve_install_dir() {
+  if [ -n "$1" ]; then
+    printf '%s' "$1"
+  elif [ "$2" = yes ]; then
+    printf '%s' "$SYSTEM_INSTALL_DIR"
   else
-    INSTALL_DIR="${HOME}/.local/bin"
+    printf '%s/%s' "$3" "$USER_INSTALL_SUBDIR"
   fi
-fi
+}
 
-# Get version
-if [ -z "$VERSION" ]; then
-  API_URL="https://api.github.com/repos/${REPO}/releases/latest"
+# Read release JSON on stdin, print its tag_name.
+resolve_tag_name() {
+  sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1
+}
 
-  # GITHUB_TOKEN, then an authenticated gh, then anonymous
-  fetch_latest() {
-    if [ -n "$GITHUB_TOKEN" ]; then
-      curl -fsSL -H "Accept: application/vnd.github+json" \
-        -H "Authorization: Bearer $GITHUB_TOKEN" "$API_URL"
-    elif command -v gh >/dev/null 2>&1; then
-      gh api -H "Accept: application/vnd.github+json" \
-        "repos/${REPO}/releases/latest" 2>/dev/null \
-        || curl -fsSL -H "Accept: application/vnd.github+json" "$API_URL"
-    else
-      curl -fsSL -H "Accept: application/vnd.github+json" "$API_URL"
+# resolve_expected_checksum <archive_name>
+#
+# Reads checksums.txt on stdin and prints the hash recorded for the archive.
+# Matches the whole file-name field: a bare prefix match would accept the hash
+# of a different, longer asset name.
+resolve_expected_checksum() {
+  awk -v want="$1" '
+    {
+      name = $2
+      sub(/^\*/, "", name)  # sha256sum marks binary mode with a leading *
+      if (name == want) { print $1; exit }
+    }
+  '
+}
+
+# path_contains_dir <dir> <path_value>
+path_contains_dir() {
+  case ":$2:" in
+    *":$1:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# format_path_instructions <dir>
+format_path_instructions() {
+  printf '%s\n' \
+    "" \
+    "Add $1 to your PATH:" \
+    "  export PATH=\"$1:\$PATH\"" \
+    "" \
+    "To make it permanent, add that line to your ~/.bashrc or ~/.zshrc"
+}
+
+# ---------------------------------------------------------------------------
+# Imperative shell
+#
+# Everything below reads the environment, talks to the network, or writes to
+# disk.
+# ---------------------------------------------------------------------------
+
+log() { printf '%s\n' "$*"; }
+warn() { printf '%s\n' "$*" >&2; }
+die() {
+  warn "$*"
+  exit 1
+}
+
+get_platform_name() { uname -s; }
+get_machine_name() { uname -m; }
+
+# GITHUB_TOKEN, then an authenticated gh, then anonymous.
+fetch_release_json() {
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    curl -fsSL -H 'Accept: application/vnd.github+json' \
+      -H "Authorization: Bearer ${GITHUB_TOKEN}" "$RELEASE_API_URL"
+  elif command -v gh >/dev/null 2>&1; then
+    gh api -H 'Accept: application/vnd.github+json' \
+      "repos/${REPO}/releases/latest" 2>/dev/null ||
+      curl -fsSL -H 'Accept: application/vnd.github+json' "$RELEASE_API_URL"
+  else
+    curl -fsSL -H 'Accept: application/vnd.github+json' "$RELEASE_API_URL"
+  fi
+}
+
+# Print the latest release tag, or return non-zero once the retries are spent.
+fetch_latest_version() {
+  local attempt tag
+  attempt=1
+  while [ "$attempt" -le "$FETCH_ATTEMPTS" ]; do
+    tag="$(fetch_release_json 2>/dev/null | resolve_tag_name || true)"
+    if [ -n "$tag" ]; then
+      printf '%s' "$tag"
+      return 0
     fi
-  }
-
-  VERSION=""
-  i=1
-  while [ "$i" -le 3 ]; do
-    VERSION="$(fetch_latest | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
-    [ -n "$VERSION" ] && break
-    [ "$i" -lt 3 ] && sleep "$i"
-    i=$((i + 1))
+    [ "$attempt" -lt "$FETCH_ATTEMPTS" ] && sleep "$attempt"
+    attempt=$((attempt + 1))
   done
+  return 1
+}
 
-  if [ -z "$VERSION" ]; then
-    echo "Failed to determine latest version (GitHub API unreachable or rate-limited)." >&2
-    echo "Set GITHUB_TOKEN, run 'gh auth login', or set VERSION to install a specific release." >&2
-    exit 1
-  fi
-fi
+# download_file <url> <dest>
+download_file() {
+  # -f so an HTTP error page is never saved as if it were the archive.
+  curl -fsSL -o "$2" "$1"
+}
 
-# Strip v prefix for filename
-VERSION_NUM="${VERSION#v}"
-
-# Build download URL
-ARCHIVE="${BINARY}_${OS}_${ARCH}.tar.gz"
-URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}"
-CHECKSUM_URL="https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt"
-
-echo "Installing ${BINARY} ${VERSION} (${OS}/${ARCH})..."
-
-# Create temp directory
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
-
-# Download archive and checksums
-curl -sSL -o "${TMP_DIR}/${ARCHIVE}" "$URL"
-curl -sSL -o "${TMP_DIR}/checksums.txt" "$CHECKSUM_URL"
-
-# Verify checksum
-cd "$TMP_DIR"
-EXPECTED="$(grep "${ARCHIVE}" checksums.txt | awk '{print $1}')"
-if [ -n "$EXPECTED" ]; then
+# file_sha256 <path>
+file_sha256() {
   if command -v sha256sum >/dev/null 2>&1; then
-    ACTUAL="$(sha256sum "${ARCHIVE}" | awk '{print $1}')"
+    sha256sum "$1" | awk '{print $1}'
   elif command -v shasum >/dev/null 2>&1; then
-    ACTUAL="$(shasum -a 256 "${ARCHIVE}" | awk '{print $1}')"
+    shasum -a 256 "$1" | awk '{print $1}'
   else
-    echo "Warning: cannot verify checksum (no sha256sum or shasum found)" >&2
-    ACTUAL="$EXPECTED"
+    return 1
+  fi
+}
+
+# verify_checksum <archive_path> <archive_name> <checksums_path>
+verify_checksum() {
+  local expected actual
+  expected="$(resolve_expected_checksum "$2" <"$3")"
+  if [ -z "$expected" ]; then
+    warn "Warning: $2 is not listed in ${CHECKSUMS_NAME}; skipping verification"
+    return 0
   fi
 
-  if [ "$ACTUAL" != "$EXPECTED" ]; then
-    echo "Checksum verification failed!" >&2
-    echo "  Expected: $EXPECTED" >&2
-    echo "  Actual:   $ACTUAL" >&2
+  if ! actual="$(file_sha256 "$1")"; then
+    warn "Warning: cannot verify checksum (no sha256sum or shasum found)"
+    return 0
+  fi
+
+  if [ "$actual" != "$expected" ]; then
+    warn "Checksum verification failed for $2"
+    warn "  Expected: ${expected}"
+    warn "  Actual:   ${actual}"
     exit 1
   fi
-fi
+}
 
-# Extract
-tar xzf "${ARCHIVE}"
+# install_binary <source_path> <install_dir>
+install_binary() {
+  mkdir -p "$2"
+  mv "$1" "$2/${BINARY_NAME}"
+  chmod +x "$2/${BINARY_NAME}"
+}
 
-# Install
-mkdir -p "$INSTALL_DIR"
-mv "${BINARY}" "${INSTALL_DIR}/${BINARY}"
-chmod +x "${INSTALL_DIR}/${BINARY}"
+main() {
+  platform="$(get_platform_name)"
+  machine="$(get_machine_name)"
 
-echo "Installed ${BINARY} to ${INSTALL_DIR}/${BINARY}"
+  os="$(resolve_os "$platform")" || die "Unsupported OS: ${platform}"
+  arch="$(resolve_arch "$machine")" || die "Unsupported architecture: ${machine}"
 
-# Check if INSTALL_DIR is in PATH
-case ":$PATH:" in
-  *":${INSTALL_DIR}:"*) ;;
-  *)
-    echo ""
-    echo "Add ${INSTALL_DIR} to your PATH:"
-    echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
-    echo ""
-    echo "To make it permanent, add that line to your ~/.bashrc or ~/.zshrc"
-    ;;
-esac
+  system_writable=no
+  [ -w "$SYSTEM_INSTALL_DIR" ] && system_writable=yes
+  install_dir="$(resolve_install_dir "${INSTALL_DIR:-}" "$system_writable" "${HOME:-}")"
 
-echo ""
-echo "Run: ${BINARY} --version"
+  release_tag="${VERSION:-}"
+  if [ -z "$release_tag" ]; then
+    if ! release_tag="$(fetch_latest_version)"; then
+      warn "Failed to determine latest version (GitHub API unreachable or rate-limited)."
+      die "Set GITHUB_TOKEN, run 'gh auth login', or set VERSION to install a specific release."
+    fi
+  fi
+
+  archive_name="$(resolve_archive_name "$os" "$arch")"
+  archive_url="${DOWNLOAD_BASE_URL}/${release_tag}/${archive_name}"
+  checksums_url="${DOWNLOAD_BASE_URL}/${release_tag}/${CHECKSUMS_NAME}"
+
+  log "Installing ${CLI_NAME} ${release_tag} (${os}/${arch})..."
+
+  # Not local: the EXIT trap expands TMP_DIR after main has returned.
+  TMP_DIR="$(mktemp -d)"
+  trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+
+  archive_path="${TMP_DIR}/${archive_name}"
+  checksums_path="${TMP_DIR}/${CHECKSUMS_NAME}"
+  extract_dir="${TMP_DIR}/extract"
+
+  download_file "$archive_url" "$archive_path"
+  download_file "$checksums_url" "$checksums_path"
+  verify_checksum "$archive_path" "$archive_name" "$checksums_path"
+
+  mkdir -p "$extract_dir"
+  tar -xzf "$archive_path" -C "$extract_dir"
+
+  source_binary="${extract_dir}/${BINARY_NAME}"
+  [ -f "$source_binary" ] || die "Archive did not contain ${BINARY_NAME}"
+
+  install_binary "$source_binary" "$install_dir"
+  log "Installed ${CLI_NAME} to ${install_dir}/${BINARY_NAME}"
+
+  path_contains_dir "$install_dir" "${PATH:-}" || format_path_instructions "$install_dir"
+
+  log ""
+  log "Run: ${CLI_NAME} --version"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Follow-up to my review on #208, where we noted the inconsistencies between `install.sh` and `install.ps` in the following [comment](https://github.com/langchain-ai/langsmith-cli/pull/208#pullrequestreview-4802114643).

While I was at it, took the time to revamp the whole install scripts.

What changed:
- Have the two scripts mirror each other as closely as possible (while still keeping the PowerShell and Bash semantics).
- Extract out core functions to make the scripts easier to maintain.
- Put main logic in `main` (`install.sh`) and `Invoke-Install` (`install.ps1`) functions.
- Make `install.ps1` a proper PowerShell script.