### PR TITLE
feat(issues): allow any lifecycle status on update, and record a reason

### DIFF
--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -52,6 +52,18 @@ func issueStatusList() string {
 	return strings.Join(names, ", ")
 }
 
+// validIssueUpdateStatus reports whether this is a state an issue can hold. It
+// uses the resource's own IssueStatus rather than the list filter's enum: the
+// question here is what an issue may become, not what may be filtered on.
+//
+// Which transitions a given caller may make is the server's decision, not the
+// CLI's — it varies by the caller's role, so a client-side allow-list here would
+// either forbid something the server permits or imply something it doesn't. This
+// only catches typos before a round-trip, the same way the list filter does.
+func validIssueUpdateStatus(status string) bool {
+	return langsmith.IssueStatus(status).IsKnown()
+}
+
 // issuePriorities mirrors the keys priorityToSeverity accepts, for its message.
 var issuePriorities = []string{"urgent", "high", "medium", "low"}
 
@@ -348,6 +360,7 @@ func newProjectIssuesUpdateCmd() *cobra.Command {
 		proposedFix string
 		evaluator   string
 		status      string
+		reason      string
 		outputFile  string
 	)
 
@@ -363,11 +376,12 @@ The issue ID is the UUID returned by 'langsmith project issues list'.
 --name and --description are for factual corrections only (when new evidence disproves the original finding).
 --proposed-fix updates the suggested code fix shown to users.
 --evaluator replaces the suggested evaluator. Pass the evaluator config as JSON — the CLI wraps it automatically.
---status reopens a resolved issue. The only accepted value is 'open' — closing an issue is a human action done via the UI.
+--status sets the issue's lifecycle state: open, fixing, watching, completed, or ignored ('ignored' is shown as "Incorrectly Flagged"). Pass --reason to record why; it is stored on the issue's history alongside who made the change. Which transitions you may make depends on your role — the server rejects the ones you may not.
 
 Examples:
   langsmith project issues update <id> --name "Corrected name" --description "New finding..."
   langsmith project issues update <id> --status open
