### PR TITLE
feat(sandbox): accept name:tag on snapshot capture and build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/itchyny/gojq v0.12.15
-	github.com/langchain-ai/langsmith-go v0.25.4
+	github.com/langchain-ai/langsmith-go v0.25.5
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/langchain-ai/langsmith-go v0.25.2 h1:jHy1p02zT9a4m3TySTuB+dv0oT4Mfp7h
 github.com/langchain-ai/langsmith-go v0.25.2/go.mod h1:I8S3n3i7P/EdlMOoJXUeuD6+XBrkopJ6LByZxHq5rGA=
 github.com/langchain-ai/langsmith-go v0.25.4 h1:PyNaofnvqJRGBXRYloX9Zk40ajBbr8JtKki3KUzeYoM=
 github.com/langchain-ai/langsmith-go v0.25.4/go.mod h1:I8S3n3i7P/EdlMOoJXUeuD6+XBrkopJ6LByZxHq5rGA=
+github.com/langchain-ai/langsmith-go v0.25.5 h1:uLEpOMfWEHH72eVf3Mx/WxEMgTGhRbvA0R2FRB6WbyU=
+github.com/langchain-ai/langsmith-go v0.25.5/go.mod h1:oBp+dsngsLpTAiaIT8ZC+5H5qV8PrTt+gY1dQixp2HM=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=

