### PR TITLE
fix(auth): point users at 'langsmith auth login' in cmdutil errors

### DIFF
--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -101,7 +101,7 @@ func GetClient(cmd *cobra.Command) (*client.Client, error) {
 		return nil, err
 	}
 	if opts.APIKey == "" && opts.OAuthAccessToken == "" {
-		return nil, fmt.Errorf("not authenticated; run 'langsmith login', set LANGSMITH_API_KEY, or pass --api-key")
+		return nil, fmt.Errorf("not authenticated; run 'langsmith auth login', set LANGSMITH_API_KEY, or pass --api-key")
 	}
 	return client.NewWithOptions(opts), nil
 }
@@ -175,7 +175,7 @@ func ResolveClientOptions(cmd *cobra.Command, refreshOAuth bool) (client.Options
 			}
 			token, err := refreshProfileToken(ctx, opts.APIURL, profile.OAuth.RefreshToken)
 			if err != nil {
-				return opts, fmt.Errorf("refreshing OAuth token for profile %q: %w; run 'langsmith login --profile %s' to reauthenticate", profileName, err, profileName)
+				return opts, fmt.Errorf("refreshing OAuth token for profile %q: %w; run 'langsmith auth login --profile %s' to reauthenticate", profileName, err, profileName)
 			}
 			applyTokenResponse(&profile, token, time.Now())
 			cfg.Profiles[profileName] = profile

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -125,6 +125,8 @@ func TestGetClient_MissingKey(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing API key")
 	}
+	// "langsmith login" is not a command; the OAuth flow lives under "auth".
+	require.Contains(t, err.Error(), "langsmith auth login")
 }
 
 func TestGetClient_ProfileBearer(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,7 +24,7 @@ type Profile struct {
 	OAuth       OAuth  `json:"oauth,omitempty"`
 }
 
-// OAuth stores OAuth tokens written by `langsmith login`.
+// OAuth stores OAuth tokens written by `langsmith auth login`.
 type OAuth struct {
 	AccessToken  string `json:"access_token,omitempty"`
 	RefreshToken string `json:"refresh_token,omitempty"`


### PR DESCRIPTION
## What

The auth-failure messages in `internal/cmdutil` told users to run `langsmith login`, which is not a command:

```
$ langsmith login
unknown command "login" for "langsmith"
```

The OAuth flow lives under `langsmith auth login`. `internal/cmd/root.go` and `internal/cmd/auth.go` already had the correct text; only `internal/cmdutil/resolve.go` — the resolver behind the `api`, `sandbox` and `ssh` subcommands — was wrong. That is the path that surfaces the hint when a sandbox command hits an expired or revoked token, so the bad advice is what a user actually sees:

```
refreshing OAuth token for profile "dev": invalid_grant: refresh token has been revoked; run 'langsmith login --profile dev' to reauthenticate
```

Two error strings and one stale doc comment on the `OAuth` struct.

## Test Plan

- [x] `TestGetClient_MissingKey` now asserts the message names `langsmith auth login`
- [x] Confirmed `langsmith login` exits non-zero with `unknown command "login" for "langsmith"`, and that the root command tree exposes `auth` but no `login`
- [x] `gofmt -l`, `go build ./...`, `go test ./internal/cmdutil/... ./internal/config/...` pass

## Note

`docs/superpowers/specs/2026-04-03-profiles-design.md` also mentions `langsmith login`, but as a point-in-time design note listing it under "future work". Left as-is rather than rewriting a historical spec.
