### PR TITLE
fix(profile): let an explicit --profile win over LANGSMITH_ENDPOINT

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -170,7 +170,11 @@ func resolveClientOptions(refreshOAuth bool) (client.Options, error) {
 	}
 
 	if v := os.Getenv("LANGSMITH_ENDPOINT"); v != "" {
-		opts.APIURL = client.NormalizeURL(v)
+		if flagProfile != "" && hasProfile && profile.APIURL != "" {
+			fmt.Fprintf(os.Stderr, "warning: ignoring LANGSMITH_ENDPOINT because profile %q was selected with --profile\n", profileName)
+		} else {
+			opts.APIURL = client.NormalizeURL(v)
+		}
 	}
 	if flagAPIURL != "" {
 		opts.APIURL = client.NormalizeURL(flagAPIURL)

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func isolateConfig(t *testing.T) {
@@ -542,4 +544,72 @@ func TestRootCmd_UnknownSubcommand(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for unknown subcommand")
 	}
+}
+
+// ---------- LANGSMITH_ENDPOINT vs explicit --profile ----------
+
+// setupEndpointProfiles isolates the package-level flag vars and writes a config
+// whose "dev" profile carries an api_url and whose "bare" profile omits one.
+func setupEndpointProfiles(t *testing.T, profile string) {
+	t.Helper()
+	oldKey, oldURL, oldProfile, oldWS := flagAPIKey, flagAPIURL, flagProfile, flagWorkspaceID
+	t.Cleanup(func() {
+		flagAPIKey, flagAPIURL, flagProfile, flagWorkspaceID = oldKey, oldURL, oldProfile, oldWS
+	})
+	flagAPIKey, flagAPIURL, flagWorkspaceID = "", "", ""
+	flagProfile = profile
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_WORKSPACE_ID", "")
+	t.Setenv("LANGSMITH_TENANT_ID", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "https://api.smith.langchain.com")
+	require.NoError(t, os.WriteFile(path, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_url": "https://dev.api.smith.langchain.com",
+      "api_key": "dev-key"
+    },
+    "bare": {
+      "api_key": "bare-key"
+    }
+  }
+}
+`), 0600))
+}
+
+func TestResolveClientOptions_ProfileFlagIgnoresEnvEndpoint(t *testing.T) {
+	setupEndpointProfiles(t, "dev")
+
+	opts, err := resolveClientOptions(false)
+	require.NoError(t, err)
+	require.Equal(t, "https://dev.api.smith.langchain.com", opts.APIURL)
+}
+
+func TestResolveClientOptions_ProfileFlagWithoutAPIURLHonorsEnvEndpoint(t *testing.T) {
+	setupEndpointProfiles(t, "bare")
+
+	opts, err := resolveClientOptions(false)
+	require.NoError(t, err)
+	require.Equal(t, "https://api.smith.langchain.com", opts.APIURL)
+}
+
+func TestResolveClientOptions_ImplicitProfileHonorsEnvEndpoint(t *testing.T) {
+	setupEndpointProfiles(t, "")
+
+	opts, err := resolveClientOptions(false)
+	require.NoError(t, err)
+	require.Equal(t, "https://api.smith.langchain.com", opts.APIURL)
+}
+
+func TestResolveClientOptions_APIURLFlagBeatsProfileEndpoint(t *testing.T) {
+	setupEndpointProfiles(t, "dev")
+	flagAPIURL = "https://flag.example.com"
+
+	opts, err := resolveClientOptions(false)
+	require.NoError(t, err)
+	require.Equal(t, "https://flag.example.com", opts.APIURL)
 }

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -140,7 +140,11 @@ func ResolveClientOptions(cmd *cobra.Command, refreshOAuth bool) (client.Options
 	}
 
 	if v := os.Getenv("LANGSMITH_ENDPOINT"); v != "" {
-		opts.APIURL = client.NormalizeURL(v)
+		if flagProfile != "" && hasProfile && profile.APIURL != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: ignoring LANGSMITH_ENDPOINT because profile %q was selected with --profile\n", profileName)
+		} else {
+			opts.APIURL = client.NormalizeURL(v)
+		}
 	}
 	if v := getFlagString(cmd, "api-url"); v != "" {
 		opts.APIURL = client.NormalizeURL(v)

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -475,3 +475,85 @@ func TestResolveClientOptions_ProfileEnvTrimsWhitespace(t *testing.T) {
 		t.Fatalf("expected profile API key, got %q", opts.APIKey)
 	}
 }
+
+// writeEndpointConfig writes a config whose "dev" profile carries an api_url and
+// whose "bare" profile omits one.
+func writeEndpointConfig(t *testing.T) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_WORKSPACE_ID", "")
+	t.Setenv("LANGSMITH_TENANT_ID", "")
+	t.Setenv("LANGSMITH_PROFILE", "")
+	require.NoError(t, os.WriteFile(path, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_url": "https://dev.api.smith.langchain.com",
+      "api_key": "dev-key"
+    },
+    "bare": {
+      "api_key": "bare-key"
+    }
+  }
+}
+`), 0600))
+}
+
+func TestResolveClientOptions_ProfileFlagIgnoresEnvEndpoint(t *testing.T) {
+	writeEndpointConfig(t)
+	t.Setenv("LANGSMITH_ENDPOINT", "https://api.smith.langchain.com")
+
+	cmd := newTestCmd()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	require.NoError(t, cmd.PersistentFlags().Set("profile", "dev"))
+
+	opts, err := ResolveClientOptions(cmd, false)
+	require.NoError(t, err)
+	require.Equal(t, "https://dev.api.smith.langchain.com", opts.APIURL)
+	require.Contains(t, stderr.String(), `warning: ignoring LANGSMITH_ENDPOINT because profile "dev" was selected with --profile`)
+}
+
+func TestResolveClientOptions_ProfileFlagWithoutAPIURLHonorsEnvEndpoint(t *testing.T) {
+	writeEndpointConfig(t)
+	t.Setenv("LANGSMITH_ENDPOINT", "https://api.smith.langchain.com")
+
+	cmd := newTestCmd()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	require.NoError(t, cmd.PersistentFlags().Set("profile", "bare"))
+
+	opts, err := ResolveClientOptions(cmd, false)
+	require.NoError(t, err)
+	require.Equal(t, "https://api.smith.langchain.com", opts.APIURL)
+	require.Empty(t, stderr.String())
+}
+
+func TestResolveClientOptions_ImplicitProfileHonorsEnvEndpoint(t *testing.T) {
+	writeEndpointConfig(t)
+	t.Setenv("LANGSMITH_ENDPOINT", "https://api.smith.langchain.com")
+
+	cmd := newTestCmd()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	opts, err := ResolveClientOptions(cmd, false)
+	require.NoError(t, err)
+	require.Equal(t, "https://api.smith.langchain.com", opts.APIURL)
+	require.Empty(t, stderr.String())
+}
+
+func TestResolveClientOptions_APIURLFlagBeatsProfile(t *testing.T) {
+	writeEndpointConfig(t)
+	t.Setenv("LANGSMITH_ENDPOINT", "https://api.smith.langchain.com")
+
+	cmd := newTestCmd()
+	require.NoError(t, cmd.PersistentFlags().Set("profile", "dev"))
+	require.NoError(t, cmd.PersistentFlags().Set("api-url", "https://flag.example.com"))
+
+	opts, err := ResolveClientOptions(cmd, false)
+	require.NoError(t, err)
+	require.Equal(t, "https://flag.example.com", opts.APIURL)
+}


