### PR TITLE
docs(sandbox): document proxy rule env_vars in --proxy-config help

### DIFF
--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -134,6 +134,7 @@ allows and what headers to inject. Format:
         {"name": "Authorization", "type": "opaque", "value": "Bearer sk-..."},
         {"name": "X-Key", "type": "workspace_secret", "value": "Bearer {OPENAI_API_KEY}"}
       ],
+      "env_vars": {"OPENAI_API_KEY": "proxy-injected"},
       "enabled": true
     }],
     "no_proxy": ["internal.example.com"],
@@ -145,6 +146,10 @@ allows and what headers to inject. Format:
 
 Header types: "plaintext" (literal value), "opaque" (encrypted, hidden in API
 responses), "workspace_secret" (resolved from workspace secrets via {KEY}).
+
+A rule's "env_vars" are plaintext variables set for every command in the sandbox
+while the rule is enabled, for tools that refuse to run without a credential
+variable even though the proxy injects the real credential on the wire.
 
 Examples:
   langsmith sandbox create


### PR DESCRIPTION
`--proxy-config` already forwards `env_vars` on a proxy rule as raw JSON, but the flag's help text is the only place the config shape is documented and it did not mention the field. Adds it to the example and explains what it is for.

## Test Plan

- [x] `go vet ./internal/cmd/`
- [x] `go test ./internal/cmd -run ProxyConfig`