### PR TITLE
feat(sandbox): add generate-download-url command

### DIFF
--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -33,6 +33,9 @@ Common workflows:
   # Generate an authenticated HTTP URL for a service inside the sandbox
   langsmith sandbox service-url my-vm --port 8000
 
+  # Generate a credential-free link that downloads one file from the sandbox
+  langsmith sandbox generate-download-url my-vm --path /tmp/report.pdf
+
   # Set up SSH access (writes ~/.ssh/config so "ssh sandbox-my-vm" works)
   # Requires sshd to be installed in your Docker image.
   langsmith sandbox ssh-setup my-vm`,
@@ -51,6 +54,7 @@ Common workflows:
 	cmd.AddCommand(newSandboxExecCmd())
 	cmd.AddCommand(newSandboxConsoleCmd())
 	cmd.AddCommand(sandboxServiceURLCommand.Cobra())
+	cmd.AddCommand(sandboxDownloadURLCommand.Cobra())
 	cmd.AddCommand(newSandboxTunnelCmd())
 	cmd.AddCommand(newSandboxSSHSetupCmd())
 

--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -296,6 +296,11 @@ The link carries its own token, so anyone with the URL can fetch that one file
 with no LangSmith credential. It is pinned to the sandbox and the exact path,
 and cannot be repointed at another file. Fetching wakes a stopped sandbox.
 
+Do not modify the file after minting a link for it. The link is pinned to a
+path, not to a snapshot of the contents, so a later write to that path may or
+may not be reflected in what the link serves. Write a new file and mint a new
+link when the contents change.
+
 Without --expires-in-seconds the link never expires.
 
 Examples:
@@ -315,6 +320,11 @@ Examples:
 	Action: func(ctx context.Context, cmd *cobra.Command, in *sandboxDownloadURLInput, args []string) (any, error) {
 		if cmd.Flags().Changed("expires-in-seconds") && in.ExpiresInSeconds < 1 {
 			return nil, fmt.Errorf("--expires-in-seconds must be greater than 0")
+		}
+		switch in.ContentDisposition {
+		case "", "attachment", "inline":
+		default:
+			return nil, fmt.Errorf("--content-disposition must be attachment or inline (got %q)", in.ContentDisposition)
 		}
 
 		c, err := cmdutil.GetClient(cmd)

--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -58,6 +58,13 @@ type sandboxServiceURLInput struct {
 	ExpiresInSeconds int64
 }
 
+type sandboxDownloadURLInput struct {
+	Path               string
+	ExpiresInSeconds   int64
+	ContentType        string
+	ContentDisposition string
+}
+
 var sandboxBoxDetailRender = structured.PropertyList{
 	Properties: []structured.Property{
 		{Label: "Name", Template: "{{.Name}}"},
@@ -269,6 +276,72 @@ Examples:
 		return resp, nil
 	},
 	Render: sandboxServiceURLRender,
+}
+
+var sandboxDownloadURLRender = structured.PropertyList{
+	Properties: []structured.Property{
+		{Label: "Download URL", Template: "{{.DownloadURL}}"},
+		{Label: "Expires", Template: "{{if .ExpiresAt}}{{formatTime .ExpiresAt}}{{else}}never{{end}}"},
+	},
+	Caption: `Example:
+  curl -LO "{{.DownloadURL}}"`,
+}
+
+var sandboxDownloadURLCommand = structured.Command[*sandboxDownloadURLInput]{
+	Use:   "generate-download-url <name> --path <path>",
+	Short: "Generate a link that downloads a sandbox file without credentials",
+	Long: `Generate a link that downloads a single file from a sandbox.
+
+The link carries its own token, so anyone with the URL can fetch that one file
+with no LangSmith credential. It is pinned to the sandbox and the exact path,
+and cannot be repointed at another file. Fetching wakes a stopped sandbox.
+
+Without --expires-in-seconds the link never expires.
+
+Examples:
+  langsmith sandbox generate-download-url my-vm --path /tmp/report.pdf
+  langsmith sandbox generate-download-url my-vm --path /tmp/report.pdf --expires-in-seconds 3600
+  langsmith sandbox generate-download-url my-vm --path /tmp/page.html --content-disposition inline`,
+	Args: cobra.ExactArgs(1),
+	Input: func(cmd *cobra.Command) *sandboxDownloadURLInput {
+		in := &sandboxDownloadURLInput{}
+		cmd.Flags().StringVar(&in.Path, "path", in.Path, "File path inside the sandbox")
+		cmd.Flags().Int64Var(&in.ExpiresInSeconds, "expires-in-seconds", in.ExpiresInSeconds, "Link TTL in seconds (omit for a link that never expires)")
+		cmd.Flags().StringVar(&in.ContentType, "content-type", in.ContentType, "Content-Type to serve the file as")
+		cmd.Flags().StringVar(&in.ContentDisposition, "content-disposition", in.ContentDisposition, "Content-Disposition to serve the file with (attachment or inline)")
+		_ = cmd.MarkFlagRequired("path")
+		return in
+	},
+	Action: func(ctx context.Context, cmd *cobra.Command, in *sandboxDownloadURLInput, args []string) (any, error) {
+		if cmd.Flags().Changed("expires-in-seconds") && in.ExpiresInSeconds < 1 {
+			return nil, fmt.Errorf("--expires-in-seconds must be greater than 0")
+		}
+
+		c, err := cmdutil.GetClient(cmd)
+		if err != nil {
+			return nil, err
+		}
+
+		params := langsmith.SandboxBoxGenerateDownloadURLParams{
+			Path: langsmith.F(in.Path),
+		}
+		if cmd.Flags().Changed("expires-in-seconds") {
+			params.ExpiresInSeconds = langsmith.F(in.ExpiresInSeconds)
+		}
+		if in.ContentType != "" {
+			params.ContentType = langsmith.F(in.ContentType)
+		}
+		if in.ContentDisposition != "" {
+			params.ContentDisposition = langsmith.F(in.ContentDisposition)
+		}
+
+		resp, err := c.SDK.Sandboxes.Boxes.GenerateDownloadURL(ctx, args[0], params)
+		if err != nil {
+			return nil, fmt.Errorf("generating download URL: %w", err)
+		}
+		return resp, nil
+	},
+	Render: sandboxDownloadURLRender,
 }
 
 var sandboxListCommand = structured.Command[struct{}]{

--- a/internal/cmd/sandbox_test.go
+++ b/internal/cmd/sandbox_test.go
@@ -90,7 +90,8 @@ func TestSandboxCmd_FlatSubcommands(t *testing.T) {
 	expected := map[string]bool{
 		"create": false, "list": false, "get": false, "update": false,
 		"delete": false, "start": false, "stop": false,
-		"exec": false, "console": false, "service-url": false, "tunnel": false, "ssh-setup": false,
+		"exec": false, "console": false, "service-url": false, "generate-download-url": false,
+		"tunnel": false, "ssh-setup": false,
 		"snapshot": false,
 	}
 	for _, sub := range cmd.Commands() {
@@ -446,6 +447,66 @@ func TestSandboxServiceURLCmd_RejectsInvalidPort(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--port must be between 1 and 65535")
+}
+
+func TestSandboxDownloadURLCmd_Flags(t *testing.T) {
+	cmd := sandboxDownloadURLCommand.Cobra()
+
+	require.NotNil(t, cmd.Flags().Lookup("path"))
+	require.NotNil(t, cmd.Flags().Lookup("expires-in-seconds"))
+	require.NotNil(t, cmd.Flags().Lookup("content-type"))
+	require.NotNil(t, cmd.Flags().Lookup("content-disposition"))
+}
+
+func TestSandboxDownloadURLCmd_GeneratesDownloadURL(t *testing.T) {
+	var body map[string]any
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/v2/sandboxes/boxes/my-vm/download-url", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"download_url":"https://box--dl.example/tok","token":"tok","expires_at":"2026-05-27T12:00:00Z"}`))
+		require.NoError(t, err)
+	})
+
+	out, err := executeCommand(t, "--api-key", "test-key", "--api-url", ts.URL, "sandbox", "generate-download-url", "my-vm",
+		"--path", "/tmp/report.pdf", "--expires-in-seconds", "3600", "--content-type", "application/pdf", "--content-disposition", "inline")
+
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/report.pdf", body["path"])
+	assert.Equal(t, float64(3600), body["expires_in_seconds"])
+	assert.Equal(t, "application/pdf", body["content_type"])
+	assert.Equal(t, "inline", body["content_disposition"])
+	assert.Contains(t, out, "Download URL:")
+	assert.Contains(t, out, "https://box--dl.example/tok")
+	assert.Contains(t, out, `curl -LO "https://box--dl.example/tok"`)
+}
+
+func TestSandboxDownloadURLCmd_RendersNeverExpires(t *testing.T) {
+	var body map[string]any
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"download_url":"https://box--dl.example/tok","token":"tok","expires_at":null}`))
+		require.NoError(t, err)
+	})
+
+	out, err := executeCommand(t, "--api-key", "test-key", "--api-url", ts.URL, "sandbox", "generate-download-url", "my-vm", "--path", "/tmp/report.pdf")
+
+	require.NoError(t, err)
+	assert.NotContains(t, body, "expires_in_seconds")
+	assert.NotContains(t, body, "content_type")
+	assert.NotContains(t, body, "content_disposition")
+	assert.Contains(t, out, "never")
+}
+
+func TestSandboxDownloadURLCmd_RejectsNonPositiveExpiry(t *testing.T) {
+	_, err := executeCommand(t, "--api-key", "test-key", "sandbox", "generate-download-url", "my-vm", "--path", "/tmp/f", "--expires-in-seconds", "0")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--expires-in-seconds must be greater than 0")
 }
 
 func TestSnapshotBuildCmd_CapacityFlag(t *testing.T) {

--- a/internal/cmd/sandbox_test.go
+++ b/internal/cmd/sandbox_test.go
@@ -502,6 +502,13 @@ func TestSandboxDownloadURLCmd_RendersNeverExpires(t *testing.T) {
 	assert.Contains(t, out, "never")
 }
 
+func TestSandboxDownloadURLCmd_RejectsUnknownDisposition(t *testing.T) {
+	_, err := executeCommand(t, "--api-key", "test-key", "sandbox", "generate-download-url", "my-vm", "--path", "/tmp/f", "--content-disposition", "sideways")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--content-disposition must be attachment or inline")
+}
+
 func TestSandboxDownloadURLCmd_RejectsNonPositiveExpiry(t *testing.T) {
 	_, err := executeCommand(t, "--api-key", "test-key", "sandbox", "generate-download-url", "my-vm", "--path", "/tmp/f", "--expires-in-seconds", "0")
 


### PR DESCRIPTION
## Overview

Adds `langsmith sandbox generate-download-url <name> --path <path>`, which mints a link that downloads one file from a sandbox with no LangSmith credential attached. Use it to hand a sandbox file to something that cannot send an API key: a browser tab, an `<a href>`, a webhook consumer.

Wraps `POST /api/v2/sandboxes/boxes/{name}/download-url` through `Sandboxes.Boxes.GenerateDownloadURL` in the generated Go SDK, so no dependency bump is needed (present since `langsmith-go v0.25.6`).

```
$ langsmith sandbox generate-download-url my-vm --path /tmp/report.pdf
Download URL: https://<sandbox-id>--dl.smithbox.dev/ey...
Expires:      never

Example:
  curl -LO "https://<sandbox-id>--dl.smithbox.dev/ey..."
```

Flags: `--path` (required), `--expires-in-seconds`, `--content-type`, `--content-disposition`.

Omitting `--expires-in-seconds` mints a link that never expires, so the rendered expiry reads `never` rather than defaulting to a time.

## Test plan

- [x] `go test ./...`
- [x] Unit: request body for the full flag set, `never` rendering on a null `expires_at`, omission of unset optional fields, non-positive `--expires-in-seconds` rejected, command registered on `sandbox`