--- a/internal/cmd/sandbox_snapshot.go
+++ b/internal/cmd/sandbox_snapshot.go
@@ -20,11 +20,15 @@ var sandboxSnapshotCommand = structured.Parent{
 	Long: `Manage sandbox snapshots — ext4 rootfs images built from Docker images
 or captured from running sandboxes. Snapshots are used to create new sandboxes.
 
+A snapshot is named Docker-style: "name:tag" is a mutable pointer to one
+immutable snapshot, and a bare name means "name:latest". Publishing over an
+existing name:tag moves the pointer; the old snapshot stays addressable by id.
+
 Examples:
   langsmith sandbox snapshot list
   langsmith sandbox snapshot build my-snap --docker-image ubuntu:24.04
-  langsmith sandbox snapshot capture my-snap --box my-vm
-  langsmith sandbox snapshot get <id>
+  langsmith sandbox snapshot capture my-snap:v2 --box my-vm
+  langsmith sandbox snapshot get my-snap:v2
   langsmith sandbox snapshot delete <id>`,
 	Children: []func() *cobra.Command{
 		snapshotListCommand.Cobra,
@@ -56,6 +60,7 @@ var snapshotListCommand = structured.Command[struct{}]{
 		Columns: []structured.Column{
 			{Header: "ID", Template: "{{.ID}}"},
 			{Header: "Name", Template: "{{.Name}}"},
+			{Header: "Tags", Template: "{{joinOrDash .Tags}}"},
 			{Header: "Image", Template: "{{dash .DockerImage}}"},
 			{Header: "Status", Template: "{{.Status}}"},
 			{Header: "Size", Template: "{{formatBytesOrDash .FsUsedBytes}}"},
@@ -71,12 +76,16 @@ type snapshotBuildInput struct {
 }
 
 var snapshotBuildCommand = structured.Command[*snapshotBuildInput]{
-	Use:   "build <name>",
+	Use:   "build <name[:tag]>",
 	Short: "Build a snapshot from a Docker image",
 	Long: `Build a snapshot from a Docker image.
 
+The tag is applied once the build finishes. Omit it and the snapshot inherits the
+Docker image's tag (ubuntu:24.04 becomes 24.04), else "latest".
+
 	Examples:
 	  langsmith sandbox snapshot build my-snap --docker-image ubuntu:24.04
+	  langsmith sandbox snapshot build my-snap:v2 --docker-image ubuntu:24.04
 	  langsmith sandbox snapshot build my-snap --docker-image ubuntu:24.04 --capacity 8gb`,
 	Args: cobra.ExactArgs(1),
 	Input: func(cmd *cobra.Command) *snapshotBuildInput {
@@ -89,7 +98,7 @@ var snapshotBuildCommand = structured.Command[*snapshotBuildInput]{
 		return in
 	},
 	Action: func(ctx context.Context, cmd *cobra.Command, in *snapshotBuildInput, args []string) (any, error) {
-		name := args[0]
+		name, tag := splitSnapshotRef(args[0])
 		if in.DockerImage == "" {
 			return nil, fmt.Errorf("--docker-image is required")
 		}
@@ -109,6 +118,9 @@ var snapshotBuildCommand = structured.Command[*snapshotBuildInput]{
 			DockerImage:     langsmith.F(in.DockerImage),
 			FsCapacityBytes: langsmith.F(capBytes),
 		}
+		if tag != "" {
+			params.Tag = langsmith.F(tag)
+		}
 		if in.RegistryID != "" {
 			params.RegistryID = langsmith.F(in.RegistryID)
 		}
@@ -122,6 +134,7 @@ var snapshotBuildCommand = structured.Command[*snapshotBuildInput]{
 	},
 	Render: structured.Template(`ID:      {{.ID}}
 Name:    {{.Name}}
+Tags:    {{joinOrDash .Tags}}
 Image:   {{dash .DockerImage}}
 Status:  {{.Status}}
 Size:    {{formatBytesOrDash .FsUsedBytes}}
@@ -135,14 +148,17 @@ type snapshotCaptureInput struct {
 }
 
 var snapshotCaptureCommand = structured.Command[*snapshotCaptureInput]{
-	Use:   "capture <name>",
+	Use:   "capture <name[:tag]>",
 	Short: "Capture a snapshot from a running sandbox",
 	Long: `Capture a snapshot from a sandbox VM. If --checkpoint is specified, uses
 that existing checkpoint (no VM interaction needed). Otherwise creates a
 fresh checkpoint from the running VM's current state.
 
+An omitted tag means "latest".
+
 	Examples:
 	  langsmith sandbox snapshot capture my-snap --box my-vm
+	  langsmith sandbox snapshot capture my-snap:2026081101 --box my-vm
 	  langsmith sandbox snapshot capture my-snap --box my-vm --checkpoint 2026-03-29T00:09:28Z`,
 	Args: cobra.ExactArgs(1),
 	Input: func(cmd *cobra.Command) *snapshotCaptureInput {
@@ -152,7 +168,7 @@ fresh checkpoint from the running VM's current state.
 		return in
 	},
 	Action: func(ctx context.Context, cmd *cobra.Command, in *snapshotCaptureInput, args []string) (any, error) {
-		name := args[0]
+		name, tag := splitSnapshotRef(args[0])
 		if in.BoxName == "" {
 			return nil, fmt.Errorf("--box is required")
 		}
@@ -164,6 +180,9 @@ fresh checkpoint from the running VM's current state.
 
 		params := langsmith.SandboxBoxNewSnapshotParams{
 			Name: langsmith.F(name),
+		}
+		if tag != "" {
+			params.Tag = langsmith.F(tag)
 		}
 		if in.Checkpoint != "" {
 			params.Checkpoint = langsmith.F(in.Checkpoint)
@@ -178,6 +197,7 @@ fresh checkpoint from the running VM's current state.
 	},
 	Render: structured.Template(`ID:      {{.ID}}
 Name:    {{.Name}}
+Tags:    {{joinOrDash .Tags}}
 Image:   {{dash .DockerImage}}
 Status:  {{.Status}}
 Size:    {{formatBytesOrDash .FsUsedBytes}}
@@ -186,8 +206,8 @@ Created: {{formatTime .CreatedAt}}
 }
 
 var snapshotGetCommand = structured.Command[struct{}]{
-	Use:   "get <snapshot-id>",
-	Short: "Get a snapshot by ID",
+	Use:   "get <snapshot-id|name[:tag]>",
+	Short: "Get a snapshot by ID or Docker-style reference",
 	Args:  cobra.ExactArgs(1),
 	Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
 		c, err := cmdutil.GetClient(cmd)
@@ -204,6 +224,7 @@ var snapshotGetCommand = structured.Command[struct{}]{
 	},
 	Render: structured.Template(`ID:      {{.ID}}
 Name:    {{.Name}}
+Tags:    {{joinOrDash .Tags}}
 Image:   {{dash .DockerImage}}
 Status:  {{.Status}}
 Size:    {{formatBytesOrDash .FsUsedBytes}}
@@ -212,8 +233,8 @@ Created: {{formatTime .CreatedAt}}
 }
 
 var snapshotDeleteCommand = structured.Command[struct{}]{
-	Use:   "delete <snapshot-id>",
-	Short: "Delete a snapshot",
+	Use:   "delete <snapshot-id|name[:tag]>",
+	Short: "Delete a snapshot by ID or Docker-style reference",
 	Args:  cobra.ExactArgs(1),
 	Action: func(ctx context.Context, cmd *cobra.Command, in struct{}, args []string) (any, error) {
 		c, err := cmdutil.GetClient(cmd)
@@ -229,6 +250,13 @@ var snapshotDeleteCommand = structured.Command[struct{}]{
 	},
 	Render: structured.Template(`{{.Message}}
 `),
+}
+
+// splitSnapshotRef splits a Docker-style name[:tag] on the first colon. The
+// server rejects a colon inside a name, so an empty tag leaves the default to it.
+func splitSnapshotRef(ref string) (name, tag string) {
+	name, tag, _ = strings.Cut(ref, ":")
+	return name, tag
 }
 
 func parseByteSize(s string) (int64, error) {

--- a/internal/cmd/sandbox_snapshot_test.go
+++ b/internal/cmd/sandbox_snapshot_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	langsmith "github.com/langchain-ai/langsmith-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitSnapshotRef(t *testing.T) {
+	tests := []struct {
+		ref      string
+		wantName string
+		wantTag  string
+	}{
+		{ref: "my-snap", wantName: "my-snap", wantTag: ""},
+		{ref: "my-snap:v2", wantName: "my-snap", wantTag: "v2"},
+		{ref: "my-snap:2026081101", wantName: "my-snap", wantTag: "2026081101"},
+		{ref: "my-snap:latest", wantName: "my-snap", wantTag: "latest"},
+		// A trailing colon carries no tag, so the server applies its default.
+		{ref: "my-snap:", wantName: "my-snap", wantTag: ""},
+		// Split on the first colon only; the server rejects a colon inside a name.
+		{ref: "my-snap:v2:extra", wantName: "my-snap", wantTag: "v2:extra"},
+		{ref: "", wantName: "", wantTag: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.ref, func(t *testing.T) {
+			name, tag := splitSnapshotRef(tc.ref)
+
+			assert.Equal(t, tc.wantName, name)
+			assert.Equal(t, tc.wantTag, tag)
+		})
+	}
+}
+
+func TestJoinOrDashRendersSnapshotTags(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []string
+		want string
+	}{
+		{name: "no tags is dangling", tags: nil, want: "Tags:    -"},
+		{name: "one tag", tags: []string{"latest"}, want: "Tags:    latest"},
+		{name: "many tags", tags: []string{"latest", "v2"}, want: "Tags:    latest, v2"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+
+			err := snapshotGetCommand.Render.RenderText(&out, langsmith.SnapshotResponse{
+				ID:   "snap-1",
+				Name: "my-snap",
+				Tags: tc.tags,
+			})
+
+			require.NoError(t, err)
+			assert.Contains(t, out.String(), tc.want)
+		})
+	}
+}

--- a/internal/structured/template_funcs.go
+++ b/internal/structured/template_funcs.go
@@ -2,6 +2,7 @@ package structured
 
 import (
 	"fmt"
+	"strings"
 	"text/template"
 	"time"
 )
@@ -13,8 +14,16 @@ func templateFuncs() template.FuncMap {
 		"formatBytesOrDash": formatBytesOrDash,
 		"formatCount":       formatCount,
 		"formatTime":        formatTime,
+		"joinOrDash":        joinOrDash,
 		"shortID":           shortID,
 	}
+}
+
+func joinOrDash(items []string) string {
+	if len(items) == 0 {
+		return "-"
+	}
+	return strings.Join(items, ", ")
 }
 
 func dash(s string) string {


### PR DESCRIPTION
## Description

The server addresses snapshots Docker-style: `name:tag` is a mutable pointer to one immutable snapshot, and a bare name means `name:latest`. The CLI never learned that half of it — it sent the whole positional argument as `name`, so `capture my-snap:v2` failed with `snapshot name must not contain a colon`.

Split the positional on the first colon and send the tag as its own request field, on both `snapshot capture` and `snapshot build`. An omitted tag leaves the default to the server (`latest` on capture; the Docker image's own tag on build).

Also surfaces the `tags` the server already returns: a Tags column on `snapshot list` and a Tags line on the capture/build/get detail output, rendered `-` when a snapshot is dangling. `snapshot get` and `delete` needed no code change — they already pass the string through, and the server resolves a reference wherever it accepts an id — so only their help text moved.

Requires langsmith-go v0.25.5 for the `tag` request field; bumped from v0.25.4.

## Test Plan

- [x] `go build ./...`, `go vet ./internal/...`, `go test ./internal/...`
- [x] New table test for the name/tag split, covering a bare name, `name:tag`, a trailing colon, and a second colon in the tag
- [x] New test asserting tag rendering, including the dangling (`-`) case
- [x] Verified against prod: `snapshot capture ramon-capture:2026081101` through `:2026081103` land with the right tags, `snapshot get <uuid>` and `snapshot get name:tag` both resolve, and `sandbox create --snapshot ramon-capture:2026081103` boots the tagged snapshot