+  langsmith project issues update <id> --status ignored --reason "Duplicate of 1ac6dbe2 — same root cause, one fix closes both"
   langsmith project issues update <id> --proposed-fix "Root cause: missing null check.\n\` + "`" + `` + "`" + `diff\n-if result:\n+if result is not None:\n` + "`" + `` + "`" + `"
   langsmith project issues update <id> --evaluator '{"type":"llm","display_name":"no_hallucination","prompt":[["system","Evaluate whether the response contains hallucinated facts. Score 1 if grounded, 0 if not."],["user","Evaluate and score."]],"schema":{"type":"object","properties":{"score":{"type":"integer","minimum":0,"maximum":1},"reasoning":{"type":"string"}},"required":["score","reasoning"]}}'
   langsmith project issues update <id> --evaluator '{"type":"code","display_name":"no_tool_errors","code_evaluators":[{"code":"def perform_eval(run, example=None):\n    out = str((run.outputs or {}).get(\"output\",\"\")).lower()\n    return {\"score\": 0 if \"error\" in out else 1, \"key\": \"no_tool_errors\"}","language":"python"}]}'`,
@@ -377,8 +391,11 @@ Examples:
 			if name == "" && description == "" && proposedFix == "" && evaluator == "" && status == "" {
 				ExitError("at least one of --name, --description, --proposed-fix, --evaluator, or --status is required")
 			}
-			if status != "" && status != "open" {
-				ExitError("--status only accepts 'open' — closing an issue is done via the UI")
+			if status != "" && !validIssueUpdateStatus(status) {
+				ExitErrorf("invalid --status %q: must be one of %s", status, issueStatusList())
+			}
+			if reason != "" && status == "" {
+				ExitError("--reason describes a status change; pass it with --status")
 			}
 
 			c := MustGetClient()
@@ -396,6 +413,9 @@ Examples:
 			}
 			if status != "" {
 				body["status"] = status
+			}
+			if reason != "" {
+				body["reason"] = reason
 			}
 			if evaluator != "" {
 				var evalConfig map[string]any
@@ -439,7 +459,8 @@ Examples:
 	cmd.Flags().StringVar(&name, "name", "", "Corrected name (use only when original is factually wrong)")
 	cmd.Flags().StringVar(&description, "description", "", "Corrected description (use only when original is factually wrong)")
 	cmd.Flags().StringVar(&proposedFix, "proposed-fix", "", "Updated proposed fix (markdown with code diff)")
-	cmd.Flags().StringVar(&status, "status", "", "Reopen a resolved issue. Only 'open' is accepted — closing is done via the UI")
+	cmd.Flags().StringVar(&status, "status", "", "New lifecycle state: open, fixing, watching, completed, or ignored")
+	cmd.Flags().StringVar(&reason, "reason", "", "Why the status changed, recorded on the issue's history. Use with --status")
 	cmd.Flags().StringVar(&evaluator, "evaluator", "", `Replace the suggested evaluator. JSON with "type" ("llm" or "code"), "display_name", and type-specific fields`)
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 

--- a/internal/cmd/issues_test.go
+++ b/internal/cmd/issues_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -181,5 +182,49 @@ func TestParseAssertion_Invalid(t *testing.T) {
 		if err == nil {
 			t.Errorf("parseAssertion(%q) [%s]: expected error, got nil", tc.input, tc.desc)
 		}
+	}
+}
+
+// ==================== Update status and reason ====================
+
+// The update command used to hard-reject anything but "open" client-side, so a
+// dismissal never reached the server. Which transitions a caller may make is
+// role-dependent and belongs to the server; this only catches typos.
+func TestValidIssueUpdateStatus(t *testing.T) {
+	for _, status := range []string{"open", "fixing", "watching", "completed", "ignored"} {
+		if !validIssueUpdateStatus(status) {
+			t.Errorf("validIssueUpdateStatus(%q) = false, want true", status)
+		}
+	}
+	for _, status := range []string{"closed", "dismissed", "resolved", "Open", "", "bogus"} {
+		if validIssueUpdateStatus(status) {
+			t.Errorf("validIssueUpdateStatus(%q) = true, want false", status)
+		}
+	}
+}
+
+func TestProjectIssuesUpdateCmd_Flags(t *testing.T) {
+	cmd := newProjectIssuesUpdateCmd()
+	for _, name := range []string{"name", "description", "proposed-fix", "status", "reason", "evaluator"} {
+		if f := cmd.Flags().Lookup(name); f == nil {
+			t.Errorf("flag --%s not found", name)
+		} else if f.DefValue != "" {
+			t.Errorf("flag --%s: expected empty default, got %q", name, f.DefValue)
+		}
+	}
+}
+
+// The old help text told callers closing was UI-only. Leaving that in place
+// while the server accepts a dismissal is how the --title flag went stale for
+// months: documented, never accepted, failing quietly.
+func TestProjectIssuesUpdateCmd_HelpDocumentsDismissal(t *testing.T) {
+	cmd := newProjectIssuesUpdateCmd()
+	for _, want := range []string{"ignored", "Incorrectly Flagged", "--reason"} {
+		if !strings.Contains(cmd.Long, want) {
+			t.Errorf("update help does not mention %q", want)
+		}
+	}
+	if strings.Contains(cmd.Long, "only accepted value is 'open'") {
+		t.Error("update help still claims only 'open' is accepted")
 	}
 }


### PR DESCRIPTION
## Description

`langsmith project issues update` rejected every `--status` except `open` in the CLI itself, with the message "closing an issue is done via the UI". Two things were wrong with that:

- The API accepts all five states, and the UI's **Incorrectly Flagged** button is an ordinary `PATCH /issues/{id}` with `status=ignored`. The CLI was the only place the operation was unavailable.
- Because the rejection was client-side, the request never reached the server to be judged. Whether a given caller may make a given transition is role-dependent — the server already enforces it — so the CLI was pre-empting a decision it doesn't own, and getting it wrong for anyone allowed to make it.

Validation now just catches typos before a round-trip, delegating to the SDK's `IsKnown` the same way the `list --status` filter already does. `issueStatusList()` supplies the message.

Also adds `--reason`. The update body had no way to send one, so a status change through the CLI was always unexplained; the server records it on the issue's status-change history alongside who made the change. It requires `--status`, since that is the only thing it annotates.

### Note for reviewers

This widens what the CLI can do: previously `completed`, `fixing`, and `watching` were unreachable through it, and now they aren't. That matches the API and the UI rather than adding anything new, but it is a real behavior change and worth a look. The help text's claim that closing is UI-only is removed, since it is no longer true.

Motivation is Engine dismissing duplicate issues it filed earlier — it can identify them but has no way to act, since a bespoke tool would duplicate a CLI verb that should exist anyway. The server-side permission change for that lands separately in langchainplus; this PR is useful on its own for anyone triaging a board from the terminal.

## Test Plan

- [x] `validIssueUpdateStatus` accepts all five states and rejects `closed`, `dismissed`, `resolved`, wrong case, and empty
- [x] `--reason` is registered and rejected without `--status`
- [x] Help text documents `ignored` / Incorrectly Flagged and no longer claims only `open` is accepted
- [x] Full suite green (`go test ./...`); `gofmt` and `go vet` clean
- [ ] Manual check against a real board once released: `issues update <id> --status ignored --reason "..."` and confirm the reason appears in the issue's history

Note: `internal/cmdutil.TestResolveAPIURL_Default` fails when `LANGSMITH_ENDPOINT` is set in the environment — pre-existing and unrelated, passes with it unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
