### PR TITLE
feat(custom-apps): vendor current design system into templates [LSDK-331]

### DIFF
--- a/internal/cmd/apps_init.go
+++ b/internal/cmd/apps_init.go
@@ -58,33 +58,42 @@ type appType struct {
 	templateFS   embed.FS
 	templateRoot string
 	agentsMD     string // template-specific AGENTS.md fragment; "" = none (generic base only)
+	// Design-system registry items pulled at init. Every component item
+	// depends on "theme", so listing theme alone still installs the real
+	// tokens and Tailwind preset over the scaffold's placeholders.
+	registryItems []string
 }
 
 var appTypes = map[string]appType{
 	"blank": {
-		templateFS:   blankStarterFS,
-		templateRoot: "templates/blank",
-		agentsMD:     "",
+		templateFS:    blankStarterFS,
+		templateRoot:  "templates/blank",
+		agentsMD:      "",
+		registryItems: []string{"theme"},
 	},
 	"annotation-queue": {
-		templateFS:   annotationQueueStarterFS,
-		templateRoot: "templates/annotation-queue",
-		agentsMD:     "annotation_queue",
+		templateFS:    annotationQueueStarterFS,
+		templateRoot:  "templates/annotation-queue",
+		agentsMD:      "annotation_queue",
+		registryItems: []string{"theme"},
 	},
 	"annotation-queue-grid": {
-		templateFS:   annotationQueueGridStarterFS,
-		templateRoot: "templates/annotation-queue-grid",
-		agentsMD:     "annotation_queue_grid",
+		templateFS:    annotationQueueGridStarterFS,
+		templateRoot:  "templates/annotation-queue-grid",
+		agentsMD:      "annotation_queue_grid",
+		registryItems: []string{"theme"},
 	},
 	"coding-agent-dashboard": {
-		templateFS:   codingAgentDashboardStarterFS,
-		templateRoot: "templates/coding-agent-dashboard",
-		agentsMD:     "coding_agent_dashboard",
+		templateFS:    codingAgentDashboardStarterFS,
+		templateRoot:  "templates/coding-agent-dashboard",
+		agentsMD:      "coding_agent_dashboard",
+		registryItems: []string{"theme"},
 	},
 	"experiment-comparison": {
-		templateFS:   experimentComparisonStarterFS,
-		templateRoot: "templates/experiment-comparison",
-		agentsMD:     "experiment_comparison",
+		templateFS:    experimentComparisonStarterFS,
+		templateRoot:  "templates/experiment-comparison",
+		agentsMD:      "experiment_comparison",
+		registryItems: []string{"theme"},
 	},
 }
 
@@ -163,6 +172,7 @@ Installs dependencies as the last step, so you can cd in and run
 			if err := installAppDeps(dir); err != nil {
 				return err
 			}
+			addRegistryComponents(dir, at.registryItems)
 			fmt.Fprintf(os.Stderr, "Next: cd %s && langsmith apps dev.\n", slug)
 			output.OutputJSON(map[string]any{
 				"status":   "scaffolded",
@@ -218,6 +228,37 @@ func installAppDeps(dir string) error {
 		return fmt.Errorf("\"npm install\" failed: %w", err)
 	}
 	return nil
+}
+
+// registryNamespace matches the "registries" key in each template's components.json.
+const registryNamespace = "@langsmith"
+
+// addRegistryComponents pulls design-system items into the scaffold. Best
+// effort: a scaffold without them still builds on the placeholder theme, so a
+// missing npx or an unreachable registry prints the manual command instead of
+// failing init.
+func addRegistryComponents(dir string, items []string) {
+	if len(items) == 0 {
+		return
+	}
+	args := []string{"shadcn", "add", "--overwrite", "--yes"}
+	for _, item := range items {
+		args = append(args, registryNamespace+"/"+item)
+	}
+	manual := "npx " + strings.Join(args, " ")
+
+	if _, err := exec.LookPath("npx"); err != nil {
+		fmt.Fprintf(os.Stderr, "note: npx not found on PATH — run %q to install design system components\n", manual)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "Adding design system components: %s\n", strings.Join(items, ", "))
+	c := exec.Command("npx", args...)
+	c.Dir = dir
+	c.Stdout = os.Stderr
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "note: design system install failed (%v) — run %q to retry\n", err, manual)
+	}
 }
 
 func scaffoldCustomAppStarter(dir, name, description string, at appType, force bool) ([]string, error) {

--- a/internal/cmd/apps_init_test.go
+++ b/internal/cmd/apps_init_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -776,4 +777,47 @@ func TestEmbeddedTemplates_CarryNoStrayBuildArtifacts(t *testing.T) {
 		check(name, at.templateFS)
 	}
 	check("_shared", sharedFS)
+}
+
+func TestAppTemplatesPullDesignSystemTheme(t *testing.T) {
+	for name, at := range appTypes {
+		t.Run(name, func(t *testing.T) {
+			if len(at.registryItems) == 0 {
+				t.Fatal("template pulls no registry items; theme is required for tokens")
+			}
+			var hasTheme bool
+			for _, item := range at.registryItems {
+				if item == "theme" {
+					hasTheme = true
+				}
+			}
+			if !hasTheme {
+				t.Errorf("registryItems %v must include theme", at.registryItems)
+			}
+
+			dir := t.TempDir()
+			if _, err := scaffoldCustomAppStarter(dir, "my-app", "", at, false); err != nil {
+				t.Fatalf("scaffold: %v", err)
+			}
+			raw, err := os.ReadFile(filepath.Join(dir, "components.json"))
+			if err != nil {
+				t.Fatalf("read components.json: %v", err)
+			}
+			var cfg struct {
+				Registries map[string]string `json:"registries"`
+			}
+			if err := json.Unmarshal(raw, &cfg); err != nil {
+				t.Fatalf("parse components.json: %v", err)
+			}
+			// Without this, "shadcn add" fails with Unknown registry "@langsmith".
+			if cfg.Registries[registryNamespace] == "" {
+				t.Errorf("components.json must pre-register %s, got %v", registryNamespace, cfg.Registries)
+			}
+		})
+	}
+}
+
+func TestAddRegistryComponentsIsBestEffort(t *testing.T) {
+	// No items and a nonexistent dir: must not panic or block init.
+	addRegistryComponents(filepath.Join(t.TempDir(), "missing"), nil)
 }

