### PR TITLE
fix(auth): resolve OAuth endpoints via RFC 8414 discovery

### DIFF
--- a/internal/client/oauth.go
+++ b/internal/client/oauth.go
@@ -3,9 +3,11 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -14,6 +16,12 @@ const (
 	wellKnownOAuthPath    = "/.well-known/oauth-authorization-server"
 	oauthDiscoveryMaxBody = 1 << 20 // 1 MiB cap on the metadata document
 )
+
+// errNoOAuthMetadata means the deployment does not serve a usable discovery
+// document. It is distinct from a transport or 5xx failure, which says nothing
+// about whether the document exists and so must not trigger the legacy
+// fallback.
+var errNoOAuthMetadata = errors.New("no authorization server metadata")
 
 // OAuthMetadata holds absolute authorization server endpoints. The AS lives at
 // <origin>/oauth on SaaS and <origin>/api/oauth on self-hosted, so callers use
@@ -28,11 +36,10 @@ type OAuthMetadata struct {
 }
 
 type oauthServerMetadata struct {
-	Issuer                      string   `json:"issuer"`
-	DeviceAuthorizationEndpoint string   `json:"device_authorization_endpoint"`
-	TokenEndpoint               string   `json:"token_endpoint"`
-	RegistrationEndpoint        string   `json:"registration_endpoint"`
-	ProtectedResourcesSupported []string `json:"protected_resources_supported"`
+	Issuer                      string `json:"issuer"`
+	DeviceAuthorizationEndpoint string `json:"device_authorization_endpoint"`
+	TokenEndpoint               string `json:"token_endpoint"`
+	RegistrationEndpoint        string `json:"registration_endpoint"`
 }
 
 // oauthDeploymentRoot strips a trailing "/api/v1" or "/api" mount segment,
@@ -64,28 +71,38 @@ func oauthDiscoveryCandidates(apiURL string) []string {
 }
 
 // DiscoverOAuth returns the endpoints from the first candidate serving a valid
