### PR TITLE
feat(custom-apps): deny sensitive API paths [LSDK-450]

### DIFF
--- a/internal/cmd/apps_dev.go
+++ b/internal/cmd/apps_dev.go
@@ -743,6 +743,7 @@ const sandboxInnerHTMLTemplate = `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'unsafe-inline'; img-src data: blob:;">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style id="ls-theme">/* theme injected via postMessage */</style>
 <style>

--- a/internal/cmd/apps_dev.go
+++ b/internal/cmd/apps_dev.go
@@ -357,6 +357,9 @@ var deniedProxyPathPattern = regexp.MustCompile(
 	`(?i)(^|/)(api-key|api-keys|members|users|identities|roles|permissions|scim|service-accounts)(/|$)`,
 )
 
+// Batch ID lookups; apps need these to render names.
+var allowedProxyPathExceptions = regexp.MustCompile(`(?i)/(users|identities)/info$`)
+
 func handleLsDevCall(c *client.Client, w http.ResponseWriter, r *http.Request, req lsDevCallRequest) {
 
 	spaceIdx := strings.IndexByte(req.Operation, ' ')
@@ -376,7 +379,7 @@ func handleLsDevCall(c *client.Client, w http.ResponseWriter, r *http.Request, r
 		http.Error(w, fmt.Sprintf("path %q must be a relative path starting with \"/\"", path), http.StatusBadRequest)
 		return
 	}
-	if deniedProxyPathPattern.MatchString(pathPart) {
+	if !allowedProxyPathExceptions.MatchString(pathPart) && deniedProxyPathPattern.MatchString(pathPart) {
 		http.Error(w, fmt.Sprintf("path %q is not available to custom apps", pathPart), http.StatusForbidden)
 		return
 	}

--- a/internal/cmd/apps_dev.go
+++ b/internal/cmd/apps_dev.go
@@ -352,6 +352,11 @@ func makeLsDevLogHandler(token string) http.HandlerFunc {
 
 var proxyPathPattern = regexp.MustCompile(`^/[A-Za-z0-9/_-]*$`)
 
+// Mirrors smith-frontend apiProxy.ts DENIED_PATH_SEGMENTS.
+var deniedProxyPathPattern = regexp.MustCompile(
+	`(?i)(^|/)(api-key|api-keys|members|users|identities|roles|permissions|scim|service-accounts)(/|$)`,
+)
+
 func handleLsDevCall(c *client.Client, w http.ResponseWriter, r *http.Request, req lsDevCallRequest) {
 
 	spaceIdx := strings.IndexByte(req.Operation, ' ')
@@ -369,6 +374,10 @@ func handleLsDevCall(c *client.Client, w http.ResponseWriter, r *http.Request, r
 	pathPart, queryPart, hasQuery := strings.Cut(path, "?")
 	if !proxyPathPattern.MatchString(pathPart) || strings.ContainsAny(pathPart, `%\`) || strings.Contains(pathPart, "..") {
 		http.Error(w, fmt.Sprintf("path %q must be a relative path starting with \"/\"", path), http.StatusBadRequest)
+		return
+	}
+	if deniedProxyPathPattern.MatchString(pathPart) {
+		http.Error(w, fmt.Sprintf("path %q is not available to custom apps", pathPart), http.StatusForbidden)
 		return
 	}
 	if len(req.Args.Params) > 0 {

--- a/internal/cmd/apps_dev.go
+++ b/internal/cmd/apps_dev.go
@@ -743,7 +743,7 @@ const sandboxInnerHTMLTemplate = `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'unsafe-inline'; img-src data: blob:;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'unsafe-inline'; img-src data: blob:; form-action 'none'; base-uri 'none';">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style id="ls-theme">/* theme injected via postMessage */</style>
 <style>

--- a/internal/cmd/apps_dev_denylist_test.go
+++ b/internal/cmd/apps_dev_denylist_test.go
@@ -8,12 +8,12 @@ func TestDeniedProxyPathPattern(t *testing.T) {
 		"/api/v1/api-keys/abc",
 		"/api/v1/orgs/current/members",
 		"/api/v1/orgs/current/roles",
-		"/api/v1/workspaces/current/users/info",
 		"/api/v1/workspaces/current/identities",
+		"/api/v1/workspaces/current/users/search",
 		"/scim/v2/Users",
 	}
 	for _, path := range denied {
-		if !deniedProxyPathPattern.MatchString(path) {
+		if allowedProxyPathExceptions.MatchString(path) || !deniedProxyPathPattern.MatchString(path) {
 			t.Errorf("expected %q to be denied", path)
 		}
 	}
@@ -24,9 +24,11 @@ func TestDeniedProxyPathPattern(t *testing.T) {
 		"/api/v1/feedback",
 		"/v2/runs/query",
 		"/api/v1/annotation-queues/abc/runs",
+		"/api/v1/workspaces/current/users/info",
+		"/api/v1/workspaces/current/identities/info",
 	}
 	for _, path := range allowed {
-		if deniedProxyPathPattern.MatchString(path) {
+		if !allowedProxyPathExceptions.MatchString(path) && deniedProxyPathPattern.MatchString(path) {
 			t.Errorf("expected %q to be allowed", path)
 		}
 	}

--- a/internal/cmd/apps_dev_denylist_test.go
+++ b/internal/cmd/apps_dev_denylist_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import "testing"
+
+func TestDeniedProxyPathPattern(t *testing.T) {
+	denied := []string{
+		"/api/v1/api-key",
+		"/api/v1/api-keys/abc",
+		"/api/v1/orgs/current/members",
+		"/api/v1/orgs/current/roles",
+		"/api/v1/workspaces/current/users/info",
+		"/api/v1/workspaces/current/identities",
+		"/scim/v2/Users",
+	}
+	for _, path := range denied {
+		if !deniedProxyPathPattern.MatchString(path) {
+			t.Errorf("expected %q to be denied", path)
+		}
+	}
+
+	allowed := []string{
+		"/api/v1/sessions",
+		"/api/v1/datasets",
+		"/api/v1/feedback",
+		"/v2/runs/query",
+		"/api/v1/annotation-queues/abc/runs",
+	}
+	for _, path := range allowed {
+		if deniedProxyPathPattern.MatchString(path) {
+			t.Errorf("expected %q to be allowed", path)
+		}
+	}
+}


### PR DESCRIPTION
- Mirrors smith-frontend denylist in the dev proxy
- Blocks API keys, members, roles, SCIM paths
- Allows users/info and identities/info so names render
- Denied paths return 403 from the proxy
- Unit test covers denied and allowed paths