--- a/internal/cmd/templates/agents-md/_common.md
+++ b/internal/cmd/templates/agents-md/_common.md
@@ -99,9 +99,16 @@ hand-rolling UI. Each `add` writes real source into
 `src/components/langsmith/design-system/`, so you can read and edit it.
 
 ```bash
-npx shadcn registry add @langsmith=https://smith.langchain.com/r/{name}.json
 npx shadcn list @langsmith
 npx shadcn add --overwrite @langsmith/button @langsmith/badge
+```
+
+`langsmith apps init` registers the `@langsmith` namespace in `components.json`
+and pulls `@langsmith/theme`, so `registry add` is not needed. If that step was
+skipped (no `npx`, or the registry was unreachable), run it manually:
+
+```bash
+npx shadcn add --overwrite --yes @langsmith/theme
 ```
 
 `--overwrite` is required. The scaffold ships placeholder `theme.css` and

--- a/internal/cmd/templates/annotation-queue-grid/components.json
+++ b/internal/cmd/templates/annotation-queue-grid/components.json
@@ -17,5 +17,7 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "registries": {}
+  "registries": {
+    "@langsmith": "https://smith.langchain.com/r/{name}.json"
+  }
 }

--- a/internal/cmd/templates/annotation-queue/components.json
+++ b/internal/cmd/templates/annotation-queue/components.json
@@ -17,5 +17,7 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "registries": {}
+  "registries": {
+    "@langsmith": "https://smith.langchain.com/r/{name}.json"
+  }
 }

--- a/internal/cmd/templates/blank/components.json
+++ b/internal/cmd/templates/blank/components.json
@@ -17,5 +17,7 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "registries": {}
+  "registries": {
+    "@langsmith": "https://smith.langchain.com/r/{name}.json"
+  }
 }

--- a/internal/cmd/templates/coding-agent-dashboard/components.json
+++ b/internal/cmd/templates/coding-agent-dashboard/components.json
@@ -17,5 +17,7 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "registries": {}
+  "registries": {
+    "@langsmith": "https://smith.langchain.com/r/{name}.json"
+  }
 }

--- a/internal/cmd/templates/experiment-comparison/components.json
+++ b/internal/cmd/templates/experiment-comparison/components.json
@@ -17,5 +17,7 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "registries": {}
+  "registries": {
+    "@langsmith": "https://smith.langchain.com/r/{name}.json"
+  }
 }


### PR DESCRIPTION
Stacked on #257 — merge that first.

templates now ship the live registry's theme.css and tailwind.langsmith.cjs byte-identical instead of placeholder stubs. so a fresh scaffold is ds-native and offline.

- the packages are moved into package.json.tmpl.
- registries stays pre-wired so shadcn add @langsmith/<component> works with no setup
- AGENTS.md documents the refresh path plus the new-require check. 