-// RFC 8414 metadata document, or an error if none does.
+// RFC 8414 metadata document. A transient failure against any candidate is
+// reported in preference to errNoOAuthMetadata so callers do not mistake an
+// outage for a legacy backend.
 func DiscoverOAuth(ctx context.Context, apiURL string) (*OAuthMetadata, error) {
-	var lastErr error
+	var transientErr error
 	for _, base := range oauthDiscoveryCandidates(apiURL) {
-		meta, err := fetchOAuthMetadata(ctx, base+wellKnownOAuthPath)
-		if err != nil {
-			lastErr = err
-			continue
+		meta, err := fetchOAuthMetadata(ctx, base+wellKnownOAuthPath, base)
+		switch {
+		case err == nil:
+			return meta, nil
+		case errors.Is(err, errNoOAuthMetadata):
+		case transientErr == nil:
+			transientErr = err
 		}
-		return meta, nil
 	}
-	if lastErr == nil {
-		lastErr = fmt.Errorf("no authorization server metadata found for %q", apiURL)
+	if transientErr != nil {
+		return nil, fmt.Errorf("discovering OAuth authorization server: %w", transientErr)
 	}
-	return nil, fmt.Errorf("discovering OAuth authorization server: %w", lastErr)
+	return nil, fmt.Errorf("discovering OAuth authorization server for %q: %w", apiURL, errNoOAuthMetadata)
 }
 
 // ResolveOAuth prefers discovery, falling back to <base>/oauth/* so backends
-// that serve no metadata document keep working. It never returns nil.
-func ResolveOAuth(ctx context.Context, apiURL string) *OAuthMetadata {
-	if meta, err := DiscoverOAuth(ctx, apiURL); err == nil {
-		return meta
+// that serve no metadata document keep working. Transient discovery failures
+// are returned rather than masked, because the fallback would post credentials
+// to an endpoint the deployment may not serve.
+func ResolveOAuth(ctx context.Context, apiURL string) (*OAuthMetadata, error) {
+	meta, err := DiscoverOAuth(ctx, apiURL)
+	if err == nil {
+		return meta, nil
+	}
+	if !errors.Is(err, errNoOAuthMetadata) {
+		return nil, err
 	}
 	base := strings.TrimRight(NormalizeURL(apiURL), "/")
 	return &OAuthMetadata{
@@ -94,10 +111,10 @@ func ResolveOAuth(ctx context.Context, apiURL string) *OAuthMetadata {
 		TokenEndpoint:               base + "/oauth/token",
 		RegistrationEndpoint:        base + "/oauth/register",
 		Resource:                    base,
-	}
+	}, nil
 }
 
-func fetchOAuthMetadata(ctx context.Context, metadataURL string) (*OAuthMetadata, error) {
+func fetchOAuthMetadata(ctx context.Context, metadataURL, base string) (*OAuthMetadata, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
 	if err != nil {
 		return nil, err
@@ -107,31 +124,32 @@ func fetchOAuthMetadata(ctx context.Context, metadataURL string) (*OAuthMetadata
 	httpClient := &http.Client{Timeout: 15 * time.Second}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", metadataURL, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("%s: HTTP %d", metadataURL, resp.StatusCode)
+		if isTransientStatus(resp.StatusCode) {
+			return nil, fmt.Errorf("%s: HTTP %d", metadataURL, resp.StatusCode)
+		}
+		return nil, fmt.Errorf("%s: HTTP %d: %w", metadataURL, resp.StatusCode, errNoOAuthMetadata)
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, oauthDiscoveryMaxBody))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", metadataURL, err)
 	}
 
 	var doc oauthServerMetadata
 	if err := json.Unmarshal(body, &doc); err != nil {
 		// The self-hosted SPA catch-all answers unknown paths with an HTML 200.
-		return nil, fmt.Errorf("%s: response is not authorization server metadata", metadataURL)
+		return nil, fmt.Errorf("%s: not authorization server metadata: %w", metadataURL, errNoOAuthMetadata)
 	}
 	if doc.TokenEndpoint == "" || doc.DeviceAuthorizationEndpoint == "" {
-		return nil, fmt.Errorf("%s: metadata missing required endpoints", metadataURL)
+		return nil, fmt.Errorf("%s: metadata missing required endpoints: %w", metadataURL, errNoOAuthMetadata)
 	}
-
-	resource := doc.Issuer
-	if resource == "" && len(doc.ProtectedResourcesSupported) > 0 {
-		resource = doc.ProtectedResourcesSupported[0]
+	if err := validateOAuthMetadata(&doc, base); err != nil {
+		return nil, fmt.Errorf("%s: %w: %w", metadataURL, err, errNoOAuthMetadata)
 	}
 
 	return &OAuthMetadata{
@@ -139,6 +157,38 @@ func fetchOAuthMetadata(ctx context.Context, metadataURL string) (*OAuthMetadata
 		DeviceAuthorizationEndpoint: doc.DeviceAuthorizationEndpoint,
 		TokenEndpoint:               doc.TokenEndpoint,
 		RegistrationEndpoint:        doc.RegistrationEndpoint,
-		Resource:                    resource,
+		Resource:                    doc.Issuer,
 	}, nil
+}
+
+func isTransientStatus(code int) bool {
+	return code >= 500 || code == http.StatusRequestTimeout || code == http.StatusTooManyRequests
+}
+
+// validateOAuthMetadata enforces that the document describes the deployment we
+// probed: RFC 8414 requires the issuer to match the URL the well-known path was
+// built from, and every endpoint must share the issuer's origin. The CLI posts
+// refresh tokens and device codes to these URLs, so an unvalidated document
+// could redirect long-lived credentials to another host.
+func validateOAuthMetadata(doc *oauthServerMetadata, base string) error {
+	if strings.TrimRight(doc.Issuer, "/") != strings.TrimRight(base, "/") {
+		return fmt.Errorf("issuer %q does not match %q", doc.Issuer, base)
+	}
+	issuer, err := url.Parse(doc.Issuer)
+	if err != nil {
+		return fmt.Errorf("unparseable issuer %q", doc.Issuer)
+	}
+	for _, ep := range []string{doc.DeviceAuthorizationEndpoint, doc.TokenEndpoint, doc.RegistrationEndpoint} {
+		if ep == "" {
+			continue
+		}
+		u, err := url.Parse(ep)
+		if err != nil {
+			return fmt.Errorf("unparseable endpoint %q", ep)
+		}
+		if u.Scheme != issuer.Scheme || u.Host != issuer.Host {
+			return fmt.Errorf("endpoint %q is not on issuer origin %s://%s", ep, issuer.Scheme, issuer.Host)
+		}
+	}
+	return nil
 }

--- a/internal/client/oauth.go
+++ b/internal/client/oauth.go
@@ -15,18 +15,15 @@ const (
 	oauthDiscoveryMaxBody = 1 << 20 // 1 MiB cap on the metadata document
 )
 
-// OAuthMetadata holds the OAuth authorization server endpoints resolved via
-// RFC 8414 discovery. Endpoints are the absolute URLs advertised by the server,
-// so callers never construct OAuth paths themselves — this is what lets the same
-// code path serve SaaS (AS at <origin>/oauth/*) and self-hosted (AS at
-// <origin>/api/oauth/*) without branching.
+// OAuthMetadata holds absolute authorization server endpoints. The AS lives at
+// <origin>/oauth on SaaS and <origin>/api/oauth on self-hosted, so callers use
+// these rather than building paths themselves.
 type OAuthMetadata struct {
 	Issuer                      string
 	DeviceAuthorizationEndpoint string
 	TokenEndpoint               string
 	RegistrationEndpoint        string
-	// Resource is the RFC 8707 resource indicator to request (the API the token
-	// is minted for). It equals the authorization server's issuer.
+	// Resource is the RFC 8707 resource indicator; it equals the issuer.
 	Resource string
 }
 
@@ -38,9 +35,8 @@ type oauthServerMetadata struct {
 	ProtectedResourcesSupported []string `json:"protected_resources_supported"`
 }
 
-// oauthDeploymentRoot reduces apiURL to the deployment root by stripping a
-// trailing "/api/v1" or "/api" mount segment, mirroring how the SDK derives its
-// REST base URL. A basePath prefix is preserved.
+// oauthDeploymentRoot strips a trailing "/api/v1" or "/api" mount segment,
+// preserving any basePath prefix.
 func oauthDeploymentRoot(apiURL string) string {
 	u := strings.TrimRight(apiURL, "/")
 	u = strings.TrimSuffix(u, "/api/v1")
@@ -48,12 +44,8 @@ func oauthDeploymentRoot(apiURL string) string {
 	return u
 }
 
-// oauthDiscoveryCandidates returns the base URLs to probe for the RFC 8414
-// metadata document, most specific first. The user-provided path (minus a
-// trailing /api/v1) is tried first, so basePath deployments and an explicit
-// "<origin>/api" resolve directly; the "<origin>/api" self-hosted default and
-// the bare "<origin>" (SaaS) follow so a user who passes only the origin still
-// resolves.
+// oauthDiscoveryCandidates returns metadata base URLs to probe, most specific
+// first: what the user configured, then the self-hosted and SaaS mount points.
 func oauthDiscoveryCandidates(apiURL string) []string {
 	given := strings.TrimRight(NormalizeURL(apiURL), "/")
 	origin := strings.TrimRight(oauthDeploymentRoot(apiURL), "/")
@@ -71,12 +63,8 @@ func oauthDiscoveryCandidates(apiURL string) []string {
 	return out
 }
 
-// DiscoverOAuth resolves the OAuth authorization server endpoints for apiURL via
-// RFC 8414 discovery. It probes candidate .well-known locations and returns the
-// first that yields a valid metadata document (one that parses as JSON and
-// advertises token and device-authorization endpoints). It returns an error if
-// no candidate yields valid metadata, so callers can fall back to legacy path
-// construction against older backends that do not serve the document.
+// DiscoverOAuth returns the endpoints from the first candidate serving a valid
+// RFC 8414 metadata document, or an error if none does.
 func DiscoverOAuth(ctx context.Context, apiURL string) (*OAuthMetadata, error) {
 	var lastErr error
 	for _, base := range oauthDiscoveryCandidates(apiURL) {
@@ -93,12 +81,8 @@ func DiscoverOAuth(ctx context.Context, apiURL string) (*OAuthMetadata, error) {
 	return nil, fmt.Errorf("discovering OAuth authorization server: %w", lastErr)
 }
 
-// ResolveOAuth returns the OAuth endpoints for apiURL. It prefers RFC 8414
-// discovery and falls back to legacy path construction (<base>/oauth/*) when the
-// backend serves no metadata document, where <base> is apiURL with a trailing
-// /api/v1 stripped. The fallback reproduces the pre-discovery behavior, so an
-// older self-hosted backend keeps working when apiURL points at the API root
-// (e.g. "<origin>/api"). It never returns nil.
+// ResolveOAuth prefers discovery, falling back to <base>/oauth/* so backends
+// that serve no metadata document keep working. It never returns nil.
 func ResolveOAuth(ctx context.Context, apiURL string) *OAuthMetadata {
 	if meta, err := DiscoverOAuth(ctx, apiURL); err == nil {
 		return meta
@@ -138,8 +122,7 @@ func fetchOAuthMetadata(ctx context.Context, metadataURL string) (*OAuthMetadata
 
 	var doc oauthServerMetadata
 	if err := json.Unmarshal(body, &doc); err != nil {
-		// A self-hosted SPA catch-all answers unknown paths with an HTML 200;
-		// reject anything that is not a valid metadata JSON document.
+		// The self-hosted SPA catch-all answers unknown paths with an HTML 200.
 		return nil, fmt.Errorf("%s: response is not authorization server metadata", metadataURL)
 	}
 	if doc.TokenEndpoint == "" || doc.DeviceAuthorizationEndpoint == "" {

--- a/internal/client/oauth.go
+++ b/internal/client/oauth.go
@@ -1,0 +1,161 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	wellKnownOAuthPath    = "/.well-known/oauth-authorization-server"
+	oauthDiscoveryMaxBody = 1 << 20 // 1 MiB cap on the metadata document
+)
+
+// OAuthMetadata holds the OAuth authorization server endpoints resolved via
+// RFC 8414 discovery. Endpoints are the absolute URLs advertised by the server,
+// so callers never construct OAuth paths themselves — this is what lets the same
+// code path serve SaaS (AS at <origin>/oauth/*) and self-hosted (AS at
+// <origin>/api/oauth/*) without branching.
+type OAuthMetadata struct {
+	Issuer                      string
+	DeviceAuthorizationEndpoint string
+	TokenEndpoint               string
+	RegistrationEndpoint        string
+	// Resource is the RFC 8707 resource indicator to request (the API the token
+	// is minted for). It equals the authorization server's issuer.
+	Resource string
+}
+
+type oauthServerMetadata struct {
+	Issuer                      string   `json:"issuer"`
+	DeviceAuthorizationEndpoint string   `json:"device_authorization_endpoint"`
+	TokenEndpoint               string   `json:"token_endpoint"`
+	RegistrationEndpoint        string   `json:"registration_endpoint"`
+	ProtectedResourcesSupported []string `json:"protected_resources_supported"`
+}
+
+// oauthDeploymentRoot reduces apiURL to the deployment root by stripping a
+// trailing "/api/v1" or "/api" mount segment, mirroring how the SDK derives its
+// REST base URL. A basePath prefix is preserved.
+func oauthDeploymentRoot(apiURL string) string {
+	u := strings.TrimRight(apiURL, "/")
+	u = strings.TrimSuffix(u, "/api/v1")
+	u = strings.TrimSuffix(u, "/api")
+	return u
+}
+
+// oauthDiscoveryCandidates returns the base URLs to probe for the RFC 8414
+// metadata document, most specific first. The user-provided path (minus a
+// trailing /api/v1) is tried first, so basePath deployments and an explicit
+// "<origin>/api" resolve directly; the "<origin>/api" self-hosted default and
+// the bare "<origin>" (SaaS) follow so a user who passes only the origin still
+// resolves.
+func oauthDiscoveryCandidates(apiURL string) []string {
+	given := strings.TrimRight(NormalizeURL(apiURL), "/")
+	origin := strings.TrimRight(oauthDeploymentRoot(apiURL), "/")
+
+	ordered := []string{given, origin + "/api", origin}
+	seen := make(map[string]bool, len(ordered))
+	out := make([]string, 0, len(ordered))
+	for _, c := range ordered {
+		if c == "" || c == "/api" || seen[c] {
+			continue
+		}
+		seen[c] = true
+		out = append(out, c)
+	}
+	return out
+}
+
+// DiscoverOAuth resolves the OAuth authorization server endpoints for apiURL via
+// RFC 8414 discovery. It probes candidate .well-known locations and returns the
+// first that yields a valid metadata document (one that parses as JSON and
+// advertises token and device-authorization endpoints). It returns an error if
+// no candidate yields valid metadata, so callers can fall back to legacy path
+// construction against older backends that do not serve the document.
+func DiscoverOAuth(ctx context.Context, apiURL string) (*OAuthMetadata, error) {
+	var lastErr error
+	for _, base := range oauthDiscoveryCandidates(apiURL) {
+		meta, err := fetchOAuthMetadata(ctx, base+wellKnownOAuthPath)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return meta, nil
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no authorization server metadata found for %q", apiURL)
+	}
+	return nil, fmt.Errorf("discovering OAuth authorization server: %w", lastErr)
+}
+
+// ResolveOAuth returns the OAuth endpoints for apiURL. It prefers RFC 8414
+// discovery and falls back to legacy path construction (<base>/oauth/*) when the
+// backend serves no metadata document, where <base> is apiURL with a trailing
+// /api/v1 stripped. The fallback reproduces the pre-discovery behavior, so an
+// older self-hosted backend keeps working when apiURL points at the API root
+// (e.g. "<origin>/api"). It never returns nil.
+func ResolveOAuth(ctx context.Context, apiURL string) *OAuthMetadata {
+	if meta, err := DiscoverOAuth(ctx, apiURL); err == nil {
+		return meta
+	}
+	base := strings.TrimRight(NormalizeURL(apiURL), "/")
+	return &OAuthMetadata{
+		Issuer:                      base,
+		DeviceAuthorizationEndpoint: base + "/oauth/device/code",
+		TokenEndpoint:               base + "/oauth/token",
+		RegistrationEndpoint:        base + "/oauth/register",
+		Resource:                    base,
+	}
+}
+
+func fetchOAuthMetadata(ctx context.Context, metadataURL string) (*OAuthMetadata, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	httpClient := &http.Client{Timeout: 15 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("%s: HTTP %d", metadataURL, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, oauthDiscoveryMaxBody))
+	if err != nil {
+		return nil, err
+	}
+
+	var doc oauthServerMetadata
+	if err := json.Unmarshal(body, &doc); err != nil {
+		// A self-hosted SPA catch-all answers unknown paths with an HTML 200;
+		// reject anything that is not a valid metadata JSON document.
+		return nil, fmt.Errorf("%s: response is not authorization server metadata", metadataURL)
+	}
+	if doc.TokenEndpoint == "" || doc.DeviceAuthorizationEndpoint == "" {
+		return nil, fmt.Errorf("%s: metadata missing required endpoints", metadataURL)
+	}
+
+	resource := doc.Issuer
+	if resource == "" && len(doc.ProtectedResourcesSupported) > 0 {
+		resource = doc.ProtectedResourcesSupported[0]
+	}
+
+	return &OAuthMetadata{
+		Issuer:                      doc.Issuer,
+		DeviceAuthorizationEndpoint: doc.DeviceAuthorizationEndpoint,
+		TokenEndpoint:               doc.TokenEndpoint,
+		RegistrationEndpoint:        doc.RegistrationEndpoint,
+		Resource:                    resource,
+	}, nil
+}

--- a/internal/client/oauth_test.go
+++ b/internal/client/oauth_test.go
@@ -8,10 +8,8 @@ import (
 	"testing"
 )
 
-// selfHostedDiscoveryServer serves the RFC 8414 metadata document under /api
-// (as self-hosted LangSmith does) and returns an HTML 200 at the bare-root
-// .well-known path, mimicking the SPA catch-all that must not be mistaken for
-// real metadata.
+// selfHostedDiscoveryServer serves metadata under /api and, like the real SPA
+// catch-all, an HTML 200 at the bare-root .well-known path.
 func selfHostedDiscoveryServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	var srv *httptest.Server
@@ -58,8 +56,8 @@ func TestDiscoverOAuth_SelfHostedUnderApi(t *testing.T) {
 	}
 }
 
-// A self-hosted user who passes the bare origin must still resolve: the bare
-// .well-known returns HTML (rejected), and discovery falls back to /api.
+// A bare origin must still resolve: the root .well-known returns HTML, so
+// discovery has to reject it and fall back to /api.
 func TestDiscoverOAuth_BareOriginFallsBackToApi(t *testing.T) {
 	srv := selfHostedDiscoveryServer(t)
 
@@ -105,8 +103,7 @@ func TestDiscoverOAuth_SaaSAtRoot(t *testing.T) {
 	}
 }
 
-// When no metadata document exists (older backend), discovery returns an error
-// so callers can fall back to legacy path construction.
+// No metadata document must surface an error so callers can fall back.
 func TestDiscoverOAuth_NoMetadataReturnsError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
@@ -118,9 +115,8 @@ func TestDiscoverOAuth_NoMetadataReturnsError(t *testing.T) {
 	}
 }
 
-// ResolveOAuth falls back to legacy <base>/oauth/* construction when the backend
-// serves no metadata document, so older self-hosted backends keep working when
-// apiURL points at the API root.
+// Without a metadata document, ResolveOAuth keeps the legacy <base>/oauth/*
+// behavior.
 func TestResolveOAuth_FallsBackToLegacyPaths(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
@@ -139,8 +135,7 @@ func TestResolveOAuth_FallsBackToLegacyPaths(t *testing.T) {
 	}
 }
 
-// ResolveOAuth prefers discovery: a bare origin resolves to the discovered /api
-// endpoints even though the legacy fallback would have produced bare-root paths.
+// Discovery wins over the fallback, which would have produced root paths.
 func TestResolveOAuth_PrefersDiscovery(t *testing.T) {
 	srv := selfHostedDiscoveryServer(t)
 

--- a/internal/client/oauth_test.go
+++ b/internal/client/oauth_test.go
@@ -123,7 +123,10 @@ func TestResolveOAuth_FallsBackToLegacyPaths(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	meta := ResolveOAuth(context.Background(), srv.URL+"/api")
+	meta, err := ResolveOAuth(context.Background(), srv.URL+"/api")
+	if err != nil {
+		t.Fatalf("ResolveOAuth: %v", err)
+	}
 	if got, want := meta.TokenEndpoint, srv.URL+"/api/oauth/token"; got != want {
 		t.Errorf("TokenEndpoint = %q, want legacy %q", got, want)
 	}
@@ -139,8 +142,71 @@ func TestResolveOAuth_FallsBackToLegacyPaths(t *testing.T) {
 func TestResolveOAuth_PrefersDiscovery(t *testing.T) {
 	srv := selfHostedDiscoveryServer(t)
 
-	meta := ResolveOAuth(context.Background(), srv.URL)
+	meta, err := ResolveOAuth(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("ResolveOAuth: %v", err)
+	}
 	if got, want := meta.TokenEndpoint, srv.URL+"/api/oauth/token"; got != want {
 		t.Errorf("TokenEndpoint = %q, want discovered %q", got, want)
+	}
+}
+
+// metadataServer serves one metadata document at the root .well-known path.
+func metadataServer(t *testing.T, doc func(base string) map[string]any) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/oauth-authorization-server" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(doc(srv.URL))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// Credentials are POSTed to these endpoints, so a document claiming an issuer
+// other than the host we probed must not be trusted.
+func TestDiscoverOAuth_RejectsIssuerMismatch(t *testing.T) {
+	srv := metadataServer(t, func(base string) map[string]any {
+		return map[string]any{
+			"issuer":                        "https://evil.example.com",
+			"device_authorization_endpoint": base + "/oauth/device/code",
+			"token_endpoint":                base + "/oauth/token",
+		}
+	})
+
+	if _, err := DiscoverOAuth(context.Background(), srv.URL); err == nil {
+		t.Fatal("expected issuer mismatch to be rejected")
+	}
+}
+
+// An endpoint pointing off-host would exfiltrate the refresh token.
+func TestDiscoverOAuth_RejectsForeignEndpointHost(t *testing.T) {
+	srv := metadataServer(t, func(base string) map[string]any {
+		return map[string]any{
+			"issuer":                        base,
+			"device_authorization_endpoint": base + "/oauth/device/code",
+			"token_endpoint":                "https://evil.example.com/oauth/token",
+		}
+	})
+
+	if _, err := DiscoverOAuth(context.Background(), srv.URL); err == nil {
+		t.Fatal("expected foreign token endpoint to be rejected")
+	}
+}
+
+// A 5xx is a transient failure, not proof the deployment lacks metadata, so
+// falling back to legacy paths would send credentials to the wrong place.
+func TestResolveOAuth_SurfacesTransientErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream down", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	if _, err := ResolveOAuth(context.Background(), srv.URL+"/api"); err == nil {
+		t.Fatal("expected 5xx during discovery to surface as an error")
 	}
 }

--- a/internal/client/oauth_test.go
+++ b/internal/client/oauth_test.go
@@ -1,0 +1,151 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// selfHostedDiscoveryServer serves the RFC 8414 metadata document under /api
+// (as self-hosted LangSmith does) and returns an HTML 200 at the bare-root
+// .well-known path, mimicking the SPA catch-all that must not be mistaken for
+// real metadata.
+func selfHostedDiscoveryServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                        srv.URL + "/api",
+				"device_authorization_endpoint": srv.URL + "/api/oauth/device/code",
+				"token_endpoint":                srv.URL + "/api/oauth/token",
+				"registration_endpoint":         srv.URL + "/api/oauth/register",
+				"protected_resources_supported": []string{srv.URL + "/api", srv.URL + "/api/mcp"},
+			})
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<!doctype html><html><body>app</body></html>"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestDiscoverOAuth_SelfHostedUnderApi(t *testing.T) {
+	srv := selfHostedDiscoveryServer(t)
+
+	meta, err := DiscoverOAuth(context.Background(), srv.URL+"/api")
+	if err != nil {
+		t.Fatalf("DiscoverOAuth: %v", err)
+	}
+	if got, want := meta.TokenEndpoint, srv.URL+"/api/oauth/token"; got != want {
+		t.Errorf("TokenEndpoint = %q, want %q", got, want)
+	}
+	if got, want := meta.DeviceAuthorizationEndpoint, srv.URL+"/api/oauth/device/code"; got != want {
+		t.Errorf("DeviceAuthorizationEndpoint = %q, want %q", got, want)
+	}
+	if got, want := meta.RegistrationEndpoint, srv.URL+"/api/oauth/register"; got != want {
+		t.Errorf("RegistrationEndpoint = %q, want %q", got, want)
+	}
+	if got, want := meta.Resource, srv.URL+"/api"; got != want {
+		t.Errorf("Resource = %q, want %q (issuer)", got, want)
+	}
+}
+
+// A self-hosted user who passes the bare origin must still resolve: the bare
+// .well-known returns HTML (rejected), and discovery falls back to /api.
+func TestDiscoverOAuth_BareOriginFallsBackToApi(t *testing.T) {
+	srv := selfHostedDiscoveryServer(t)
+
+	meta, err := DiscoverOAuth(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("DiscoverOAuth: %v", err)
+	}
+	if got, want := meta.TokenEndpoint, srv.URL+"/api/oauth/token"; got != want {
+		t.Errorf("TokenEndpoint = %q, want %q", got, want)
+	}
+	if got, want := meta.Resource, srv.URL+"/api"; got != want {
+		t.Errorf("Resource = %q, want %q", got, want)
+	}
+}
+
+func TestDiscoverOAuth_SaaSAtRoot(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-authorization-server" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                        srv.URL,
+				"device_authorization_endpoint": srv.URL + "/oauth/device/code",
+				"token_endpoint":                srv.URL + "/oauth/token",
+				"registration_endpoint":         srv.URL + "/oauth/register",
+				"protected_resources_supported": []string{srv.URL, srv.URL + "/mcp"},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	meta, err := DiscoverOAuth(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("DiscoverOAuth: %v", err)
+	}
+	if got, want := meta.TokenEndpoint, srv.URL+"/oauth/token"; got != want {
+		t.Errorf("TokenEndpoint = %q, want %q", got, want)
+	}
+	if got, want := meta.Resource, srv.URL; got != want {
+		t.Errorf("Resource = %q, want %q", got, want)
+	}
+}
+
+// When no metadata document exists (older backend), discovery returns an error
+// so callers can fall back to legacy path construction.
+func TestDiscoverOAuth_NoMetadataReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	if _, err := DiscoverOAuth(context.Background(), srv.URL+"/api"); err == nil {
+		t.Fatal("expected error when no metadata document is served")
+	}
+}
+
+// ResolveOAuth falls back to legacy <base>/oauth/* construction when the backend
+// serves no metadata document, so older self-hosted backends keep working when
+// apiURL points at the API root.
+func TestResolveOAuth_FallsBackToLegacyPaths(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	meta := ResolveOAuth(context.Background(), srv.URL+"/api")
+	if got, want := meta.TokenEndpoint, srv.URL+"/api/oauth/token"; got != want {
+		t.Errorf("TokenEndpoint = %q, want legacy %q", got, want)
+	}
+	if got, want := meta.DeviceAuthorizationEndpoint, srv.URL+"/api/oauth/device/code"; got != want {
+		t.Errorf("DeviceAuthorizationEndpoint = %q, want legacy %q", got, want)
+	}
+	if got, want := meta.Resource, srv.URL+"/api"; got != want {
+		t.Errorf("Resource = %q, want %q", got, want)
+	}
+}
+
+// ResolveOAuth prefers discovery: a bare origin resolves to the discovered /api
+// endpoints even though the legacy fallback would have produced bare-root paths.
+func TestResolveOAuth_PrefersDiscovery(t *testing.T) {
+	srv := selfHostedDiscoveryServer(t)
+
+	meta := ResolveOAuth(context.Background(), srv.URL)
+	if got, want := meta.TokenEndpoint, srv.URL+"/api/oauth/token"; got != want {
+		t.Errorf("TokenEndpoint = %q, want discovered %q", got, want)
+	}
+}

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -105,7 +105,9 @@ func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspa
 		ctx = context.Background()
 	}
 
-	device, err := requestDeviceCode(ctx, apiURL)
+	oauthMeta := client.ResolveOAuth(ctx, apiURL)
+
+	device, err := requestDeviceCode(ctx, oauthMeta)
 	if err != nil {
 		return err
 	}
@@ -127,7 +129,7 @@ func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspa
 	defer cancel()
 
 	interval := normalizeDeviceCodePollInterval(time.Duration(device.Interval) * time.Second)
-	token, err := pollDeviceToken(pollCtx, apiURL, device.DeviceCode, interval)
+	token, err := pollDeviceToken(pollCtx, oauthMeta, device.DeviceCode, interval)
 	if err != nil {
 		return err
 	}
@@ -307,13 +309,13 @@ func promptLine(cmd *cobra.Command, prompt string) (string, error) {
 	return line, nil
 }
 
-func requestDeviceCode(ctx context.Context, apiURL string) (*deviceCodeResponse, error) {
+func requestDeviceCode(ctx context.Context, meta *client.OAuthMetadata) (*deviceCodeResponse, error) {
 	values := url.Values{
 		"client_id": {oauthClientID},
-		"resource":  {oauthResource(apiURL)},
+		"resource":  {meta.Resource},
 	}
 	var resp deviceCodeResponse
-	if err := postOAuthForm(ctx, apiURL, "/oauth/device/code", values, &resp); err != nil {
+	if err := postOAuthForm(ctx, meta.DeviceAuthorizationEndpoint, values, &resp); err != nil {
 		return nil, fmt.Errorf("requesting device code: %w", err)
 	}
 	if resp.DeviceCode == "" || resp.UserCode == "" || resp.VerificationURI == "" {
@@ -323,14 +325,15 @@ func requestDeviceCode(ctx context.Context, apiURL string) (*deviceCodeResponse,
 }
 
 func refreshProfileToken(ctx context.Context, apiURL, refreshToken string) (*oauthTokenResponse, error) {
+	meta := client.ResolveOAuth(ctx, apiURL)
 	values := url.Values{
 		"grant_type":    {"refresh_token"},
 		"client_id":     {oauthClientID},
-		"resource":      {oauthResource(apiURL)},
+		"resource":      {meta.Resource},
 		"refresh_token": {refreshToken},
 	}
 	var resp oauthTokenResponse
-	if err := postOAuthForm(ctx, apiURL, "/oauth/token", values, &resp); err != nil {
+	if err := postOAuthForm(ctx, meta.TokenEndpoint, values, &resp); err != nil {
 		return nil, err
 	}
 	if resp.AccessToken == "" {
@@ -339,11 +342,11 @@ func refreshProfileToken(ctx context.Context, apiURL, refreshToken string) (*oau
 	return &resp, nil
 }
 
-func pollDeviceToken(ctx context.Context, apiURL, deviceCode string, interval time.Duration) (*oauthTokenResponse, error) {
+func pollDeviceToken(ctx context.Context, meta *client.OAuthMetadata, deviceCode string, interval time.Duration) (*oauthTokenResponse, error) {
 	interval = normalizeDeviceCodePollInterval(interval)
 
 	for {
-		token, oauthErr, err := requestDeviceToken(ctx, apiURL, deviceCode)
+		token, oauthErr, err := requestDeviceToken(ctx, meta, deviceCode)
 		if err != nil {
 			return nil, err
 		}
@@ -378,15 +381,15 @@ func normalizeDeviceCodePollInterval(interval time.Duration) time.Duration {
 	return interval
 }
 
-func requestDeviceToken(ctx context.Context, apiURL, deviceCode string) (*oauthTokenResponse, *oauthErrorResponse, error) {
+func requestDeviceToken(ctx context.Context, meta *client.OAuthMetadata, deviceCode string) (*oauthTokenResponse, *oauthErrorResponse, error) {
 	values := url.Values{
 		"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
 		"client_id":   {oauthClientID},
 		"device_code": {deviceCode},
-		"resource":    {oauthResource(apiURL)},
+		"resource":    {meta.Resource},
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, oauthURL(apiURL, "/oauth/token"), strings.NewReader(values.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, meta.TokenEndpoint, strings.NewReader(values.Encode()))
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating token request: %w", err)
 	}
@@ -418,8 +421,8 @@ func requestDeviceToken(ctx context.Context, apiURL, deviceCode string) (*oauthT
 	return nil, oauthErr, nil
 }
 
-func postOAuthForm(ctx context.Context, apiURL, path string, values url.Values, result any) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, oauthURL(apiURL, path), strings.NewReader(values.Encode()))
+func postOAuthForm(ctx context.Context, endpointURL string, values url.Values, result any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, strings.NewReader(values.Encode()))
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
 	}
@@ -463,16 +466,6 @@ func applyTokenResponse(profile *lsconfig.Profile, token *oauthTokenResponse, no
 	if token.ExpiresIn > 0 {
 		profile.OAuth.ExpiresAt = now.Add(time.Duration(token.ExpiresIn) * time.Second).UTC().Format(time.RFC3339)
 	}
-}
-
-func oauthURL(apiURL, path string) string {
-	return strings.TrimRight(client.NormalizeURL(apiURL), "/") + path
-}
-
-// oauthResource is the API origin expected by the OAuth server; it must not
-// include the /api/v1 suffix accepted by LANGSMITH_ENDPOINT.
-func oauthResource(apiURL string) string {
-	return strings.TrimRight(client.NormalizeURL(apiURL), "/")
 }
 
 func openBrowserDefault(rawURL string) error {

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -105,7 +105,10 @@ func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspa
 		ctx = context.Background()
 	}
 
-	oauthMeta := client.ResolveOAuth(ctx, apiURL)
+	oauthMeta, err := client.ResolveOAuth(ctx, apiURL)
+	if err != nil {
+		return err
+	}
 
 	device, err := requestDeviceCode(ctx, oauthMeta)
 	if err != nil {
@@ -325,7 +328,10 @@ func requestDeviceCode(ctx context.Context, meta *client.OAuthMetadata) (*device
 }
 
 func refreshProfileToken(ctx context.Context, apiURL, refreshToken string) (*oauthTokenResponse, error) {
-	meta := client.ResolveOAuth(ctx, apiURL)
+	meta, err := client.ResolveOAuth(ctx, apiURL)
+	if err != nil {
+		return nil, err
+	}
 	values := url.Values{
 		"grant_type":    {"refresh_token"},
 		"client_id":     {oauthClientID},

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -200,7 +200,10 @@ func ResolveClientOptions(cmd *cobra.Command, refreshOAuth bool) (client.Options
 }
 
 func refreshProfileToken(ctx context.Context, apiURL, refreshToken string) (*oauthTokenResponse, error) {
-	meta := client.ResolveOAuth(ctx, apiURL)
+	meta, err := client.ResolveOAuth(ctx, apiURL)
+	if err != nil {
+		return nil, err
+	}
 	values := url.Values{
 		"grant_type":    {"refresh_token"},
 		"client_id":     {oauthClientID},

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -200,13 +200,14 @@ func ResolveClientOptions(cmd *cobra.Command, refreshOAuth bool) (client.Options
 }
 
 func refreshProfileToken(ctx context.Context, apiURL, refreshToken string) (*oauthTokenResponse, error) {
+	meta := client.ResolveOAuth(ctx, apiURL)
 	values := url.Values{
 		"grant_type":    {"refresh_token"},
 		"client_id":     {oauthClientID},
-		"resource":      {oauthResource(apiURL)},
+		"resource":      {meta.Resource},
 		"refresh_token": {refreshToken},
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, oauthURL(apiURL, "/oauth/token"), strings.NewReader(values.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, meta.TokenEndpoint, strings.NewReader(values.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -254,14 +255,4 @@ func decodeOAuthError(body []byte, statusCode int) *oauthErrorResponse {
 		}
 	}
 	return &oauthErr
-}
-
-func oauthURL(apiURL, path string) string {
-	return strings.TrimRight(client.NormalizeURL(apiURL), "/") + path
-}
-
-// oauthResource is the API origin expected by the OAuth server; it must not
-// include the /api/v1 suffix accepted by LANGSMITH_ENDPOINT.
-func oauthResource(apiURL string) string {
-	return strings.TrimRight(client.NormalizeURL(apiURL), "/")
 }


### PR DESCRIPTION
## Problem

`langsmith auth login` fails against self-hosted LangSmith. The CLI built OAuth URLs as `<base>/oauth/*`, which only holds on SaaS — self-hosted mounts the authorization server under `/api`, so pointing the CLI at a self-hosted origin POSTs to the bare-root `/oauth/device/code` and gets an nginx **405** (the SPA catch-all).

There was no `--api-url` that worked for everything: `<origin>/api` made OAuth resolve, and `<origin>` made REST resolve.

## Change

Resolve OAuth endpoints from the server's own authorization-server metadata instead of hardcoding paths.

- Probe `.well-known/oauth-authorization-server`, most specific first: the user-supplied path, then `<origin>/api`, then `<origin>`. A bare origin therefore works on both SaaS and self-hosted.
- Use the absolute `device_authorization_endpoint` / `token_endpoint` / `registration_endpoint` the document advertises, and its `issuer` as the resource indicator. The CLI no longer encodes where the AS lives, so SaaS, self-hosted-under-`/api`, and basePath deployments all take one code path.
- Validate the document parses as JSON carrying token and device-authorization endpoints. This matters: the self-hosted SPA catch-all answers unknown paths with an HTML **200**, which must not be mistaken for metadata.
- Fall back to the previous `<base>/oauth/*` construction when no metadata document is served, so older backends keep working.

REST needs no change here — `langsmith-go` v0.25.4 already strips a trailing `/api` or `/api/v1` from the configured base URL.

## Test Plan

- [x] Unit tests cover self-hosted-under-`/api`, bare-origin fallback, SaaS at root, HTML-200 rejection, missing-metadata error, and the legacy fallback
- [x] `langsmith auth login --api-url https://<self-hosted-host>` (bare origin, previously nginx 405) completes the device flow
- [x] `workspace list` and `project list` return real data with the resulting token, using the saved profile with no `--api-url`
- [x] Forced token refresh (backdated `expires_at`) re-mints and persists a new token
- [x] SaaS discovery resolves at the origin in a single request
- [x] Remote MCP on the same deployment: the protected-resource document at `/api/.well-known/oauth-protected-resource/mcp` names `<origin>/api` as its authorization server, i.e. the issuer this discovery resolves; a token minted with `resource=<origin>/api/mcp` completes `initialize` and `tools/list` against `/api/mcp`