### PR TITLE
feat(custom-apps): linking back to LangSmith [LSDK-431]

### DIFF
--- a/internal/cmd/apps.go
+++ b/internal/cmd/apps.go
@@ -132,6 +132,17 @@ func customAppWebURL(apiURL, workspaceID, appID string) string {
 	return u.Scheme + "://" + host + "/o/" + workspaceID + "/custom-apps/" + appID
 }
 
+// langsmithWebOrigin maps an API URL to its UI origin.
+func langsmithWebOrigin(apiURL string) string {
+	u, err := url.Parse(apiURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	host := strings.TrimPrefix(u.Host, "api.")
+	host = strings.Replace(host, ".api.", ".", 1)
+	return u.Scheme + "://" + host
+}
+
 // readAppLink returns (nil, nil) if not linked yet.
 func readAppLink(dir string) (*appLink, error) {
 	path := filepath.Join(dir, appsLinkDir, appsLinkFile)

--- a/internal/cmd/apps_dev.go
+++ b/internal/cmd/apps_dev.go
@@ -736,8 +736,15 @@ const devHostHTMLTemplate = `<!doctype html>
         var target = new URL(String(msg.url), base);
         if (target.origin === base.origin) href = target.href;
       } catch (e) {}
-      if (href) window.open(href, '_blank', 'noopener');
-      else console.warn('[langsmith apps dev] openUrl blocked (not a LangSmith URL):', msg.url);
+      if (!href) {
+        console.warn('[langsmith apps dev] openUrl blocked (not a LangSmith URL):', msg.url);
+      } else if (msg.newTab) {
+        window.open(href, '_blank', 'noopener,noreferrer');
+      } else {
+        // Prod soft-navigates in place; dev leaves the harness.
+        console.log('[langsmith apps dev] openUrl navigating away:', href);
+        window.location.assign(href);
+      }
     }
 
     if (msg.type === 'LS_LOG') {
@@ -980,8 +987,12 @@ pre, code {
     reportHeight();
   }
 
-  function openUrl(url) {
-    window.parent.postMessage({ type: 'LS_NAVIGATE', url: String(url) }, '*');
+  function openUrl(url, options) {
+    window.parent.postMessage({
+      type: 'LS_NAVIGATE',
+      url: String(url),
+      newTab: !!(options && options.newTab)
+    }, '*');
   }
 
   window.langsmith = {

--- a/internal/cmd/apps_dev.go
+++ b/internal/cmd/apps_dev.go
@@ -219,6 +219,13 @@ func prepareAppsDevServer(c *client.Client, dir, entrypoint string) (srv *http.S
 		return nil, nil, "", err
 	}
 
+	var apiURL string
+	if c != nil {
+		apiURL = c.APIURL()
+	}
+	workspaceID := GetWorkspaceID()
+	webOrigin := langsmithWebOrigin(apiURL)
+
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -238,7 +245,7 @@ func prepareAppsDevServer(c *client.Client, dir, entrypoint string) (srv *http.S
 			_, _ = w.Write([]byte(devWaitingHTML(fmt.Sprintf("entrypoint %q does not exist yet in %s — waiting for the initial build to finish", entrypoint, dir))))
 			return
 		}
-		_, _ = w.Write([]byte(renderDevHostHTML(files, entrypoint, token)))
+		_, _ = w.Write([]byte(renderDevHostHTML(files, entrypoint, token, workspaceID, webOrigin)))
 	})
 
 	mux.HandleFunc("/__ls_dev/mtime", func(w http.ResponseWriter, r *http.Request) {
@@ -522,9 +529,11 @@ setInterval(function() {
 
 // renderDevHostHTML builds the top-level host page: the sandboxed iframe
 // plus the postMessage bridge and a Light/Dark mode toolbar.
-func renderDevHostHTML(files map[string]string, entrypoint, token string) string {
+func renderDevHostHTML(files map[string]string, entrypoint, token, workspaceID, webOrigin string) string {
 	filesJSON, _ := json.Marshal(files)
 	entrypointJSON, _ := json.Marshal(entrypoint)
+	workspaceIDJSON, _ := json.Marshal(workspaceID)
+	webOriginJSON, _ := json.Marshal(webOrigin)
 
 	inner := strings.NewReplacer(
 		"__FILES_JSON__", escapeForScript(filesJSON),
@@ -534,6 +543,8 @@ func renderDevHostHTML(files map[string]string, entrypoint, token string) string
 	return strings.NewReplacer(
 		"__SANDBOX_SRCDOC__", html.EscapeString(inner),
 		"__LS_DEV_TOKEN__", token,
+		"__LS_WORKSPACE_ID_JSON__", escapeForScript(workspaceIDJSON),
+		"__LS_WEB_ORIGIN_JSON__", escapeForScript(webOriginJSON),
 	).Replace(devHostHTMLTemplate)
 }
 
@@ -659,8 +670,13 @@ const devHostHTMLTemplate = `<!doctype html>
     if (darkBtn) darkBtn.setAttribute('aria-pressed', mode === 'dark' ? 'true' : 'false');
   }
 
+  var webOrigin = __LS_WEB_ORIGIN_JSON__;
+
   function postMetadata() {
-    post({ type: 'LANGSMITH_METADATA', metadata: { mode: mode } });
+    post({
+      type: 'LANGSMITH_METADATA',
+      metadata: { mode: mode, workspaceId: __LS_WORKSPACE_ID_JSON__, host: webOrigin },
+    });
   }
 
   function setMode(next) {
@@ -692,6 +708,17 @@ const devHostHTMLTemplate = `<!doctype html>
 
     if (msg.type === 'LS_MUTATION') {
       console.log('[langsmith apps dev] setData (not persisted locally):', msg.patch);
+    }
+
+    if (msg.type === 'LS_NAVIGATE') {
+      var href = '';
+      try {
+        var base = new URL(webOrigin);
+        var target = new URL(String(msg.url), base);
+        if (target.origin === base.origin) href = target.href;
+      } catch (e) {}
+      if (href) window.open(href, '_blank', 'noopener');
+      else console.warn('[langsmith apps dev] openUrl blocked (not a LangSmith URL):', msg.url);
     }
 
     if (msg.type === 'LS_LOG') {
@@ -934,9 +961,14 @@ pre, code {
     reportHeight();
   }
 
+  function openUrl(url) {
+    window.parent.postMessage({ type: 'LS_NAVIGATE', url: String(url) }, '*');
+  }
+
   window.langsmith = {
     call: call,
     setData: setData,
+    openUrl: openUrl,
     feedback: {
       create: function(args) { return call('POST /api/v1/feedback', { body: args }); }
     }

--- a/internal/cmd/apps_dev.go
+++ b/internal/cmd/apps_dev.go
@@ -22,6 +22,8 @@ import (
 	"syscall"
 	"time"
 
+	langsmith "github.com/langchain-ai/langsmith-go"
+
 	"github.com/langchain-ai/langsmith-cli/internal/client"
 	"github.com/langchain-ai/langsmith-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -210,6 +212,23 @@ func packageJSONScript(dir, name string) (script string, pkgJSONExists bool, err
 	return pkg.Scripts[name], true, nil
 }
 
+// resolveDevWorkspaceID falls back to the API when none is configured.
+func resolveDevWorkspaceID(c *client.Client) string {
+	if id := GetWorkspaceID(); id != "" {
+		return id
+	}
+	if c == nil || c.SDK == nil {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	workspaces, err := c.SDK.Workspaces.List(ctx, langsmith.WorkspaceListParams{})
+	if err != nil || workspaces == nil || len(*workspaces) != 1 {
+		return ""
+	}
+	return (*workspaces)[0].ID
+}
+
 // prepareAppsDevServer builds (but does not start) an HTTP server on
 // 127.0.0.1 serving the sandboxed preview ("/"), a rebuild-poll endpoint
 // ("/__ls_dev/mtime"), and the API proxy ("/__ls_dev/call").
@@ -223,7 +242,7 @@ func prepareAppsDevServer(c *client.Client, dir, entrypoint string) (srv *http.S
 	if c != nil {
 		apiURL = c.APIURL()
 	}
-	workspaceID := GetWorkspaceID()
+	workspaceID := resolveDevWorkspaceID(c)
 	webOrigin := langsmithWebOrigin(apiURL)
 
 	mux := http.NewServeMux()

--- a/internal/cmd/templates/agents-md/_common.md
+++ b/internal/cmd/templates/agents-md/_common.md
@@ -106,10 +106,10 @@ Combine with `and(...)` / `or(...)`; other examples: `has(tags, "prod")`,
 
 ## Linking back to LangSmith
 
-`window.langsmith.openUrl(url)` opens a LangSmith URL in a new tab — pass an
-absolute URL or a path. The app can't navigate on its own; the host resolves the
-URL and rejects anything outside LangSmith, so `<a href>` and `window.open`
-won't work.
+`window.langsmith.openUrl(url)` navigates LangSmith to a URL — pass an absolute
+URL or a path. Pass `{ newTab: true }` as a second argument to open it in a new
+tab instead. The app can't navigate on its own; the host resolves the URL and
+rejects anything outside LangSmith, so `<a href>` and `window.open` won't work.
 
 For a run or trace, ask the API for the URL rather than building one:
 

--- a/internal/cmd/templates/agents-md/_common.md
+++ b/internal/cmd/templates/agents-md/_common.md
@@ -104,6 +104,39 @@ and(eq(metadata_key, "ls_agent_purpose"), eq(metadata_value, "coding"))
 Combine with `and(...)` / `or(...)`; other examples: `has(tags, "prod")`,
 `eq(name, "ChatOpenAI")`, `eq(is_root, true)`.
 
+## Linking back to LangSmith
+
+`window.langsmith.openUrl(url)` opens a LangSmith URL in a new tab — pass an
+absolute URL or a path. The app can't navigate on its own; the host resolves the
+URL and rejects anything outside LangSmith, so `<a href>` and `window.open`
+won't work.
+
+For a run or trace, ask the API for the URL rather than building one:
+
+```ts
+const { url } = await window.langsmith.call(`GET /api/v2/runs/${runId}/url`, {
+  params: { project_id: projectId, trace_id: traceId },
+});
+window.langsmith.openUrl(url);
+```
+
+Both params are required. This resolves host and workspace server-side, so it
+stays correct on self-hosted and EU.
+
+Build everything else from `metadata.host` and `metadata.workspaceId` — never
+hardcode `smith.langchain.com`:
+
+| Target | Path |
+| --- | --- |
+| Project | `/o/{workspaceId}/projects/p/{projectId}` |
+| Dataset | `/o/{workspaceId}/datasets/{datasetId}` |
+| Example | `/o/{workspaceId}/datasets/{datasetId}/e/{exampleId}` |
+| Experiment | `/o/{workspaceId}/datasets/{datasetId}/compare?selectedSessions={sessionId}` |
+| Annotation queue | `/o/{workspaceId}/annotation-queues/{queueId}` |
+
+The `/o/` segment is the workspace ID despite reading like an organization ID.
+Experiments have no standalone route — they're a compare view on their dataset.
+
 <!-- TEMPLATE-SPECIFIC -->
 
 ## More of the LangSmith API (starting points, not exhaustive)


### PR DESCRIPTION
Dev-server parity + agent docs for langchain-ai/langchainplus#33240.

- `metadata` now carries `workspaceId` + `host` alongside `mode`, mirroring the prod sandbox
- adds `window.langsmith.openUrl(url)` and the `LS_NAVIGATE` handler; non-LangSmith URLs are rejected with a console warning
- documents linking in `_common.md`: `GET /api/v2/runs/{run_id}/url` for runs/traces, plus URL patterns for projects, datasets, examples, experiments, queues
- `apps dev` takes the workspace ID from config, falling back to `Workspaces.List` when unset

Docs describe `metadata.workspaceId`, which only exists in prod once #33240 lands — these should merge together.