### PR TITLE
fix(output): include feedback column in runs table when requested

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -78,7 +78,7 @@ func newRunListCmd() *cobra.Command {
 
 			if fmt_ == "pretty" {
 				data := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)
-				output.PrintRunsTable(os.Stdout, data, includeMetadata, "Runs")
+				output.PrintRunsTable(os.Stdout, data, includeMetadata, includeFeedback, "Runs")
 			} else {
 				data := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)
 				output.OutputJSON(data, outputFile)

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -43,6 +43,7 @@ func TestRunListCmd_Flags(t *testing.T) {
 	}{
 		{"include-metadata", "false", ""},
 		{"include-io", "false", ""},
+		{"include-feedback", "false", ""},
 		{"full", "false", ""},
 		{"output", "", "o"},
 	}
@@ -94,6 +95,7 @@ func TestRunGetCmd_Flags(t *testing.T) {
 		{"project", ""},
 		{"include-metadata", "false"},
 		{"include-io", "false"},
+		{"include-feedback", "false"},
 		{"full", "false"},
 		{"output", ""},
 	}

--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -247,7 +247,7 @@ func newThreadGetCmd() *cobra.Command {
 			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
-				output.PrintRunsTable(os.Stdout, extracted, includeMetadata, fmt.Sprintf("Thread %s", threadID))
+				output.PrintRunsTable(os.Stdout, extracted, includeMetadata, includeFeedback, fmt.Sprintf("Thread %s", threadID))
 			} else {
 				data := map[string]any{
 					"thread_id": threadID,

--- a/internal/cmd/thread_test.go
+++ b/internal/cmd/thread_test.go
@@ -149,6 +149,7 @@ func TestThreadGetCmd_Flags(t *testing.T) {
 		{"project", "", ""},
 		{"include-metadata", "false", ""},
 		{"include-io", "false", ""},
+		{"include-feedback", "false", ""},
 		{"full", "false", ""},
 		{"limit", "0", "n"},
 		{"output", "", "o"},

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -113,7 +113,7 @@ func newTraceListCmd() *cobra.Command {
 					}
 				} else {
 					data := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)
-					output.PrintRunsTable(os.Stdout, data, includeMetadata, "Traces")
+					output.PrintRunsTable(os.Stdout, data, includeMetadata, includeFeedback, "Traces")
 				}
 			} else {
 				if showHierarchy {

--- a/internal/cmd/trace_test.go
+++ b/internal/cmd/trace_test.go
@@ -39,6 +39,7 @@ func TestTraceListCmd_Flags(t *testing.T) {
 	}{
 		{"include-metadata", "false", ""},
 		{"include-io", "false", ""},
+		{"include-feedback", "false", ""},
 		{"full", "false", ""},
 		{"show-hierarchy", "false", ""},
 		{"output", "", "o"},

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -159,7 +159,7 @@ func PrintError(msg string) {
 }
 
 // PrintRunsTable prints a table of runs in pretty format.
-func PrintRunsTable(w io.Writer, runs []map[string]any, includeMetadata bool, title string) {
+func PrintRunsTable(w io.Writer, runs []map[string]any, includeMetadata bool, includeFeedback bool, title string) {
 	if title != "" {
 		fmt.Fprintln(w, title)
 		fmt.Fprintln(w, strings.Repeat("─", len(title)))
@@ -168,6 +168,9 @@ func PrintRunsTable(w io.Writer, runs []map[string]any, includeMetadata bool, ti
 	columns := []string{"Time", "Name", "Type", "Trace ID", "Run ID"}
 	if includeMetadata {
 		columns = append(columns, "Duration", "Status", "Tokens")
+	}
+	if includeFeedback {
+		columns = append(columns, "Feedback")
 	}
 
 	table := tablewriter.NewWriter(w)
@@ -214,10 +217,107 @@ func PrintRunsTable(w io.Writer, runs []map[string]any, includeMetadata bool, ti
 			row = append(row, duration, status, tokens)
 		}
 
+		if includeFeedback {
+			row = append(row, FormatFeedbackStats(r["feedback_stats"]))
+		}
+
 		table.Append(row)
 	}
 
 	table.Render()
+}
+
+// FormatFeedbackStats formats feedback_stats into a readable string.
+func FormatFeedbackStats(v any) string {
+	if v == nil {
+		return "N/A"
+	}
+
+	statsMap := make(map[string]map[string]any)
+	switch m := v.(type) {
+	case map[string]map[string]any:
+		statsMap = m
+	case map[string]any:
+		for k, inner := range m {
+			if innerMap, ok := inner.(map[string]any); ok {
+				statsMap[k] = innerMap
+			}
+		}
+	default:
+		return "N/A"
+	}
+
+	if len(statsMap) == 0 {
+		return "N/A"
+	}
+
+	keys := make([]string, 0, len(statsMap))
+	for k := range statsMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var parts []string
+	for _, k := range keys {
+		inner := statsMap[k]
+		avgStr := formatStatNum(inner["avg"])
+		countStr := formatStatCount(inner)
+		if avgStr != "" && countStr != "" {
+			parts = append(parts, fmt.Sprintf("%s: %s (%s)", k, avgStr, countStr))
+		} else if avgStr != "" {
+			parts = append(parts, fmt.Sprintf("%s: %s", k, avgStr))
+		} else if countStr != "" {
+			parts = append(parts, fmt.Sprintf("%s: (%s)", k, countStr))
+		} else {
+			parts = append(parts, k)
+		}
+	}
+
+	if len(parts) == 0 {
+		return "N/A"
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatStatNum(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch n := v.(type) {
+	case float64:
+		return fmt.Sprintf("%.2f", n)
+	case float32:
+		return fmt.Sprintf("%.2f", n)
+	case int:
+		return fmt.Sprintf("%d", n)
+	case int64:
+		return fmt.Sprintf("%d", n)
+	case json.Number:
+		if f, err := n.Float64(); err == nil {
+			return fmt.Sprintf("%.2f", f)
+		}
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+func formatStatCount(inner map[string]any) string {
+	for _, countKey := range []string{"n", "count"} {
+		if val, ok := inner[countKey]; ok && val != nil {
+			switch n := val.(type) {
+			case float64:
+				return fmt.Sprintf("%.0f", n)
+			case float32:
+				return fmt.Sprintf("%.0f", n)
+			case int, int64:
+				return fmt.Sprintf("%d", n)
+			case json.Number:
+				return n.String()
+			default:
+				return fmt.Sprintf("%v", n)
+			}
+		}
+	}
+	return ""
 }
 
 // FormatDuration formats milliseconds as human-readable duration.

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -113,7 +113,7 @@ func TestPrintRunsTable(t *testing.T) {
 		if !strings.Contains(output, "ChatOpenAI") {
 			t.Error("expected run name in output")
 		}
-		if strings.Contains(output, "Feedback") {
+		if strings.Contains(output, "Feedback") || strings.Contains(output, "FEEDBACK") {
 			t.Error("expected no Feedback column when includeFeedback is false")
 		}
 	})

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -81,8 +81,6 @@ func TestFormatDuration(t *testing.T) {
 }
 
 func TestPrintRunsTable(t *testing.T) {
-	var buf bytes.Buffer
-
 	runs := []map[string]any{
 		{
 			"start_time": "2024-01-15T10:30:00Z",
@@ -90,17 +88,103 @@ func TestPrintRunsTable(t *testing.T) {
 			"run_type":   "llm",
 			"trace_id":   "abc123def456789012",
 			"run_id":     "run123def456789012",
+			"feedback_stats": map[string]map[string]any{
+				"correctness": {"avg": 0.8, "n": 5},
+				"helpfulness": {"avg": 1.0, "n": 2},
+			},
+		},
+		{
+			"start_time": "2024-01-15T10:31:00Z",
+			"name":       "ToolCall",
+			"run_type":   "tool",
+			"trace_id":   "abc123def456789012",
+			"run_id":     "run456def456789012",
 		},
 	}
 
-	PrintRunsTable(&buf, runs, false, "Test Runs")
+	t.Run("without feedback flag", func(t *testing.T) {
+		var buf bytes.Buffer
+		PrintRunsTable(&buf, runs, false, false, "Test Runs")
+		output := buf.String()
 
-	output := buf.String()
-	if !strings.Contains(output, "Test Runs") {
-		t.Error("expected title in output")
+		if !strings.Contains(output, "Test Runs") {
+			t.Error("expected title in output")
+		}
+		if !strings.Contains(output, "ChatOpenAI") {
+			t.Error("expected run name in output")
+		}
+		if strings.Contains(output, "Feedback") {
+			t.Error("expected no Feedback column when includeFeedback is false")
+		}
+	})
+
+	t.Run("with feedback flag", func(t *testing.T) {
+		var buf bytes.Buffer
+		PrintRunsTable(&buf, runs, false, true, "Test Runs")
+		output := buf.String()
+
+		if !strings.Contains(output, "FEEDBACK") && !strings.Contains(output, "Feedback") {
+			t.Error("expected Feedback column when includeFeedback is true")
+		}
+		if !strings.Contains(output, "correctness: 0.80 (5)") {
+			t.Errorf("expected formatted correctness feedback stats in output, got:\n%s", output)
+		}
+		if !strings.Contains(output, "helpfulness: 1.00 (2)") {
+			t.Errorf("expected formatted helpfulness feedback stats in output, got:\n%s", output)
+		}
+		if !strings.Contains(output, "N/A") {
+			t.Error("expected N/A for run without feedback stats")
+		}
+	})
+}
+
+func TestFormatFeedbackStats(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{
+			name:     "nil",
+			input:    nil,
+			expected: "N/A",
+		},
+		{
+			name:     "empty map",
+			input:    map[string]any{},
+			expected: "N/A",
+		},
+		{
+			name: "single key with avg and n",
+			input: map[string]map[string]any{
+				"correctness": {"avg": 0.8, "n": 5},
+			},
+			expected: "correctness: 0.80 (5)",
+		},
+		{
+			name: "multiple keys sorted alphabetically",
+			input: map[string]map[string]any{
+				"helpfulness": {"avg": 1.0, "n": 2},
+				"accuracy":    {"avg": 0.95, "n": 10},
+			},
+			expected: "accuracy: 0.95 (10), helpfulness: 1.00 (2)",
+		},
+		{
+			name: "feedback stats with count instead of n",
+			input: map[string]map[string]interface{}{
+				"relevance": {"avg": 0.75, "count": float64(4)},
+			},
+			expected: "relevance: 0.75 (4)",
+		},
 	}
-	if !strings.Contains(output, "ChatOpenAI") {
-		t.Error("expected run name in output")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatFeedbackStats(tt.input)
+			if got != tt.expected {
+				t.Errorf("FormatFeedbackStats() = %q, want %q", got, tt.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #186

## What was broken

`langsmith thread get <thread-id> --include-feedback` produced the exact same table whether or not the flag was set. The same bug also existed in `run list` and `trace list`. The `--include-feedback` flag was correctly plumbed through to the API query, but `output.PrintRunsTable` (the function that renders the table view) never actually accepted or used it — so the feedback data was fetched and then just thrown away when printing.

## What changed

- `PrintRunsTable` now takes an `includeFeedback` param and adds a `Feedback` column when it's set.
- Added a `FormatFeedbackStats` helper that turns feedback stats into something readable, e.g. `correctness: 0.80 (5)`, falling back to `N/A` when there's nothing to show.
- Wired `includeFeedback` through from `thread get`, `run list`, and `trace list` so the table output finally matches what the flag promises.
- Added tests covering table output with and without the feedback flag, plus flag-parsing tests for `--include-feedback`.
