### PR TITLE
feat(issues): add --start-time to examples propose [LSEN-463]

### DIFF
--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -704,6 +704,21 @@ func parseAssertion(s string) (exampleAssertion, error) {
 	return exampleAssertion{Key: key, Comment: comment}, nil
 }
 
+// proposeExampleBody builds the request body for examples propose. start_time
+// is omitted rather than sent empty when the flag is unset, so this release can
+// ship ahead of the server change that reads it, leaving callers that don't
+// pass the flag on exactly their current request shape.
+func proposeExampleBody(runID, startTime string, assertions []exampleAssertion) map[string]any {
+	body := map[string]any{
+		"run_id":     runID,
+		"assertions": assertions,
+	}
+	if startTime != "" {
+		body["start_time"] = startTime
+	}
+	return body
+}
+
 func newProjectIssuesProposeExampleCmd() *cobra.Command {
 	var (
 		runID      string
@@ -725,6 +740,10 @@ agent, so it usually starts earlier in the trace. The server validates the
 run_id and start_time against the runs database and resolves the trace_id
 automatically.
 
+--start-time is how the server addresses the run. It is not enforced here, so
+this build still works against servers predating that lookup, which accept a
+bare run_id for a run already linked to the issue.
+
 Each --assertion flag takes a key=comment pair. The key is a short identifier
 for the assertion (e.g. "correctness"), and the comment describes what the run
 should demonstrate. You may specify up to 10 assertions; keys must be unique.
@@ -743,8 +762,8 @@ Examples:
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			issueID := args[0]
-			if runID == "" || startTime == "" {
-				ExitError("--run-id and --start-time are required")
+			if runID == "" {
+				ExitError("--run-id is required")
 			}
 			if len(assertions) == 0 {
 				ExitError("at least one --assertion is required")
@@ -770,11 +789,7 @@ Examples:
 			c := MustGetClient()
 			ctx := context.Background()
 
-			body := map[string]any{
-				"run_id":     runID,
-				"start_time": startTime,
-				"assertions": parsed,
-			}
+			body := proposeExampleBody(runID, startTime, parsed)
 
 			path := fmt.Sprintf("/api/v1/platform/issues/%s/proposed-examples", issueID)
 			var result map[string]any
@@ -787,7 +802,7 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&runID, "run-id", "", "Run ID to propose as a regression example (required)")
-	cmd.Flags().StringVar(&startTime, "start-time", "", "Run start time in RFC3339 format (required)")
+	cmd.Flags().StringVar(&startTime, "start-time", "", "Run start time in RFC3339 format (required by servers that resolve unlinked runs)")
 	cmd.Flags().StringArrayVar(&assertions, "assertion", nil, `Assertion in key=comment format. May be repeated up to 10 times.`)
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 	return cmd

--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -707,6 +707,7 @@ func parseAssertion(s string) (exampleAssertion, error) {
 func newProjectIssuesProposeExampleCmd() *cobra.Command {
 	var (
 		runID      string
+		startTime  string
 		assertions []string
 		outputFile string
 	)
@@ -718,6 +719,12 @@ func newProjectIssuesProposeExampleCmd() *cobra.Command {
 the run should satisfy. The issues agent uses these to generate evaluators
 and test cases for the issue.
 
+The run does not have to be linked to the issue as evidence. Evidence points a
+reviewer at where a failure is visible; an example is replayed against the
+agent, so it usually starts earlier in the trace. The server validates the
+run_id and start_time against the runs database and resolves the trace_id
+automatically.
+
 Each --assertion flag takes a key=comment pair. The key is a short identifier
 for the assertion (e.g. "correctness"), and the comment describes what the run
 should demonstrate. You may specify up to 10 assertions; keys must be unique.
@@ -725,17 +732,19 @@ should demonstrate. You may specify up to 10 assertions; keys must be unique.
 Examples:
   langsmith project issues examples propose <issue-id> \
     --run-id <run-id> \
+    --start-time 2026-04-10T00:00:00Z \
     --assertion correctness="Response must be factually correct"
 
   langsmith project issues examples propose <issue-id> \
     --run-id <run-id> \
+    --start-time 2026-04-10T00:00:00Z \
     --assertion correctness="Must cite sources" \
     --assertion format="Output must be valid JSON"`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			issueID := args[0]
-			if runID == "" {
-				ExitError("--run-id is required")
+			if runID == "" || startTime == "" {
+				ExitError("--run-id and --start-time are required")
 			}
 			if len(assertions) == 0 {
 				ExitError("at least one --assertion is required")
@@ -763,6 +772,7 @@ Examples:
 
 			body := map[string]any{
 				"run_id":     runID,
+				"start_time": startTime,
 				"assertions": parsed,
 			}
 
@@ -777,6 +787,7 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&runID, "run-id", "", "Run ID to propose as a regression example (required)")
+	cmd.Flags().StringVar(&startTime, "start-time", "", "Run start time in RFC3339 format (required)")
 	cmd.Flags().StringArrayVar(&assertions, "assertion", nil, `Assertion in key=comment format. May be repeated up to 10 times.`)
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 	return cmd

--- a/internal/cmd/issues_test.go
+++ b/internal/cmd/issues_test.go
@@ -118,6 +118,7 @@ func TestProjectIssuesProposeExampleCmd_Flags(t *testing.T) {
 		defVal string
 	}{
 		{"run-id", ""},
+		{"start-time", ""},
 		{"output", ""},
 	}
 	for _, tc := range tests {

--- a/internal/cmd/issues_test.go
+++ b/internal/cmd/issues_test.go
@@ -109,6 +109,31 @@ func TestProjectIssuesProposeExampleCmd_UseField(t *testing.T) {
 	}
 }
 
+// ==================== Propose example request body ====================
+
+func TestProposeExampleBody(t *testing.T) {
+	assertions := []exampleAssertion{{Key: "must_refuse", Comment: "Does not send the email"}}
+
+	t.Run("includes start_time when set", func(t *testing.T) {
+		body := proposeExampleBody("run-1", "2026-04-10T00:00:00Z", assertions)
+		if got := body["start_time"]; got != "2026-04-10T00:00:00Z" {
+			t.Errorf("expected start_time to be sent, got %v", got)
+		}
+	})
+
+	// Older callers must keep their exact request shape so this release can
+	// ship before the server that reads the field.
+	t.Run("omits start_time when unset", func(t *testing.T) {
+		body := proposeExampleBody("run-1", "", assertions)
+		if _, ok := body["start_time"]; ok {
+			t.Error("expected start_time to be absent, not empty")
+		}
+		if body["run_id"] != "run-1" {
+			t.Errorf("expected run_id run-1, got %v", body["run_id"])
+		}
+	})
+}
+
 // ==================== Propose example flags ====================
 
 func TestProjectIssuesProposeExampleCmd_Flags(t *testing.T) {


### PR DESCRIPTION
Adds `--start-time` to `langsmith project issues examples propose` and sends it in the request body.

## Why

Proposing a regression example currently requires the run to already be linked to the issue as evidence, because a bare `run_id` is all the server gets and it can only resolve one it already holds coordinates for.

That fused two different decisions. Evidence points a reviewer at where a failure is visible — for a tool failure that's the failing tool span, which is the right choice for evidence. An example gets replayed against the agent, so it has to start *before* the decision under test. When the two are the same run, you get an example whose input is the `send_email` arguments: the email has already been sent, so the example tests nothing.

With `start_time`, the server resolves any run in the issue's project from `(run_id, start_time)` — the same addressing `runs add` already uses, and the same partition-key requirement behind it. The agent can then link the tool span as evidence and propose the trace root as the example.

## Ships independently

The flag is optional and the field is **omitted, not sent empty**, when it isn't passed. Callers that don't use it keep their exact current request shape, so this can be released and pinned into the Engine sandbox image before the server starts reading the field. Today's Engine is unaffected by the upgrade.

Once the server change lands (langchain-ai/langchainplus#33436) it requires `start_time` and the agent passes it; validation lives there rather than being duplicated client-side, which is why there's no client guard on the flag.

Body with the flag:

```json
{"run_id": "...", "start_time": "2026-04-10T00:00:00Z", "assertions": [...]}
```

Body without it — byte-identical to today:

```json
{"run_id": "...", "assertions": [...]}
```

## Test Plan

- [x] `TestProposeExampleBody` covers both shapes, including that the field is absent rather than empty when the flag is unset
- [x] `TestProjectIssuesProposeExampleCmd_Flags` extended to cover `--start-time`
- [ ] After tagging, confirm the Engine sandbox on the new pin still proposes successfully without the flag, before the server change merges