### PR DESCRIPTION
## What

`LANGSMITH_ENDPOINT` silently overrode the `api_url` of a profile selected explicitly on the command line, so `--profile dev` would route to whatever host the environment named and fail with `401 Unauthorized` — with nothing in the output explaining why.

When `--profile` names a profile that supplies `api_url`, the env var is now ignored and a warning goes to stderr:

```
warning: ignoring LANGSMITH_ENDPOINT because profile "dev" was selected with --profile
```

Applied to both resolvers: `resolveClientOptions` in `internal/cmd/root.go` (main CLI) and `ResolveClientOptions` in `internal/cmdutil/resolve.go` (`langsmith api` and the sandbox helpers).

This mirrors the treatment `LANGSMITH_API_KEY` already had, except that env var only warned while still taking precedence.

## Boundaries

- `--api-url` still wins — this is scoped to env vars.
- A profile resolved implicitly from `current_profile` or `LANGSMITH_PROFILE` is not "selected on the command line", so env vars still override those. Prior behavior preserved.
- An env var filling a field the profile omits is still honored; "conflict" means the profile actually sets `api_url`.

Narrower than #195, which covers the same ground for `LANGSMITH_API_KEY`, `LANGSMITH_TENANT_ID`/`LANGSMITH_WORKSPACE_ID` and `LANGSMITH_PROFILE` as well. That PR has been open since 2026-07-22 with green checks; this one can land independently or be dropped in its favour.

## Test Plan

- [x] `TestResolveClientOptions_ProfileFlagIgnoresEnvEndpoint` in both packages — profile `api_url` wins, warning emitted
- [x] `TestResolveClientOptions_ProfileFlagWithoutAPIURLHonorsEnvEndpoint` — env still honored when the profile omits `api_url`, no warning
- [x] `TestResolveClientOptions_ImplicitProfileHonorsEnvEndpoint` — implicit profiles keep the old precedence
- [x] `TestResolveClientOptions_APIURLFlagBeatsProfile` — `--api-url` still overrides
- [x] Verified all new tests fail against unmodified source (both report `api.smith.langchain.com` where `dev.api.smith.langchain.com` was expected)
- [x] `gofmt -l`, `go build ./...`, and `go test ./internal/cmd/... ./internal/cmdutil/...` pass
- [x] Verified with a locally installed binary and `LANGSMITH_ENDPOINT` exported: `langsmith --profile dev sandbox list` now warns and targets the dev host
