### PR TITLE
chore: bump langsmith-go to v0.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/itchyny/gojq v0.12.15
-	github.com/langchain-ai/langsmith-go v0.25.5
+	github.com/langchain-ai/langsmith-go v0.25.6
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/langchain-ai/langsmith-go v0.25.4 h1:PyNaofnvqJRGBXRYloX9Zk40ajBbr8Jt
 github.com/langchain-ai/langsmith-go v0.25.4/go.mod h1:I8S3n3i7P/EdlMOoJXUeuD6+XBrkopJ6LByZxHq5rGA=
 github.com/langchain-ai/langsmith-go v0.25.5 h1:uLEpOMfWEHH72eVf3Mx/WxEMgTGhRbvA0R2FRB6WbyU=
 github.com/langchain-ai/langsmith-go v0.25.5/go.mod h1:oBp+dsngsLpTAiaIT8ZC+5H5qV8PrTt+gY1dQixp2HM=
+github.com/langchain-ai/langsmith-go v0.25.6 h1:enWqO/IW+/7u0uLuanNeNVXifPfWADSZoktTe9LysuU=
+github.com/langchain-ai/langsmith-go v0.25.6/go.mod h1:oBp+dsngsLpTAiaIT8ZC+5H5qV8PrTt+gY1dQixp2HM=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -610,5 +612,70 @@ func TestToV2Params_OmitsUnsetFields(t *testing.T) {
 		v2.MinStartTime.Present || v2.Filter.Present || v2.IDs.Present ||
 		v2.PageSize.Present || v2.Selects.Present {
 		t.Error("expected all fields unset for empty input")
+	}
+}
+
+// ---------- queryRunsV2 pagination ----------
+
+// POST /api/v2/runs/query reads `cursor` from the body, so the SDK auto-pager
+// must send it there; sending it as a query parameter silently refetches the
+// first page.
+func TestQueryRunsV2_SDKAutoPagerSendsCursorInBody(t *testing.T) {
+	pages := map[string]struct {
+		ids  []string
+		next string
+	}{
+		"":         {ids: []string{"run-1", "run-2"}, next: "cursor-2"},
+		"cursor-2": {ids: []string{"run-3", "run-4"}, next: "cursor-3"},
+		"cursor-3": {ids: []string{"run-5"}},
+	}
+	var bodyCursors []string
+
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/runs/query" || r.Method != http.MethodPost {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		if cursor := r.URL.Query().Get("cursor"); cursor != "" {
+			t.Errorf("cursor sent as query parameter: %q", cursor)
+		}
+		var body struct {
+			Cursor string `json:"cursor"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding request body: %v", err)
+		}
+		bodyCursors = append(bodyCursors, body.Cursor)
+		page, ok := pages[body.Cursor]
+		if !ok {
+			t.Errorf("request body cursor %q does not match any page", body.Cursor)
+			http.Error(w, "unknown cursor", http.StatusBadRequest)
+			return
+		}
+		items := make([]map[string]any, 0, len(page.ids))
+		for _, id := range page.ids {
+			items = append(items, map[string]any{"id": id})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "next_cursor": page.next})
+	})
+	cleanup := setupTestEnv(t, ts.URL)
+	defer cleanup()
+
+	runs, err := queryRunsV2(context.Background(), MustGetClient(), langsmith.RunQueryV2Params{}, "", 100, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got []string
+	for _, run := range runs {
+		got = append(got, run.ID)
+	}
+	if strings.Join(got, ",") != "run-1,run-2,run-3,run-4,run-5" {
+		t.Errorf("runs = %v, want each of run-1..run-5 exactly once", got)
+	}
+	if strings.Join(bodyCursors, ",") != ",cursor-2,cursor-3" {
+		t.Errorf("body cursors = %v, want [\"\", cursor-2, cursor-3]", bodyCursors)
 	}
 }

--- a/internal/cmd/hub_delete.go
+++ b/internal/cmd/hub_delete.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +35,8 @@ func newHubDeleteCmd() *cobra.Command {
 			c := MustGetClient()
 			ctx := context.Background()
 
-			if err := c.SDK.Repos.Directories.Delete(ctx, owner, name); err != nil {
+			// No repo_type filter: `hub delete` deletes the repo whatever its type.
+			if err := c.SDK.Repos.Directories.Delete(ctx, owner, name, langsmith.RepoDirectoryDeleteParams{}); err != nil {
 				return fmt.Errorf("deleting %s/%s: %w", owner, name, err)
 			}
 			output.OutputJSON(map[string]any{


### PR DESCRIPTION
## Description

`langsmith-go` v0.25.6 carries the generator fix that sends body-located pagination cursors in the request body, so `Runs.QueryV2AutoPaging` against `POST /api/v2/runs/query` now advances pages instead of refetching page 1 — the root cause of the reported `trace get` duplicated/dropped runs on traces with >100 runs. Verified with the unchanged CLI paging code: a new test drives `queryRunsV2` against a three-page mock that keys on the body cursor and asserts each run is returned exactly once and no `cursor` query parameter is sent (it fails on v0.25.5).

The bump also brings one breaking signature change: `Repos.Directories.Delete` now takes a params struct for its optional `repo_type` filter. `hub delete` passes an empty one, preserving today's behavior of deleting the repo whatever its type.

This makes the manual paging loop in #262 unnecessary; that PR can be closed in favor of this bump, or merged first if you want the fix to hold on older SDK versions too.

## Test Plan
- [ ] `go test ./internal/cmd -run TestQueryRunsV2_SDKAutoPagerSendsCursorInBody`
- [ ] `langsmith trace get <trace-id> --project <p>` on a trace with >100 runs returns each run once with an accurate `run_count`
- [ ] `langsmith hub delete <owner>/<repo>` still deletes agent and skill repos

Made by [Open SWE](https://openswe.vercel.app/agents/5a7db202-4f6e-c4ec-ca71-4eb5bd2ea228)

## References
- Plan: https://openswe.vercel.app/agents/5a7db202-4f6e-c4ec-ca71-4eb5bd2ea228/plan