### PR TITLE
surface server app errors [LSDK-471]

### DIFF
--- a/internal/cmd/apps_claim.go
+++ b/internal/cmd/apps_claim.go
@@ -41,9 +41,6 @@ you need when this workspace already has an app by that name.`,
 					}
 					return fmt.Errorf("this workspace already has a custom app named %q — claim it under a different name with `langsmith apps claim %q --as \"New Name\"`", taken, args[0])
 				}
-				if client.IsForbidden(err) {
-					return fmt.Errorf("you don't have permission to claim custom apps into this workspace — ask a workspace admin")
-				}
 				return fmt.Errorf("claiming custom app %s: %w", app.ID, err)
 			}
 

--- a/internal/cmd/apps_push.go
+++ b/internal/cmd/apps_push.go
@@ -96,15 +96,6 @@ same app too.
 					updated = true
 				case isSourceArchiveRejection(err):
 					return sourceArchiveRejectionError(err)
-				case client.IsConflict(err):
-					conflictName := name
-					if conflictName == "" {
-						conflictName = link.Name
-					}
-					if conflictName == "" {
-						conflictName = link.AppID
-					}
-					return fmt.Errorf("a custom app named %q already exists in this workspace", conflictName)
 				case client.IsNotFound(err):
 					// Stale link (app deleted server-side) — recreate instead of failing.
 					fmt.Fprintf(os.Stderr, "note: custom app %s no longer exists (it may have been deleted) — creating a new one\n", link.AppID)
@@ -139,11 +130,8 @@ same app too.
 					if isSourceArchiveRejection(err) {
 						return sourceArchiveRejectionError(err)
 					}
-					if client.IsForbidden(err) {
-						return fmt.Errorf("this workspace doesn't support custom apps — ask a workspace admin to enable them, then try again")
-					}
 					if client.IsConflict(err) {
-						return fmt.Errorf("a custom app named %q already exists in this workspace. try `langsmith apps push --name \"New Name\"` instead", appName)
+						return fmt.Errorf("%w — try `langsmith apps push --name \"New Name\"` instead", err)
 					}
 					return fmt.Errorf("creating custom app: %w", err)
 				}

--- a/internal/cmd/apps_share.go
+++ b/internal/cmd/apps_share.go
@@ -31,9 +31,6 @@ workspaces can copy one into their own with "langsmith apps claim".`,
 			}
 
 			if err := c.RawPost(ctx, c.CustomAppPath(app.ID)+"/share", nil, nil); err != nil {
-				if client.IsForbidden(err) {
-					return fmt.Errorf("you don't have permission to share custom app %q — ask an organization admin to share it", app.Name)
-				}
 				if client.IsConflict(err) {
 					return fmt.Errorf("another custom app named %q is already shared with this organization; rename this one with `langsmith apps push --name \"New Name\"` first", app.Name)
 				}


### PR DESCRIPTION
`apps push` was replacing server error messages with hardcoded strings, so the new per-org app limit surfaced as "this workspace doesn't support custom apps — ask a workspace admin to enable them" — misleading, and it names a workspace when the limit is per-org.

- Dropped the 403 branch on create; the server message (reason + remedy) now flows through.
- Dropped the 409 branch on update; `default` already wraps with the app ID and the real message.
- Kept the `--name` hint on create conflicts but wrapped the server error instead of asserting "in this workspace", which is wrong now that name uniqueness is org-tier-aware.

Net −12 lines, all deleted strings. Pairs with langchainplus#34102.