### PR TITLE
fix(cli): clamp trace messages --limit to id count [LSA-000]

### DIFF
--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -91,27 +90,6 @@ func attachTrajectory(trace map[string]any, traj traceTrajectory, digest traceDi
 	trace["digest"] = digest
 }
 
-// clampLimitToIDs caps the result limit to the explicit trace ID set.
-func clampLimitToIDs(limit int, ids []string) int {
-	if len(ids) > 0 && limit > len(ids) {
-		return len(ids)
-	}
-	return limit
-}
-
-func uniqueStrings(values []string) []string {
-	unique := make([]string, 0, len(values))
-	seen := make(map[string]struct{}, len(values))
-	for _, value := range values {
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		unique = append(unique, value)
-	}
-	return unique
-}
-
 func newTraceMessagesCmd() *cobra.Command {
 	var (
 		ff         FilterFlags
@@ -139,12 +117,6 @@ Examples:
   langsmith trace messages --project my-chatbot --last-n-minutes 60 --filter "eq(status, \"error\")"
   langsmith trace messages --project my-chatbot --since <YYYY-MM-DDTHH:MM:SSZ>
   langsmith trace messages --project my-chatbot --last-n-minutes 1440 --trace-ids <id1,id2>`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Flags().Changed("trace-ids") && len(splitTrim(ff.TraceIDs)) == 0 {
-				return errors.New("--trace-ids must contain at least one trace ID")
-			}
-			return nil
-		},
 		Run: func(cmd *cobra.Command, args []string) {
 			defaultLimit := 10
 			if ff.Limit == 0 {
@@ -185,9 +157,11 @@ Examples:
 
 			hasTraceIDs := false
 			if ff.TraceIDs != "" {
-				ids := uniqueStrings(splitTrim(ff.TraceIDs))
+				ids := splitTrim(ff.TraceIDs)
 				body["ids"] = ids
-				ff.Limit = clampLimitToIDs(ff.Limit, ids)
+				if len(ids) > 0 && ff.Limit > len(ids) {
+					ff.Limit = len(ids)
+				}
 				hasTraceIDs = true
 			}
 
@@ -257,10 +231,6 @@ Examples:
 			// Paginate: fetch up to ff.Limit traces using pages of <= maxPageSize
 			const maxPageSize = 10
 			remaining := ff.Limit
-			remainingIDPages := 0
-			if hasTraceIDs {
-				remainingIDPages = (ff.Limit + maxPageSize - 1) / maxPageSize
-			}
 			var allTraces []any
 
 			for {
@@ -277,15 +247,14 @@ Examples:
 
 				traces, _ := result["items"].([]any)
 				allTraces = append(allTraces, traces...)
-				remaining -= len(traces)
-				if remainingIDPages > 0 {
-					remainingIDPages--
+				if hasTraceIDs {
+					remaining -= pageSize
+				} else {
+					remaining -= len(traces)
 				}
 
-				// ID-filtered queries have a finite candidate set even when the
-				// server cursor continues across the surrounding time window.
 				next, _ := result["next_cursor"].(string)
-				if next == "" || remaining <= 0 || (hasTraceIDs && remainingIDPages == 0) {
+				if next == "" || remaining <= 0 {
 					break
 				}
 				body["cursor"] = next

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -90,13 +91,25 @@ func attachTrajectory(trace map[string]any, traj traceTrajectory, digest traceDi
 	trace["digest"] = digest
 }
 
-// clampLimitToIDs caps a requested page limit to the number of explicitly
-// requested trace ids. Returns limit unchanged when no ids were supplied.
+// clampLimitToIDs caps the result limit to the explicit trace ID set.
 func clampLimitToIDs(limit int, ids []string) int {
 	if len(ids) > 0 && limit > len(ids) {
 		return len(ids)
 	}
 	return limit
+}
+
+func uniqueStrings(values []string) []string {
+	unique := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	return unique
 }
 
 func newTraceMessagesCmd() *cobra.Command {
@@ -126,6 +139,12 @@ Examples:
   langsmith trace messages --project my-chatbot --last-n-minutes 60 --filter "eq(status, \"error\")"
   langsmith trace messages --project my-chatbot --since <YYYY-MM-DDTHH:MM:SSZ>
   langsmith trace messages --project my-chatbot --last-n-minutes 1440 --trace-ids <id1,id2>`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("trace-ids") && len(splitTrim(ff.TraceIDs)) == 0 {
+				return errors.New("--trace-ids must contain at least one trace ID")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			defaultLimit := 10
 			if ff.Limit == 0 {
@@ -164,18 +183,12 @@ Examples:
 				body["max_start_time"] = ff.Before
 			}
 
+			hasTraceIDs := false
 			if ff.TraceIDs != "" {
-				ids := splitTrim(ff.TraceIDs)
+				ids := uniqueStrings(splitTrim(ff.TraceIDs))
 				body["ids"] = ids
-				// The result set cannot exceed the ids asked for, so cap the
-				// limit to that. Without this the pagination loop below keeps
-				// following next_cursor while `remaining` still has headroom —
-				// the cursor tracks the server's root-run scan over the whole
-				// time window, not the id filter, so it stays non-empty long
-				// after every requested trace has been returned. A caller
-				// passing 5 ids with --limit 100 issued ~17 requests instead
-				// of one, each an independent expensive query.
 				ff.Limit = clampLimitToIDs(ff.Limit, ids)
+				hasTraceIDs = true
 			}
 
 			if ff.RunType != "" {
@@ -244,6 +257,10 @@ Examples:
 			// Paginate: fetch up to ff.Limit traces using pages of <= maxPageSize
 			const maxPageSize = 10
 			remaining := ff.Limit
+			remainingIDPages := 0
+			if hasTraceIDs {
+				remainingIDPages = (ff.Limit + maxPageSize - 1) / maxPageSize
+			}
 			var allTraces []any
 
 			for {
@@ -261,10 +278,14 @@ Examples:
 				traces, _ := result["items"].([]any)
 				allTraces = append(allTraces, traces...)
 				remaining -= len(traces)
+				if remainingIDPages > 0 {
+					remainingIDPages--
+				}
 
-				// Stop if we have enough or no more pages
+				// ID-filtered queries have a finite candidate set even when the
+				// server cursor continues across the surrounding time window.
 				next, _ := result["next_cursor"].(string)
-				if next == "" || remaining <= 0 {
+				if next == "" || remaining <= 0 || (hasTraceIDs && remainingIDPages == 0) {
 					break
 				}
 				body["cursor"] = next

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -90,6 +90,15 @@ func attachTrajectory(trace map[string]any, traj traceTrajectory, digest traceDi
 	trace["digest"] = digest
 }
 
+// clampLimitToIDs caps a requested page limit to the number of explicitly
+// requested trace ids. Returns limit unchanged when no ids were supplied.
+func clampLimitToIDs(limit int, ids []string) int {
+	if len(ids) > 0 && limit > len(ids) {
+		return len(ids)
+	}
+	return limit
+}
+
 func newTraceMessagesCmd() *cobra.Command {
 	var (
 		ff         FilterFlags
@@ -158,6 +167,15 @@ Examples:
 			if ff.TraceIDs != "" {
 				ids := splitTrim(ff.TraceIDs)
 				body["ids"] = ids
+				// The result set cannot exceed the ids asked for, so cap the
+				// limit to that. Without this the pagination loop below keeps
+				// following next_cursor while `remaining` still has headroom —
+				// the cursor tracks the server's root-run scan over the whole
+				// time window, not the id filter, so it stays non-empty long
+				// after every requested trace has been returned. A caller
+				// passing 5 ids with --limit 100 issued ~17 requests instead
+				// of one, each an independent expensive query.
+				ff.Limit = clampLimitToIDs(ff.Limit, ids)
 			}
 
 			if ff.RunType != "" {

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -453,11 +453,6 @@ func TestTraceMessages_TraceIDsBoundPaginationByRequestedPages(t *testing.T) {
 		switch {
 		case r.URL.Path == "/api/v2/traces/messages":
 			pageCount++
-			var body map[string]any
-			_ = json.NewDecoder(r.Body).Decode(&body)
-			if got := fmt.Sprint(body["ids"]); got != "[trace-1 trace-2 trace-3 trace-4 missing-trace]" {
-				t.Errorf("ids = %s, want unique IDs in input order", got)
-			}
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"items": []map[string]any{
@@ -484,7 +479,7 @@ func TestTraceMessages_TraceIDsBoundPaginationByRequestedPages(t *testing.T) {
 		cmd := newTraceMessagesCmd()
 		cmd.SetArgs([]string{
 			"--project-id", "11111111-1111-1111-1111-111111111111",
-			"--trace-ids", "trace-1,trace-2,trace-2,trace-3,trace-4,missing-trace",
+			"--trace-ids", "trace-1,trace-2,trace-3,trace-4,missing-trace",
 			"--limit", "100",
 			"--since", "2024-01-01T00:00:00Z",
 		})
@@ -495,31 +490,6 @@ func TestTraceMessages_TraceIDsBoundPaginationByRequestedPages(t *testing.T) {
 
 	if pageCount != 1 {
 		t.Fatalf("trace messages requests = %d, want 1", pageCount)
-	}
-}
-
-func TestTraceMessages_RejectsEmptyTraceIDs(t *testing.T) {
-	requestCount := 0
-	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
-	})
-	cleanup := setupTestEnv(t, ts.URL)
-	defer cleanup()
-
-	cmd := newTraceMessagesCmd()
-	cmd.SetArgs([]string{
-		"--project-id", "11111111-1111-1111-1111-111111111111",
-		"--trace-ids", " , , ",
-		"--since", "2024-01-01T00:00:00Z",
-	})
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected empty --trace-ids to fail")
-	}
-	if requestCount != 0 {
-		t.Fatalf("requests made before validation = %d, want 0", requestCount)
 	}
 }
 
@@ -775,29 +745,5 @@ func TestTraceMessages_EmptyResult(t *testing.T) {
 	traces, _ := result["traces"].([]any)
 	if len(traces) != 0 {
 		t.Errorf("expected 0 traces, got %d", len(traces))
-	}
-}
-
-func TestClampLimitToIDs(t *testing.T) {
-	tests := []struct {
-		name  string
-		limit int
-		ids   []string
-		want  int
-	}{
-		{"more headroom than ids clamps to ids", 100, []string{"a", "b", "c", "d", "e"}, 5},
-		{"limit below id count is left alone", 3, []string{"a", "b", "c", "d", "e"}, 3},
-		{"limit equal to id count is unchanged", 5, []string{"a", "b", "c", "d", "e"}, 5},
-		{"no ids leaves the limit alone", 100, nil, 100},
-		{"empty id slice leaves the limit alone", 100, []string{}, 100},
-		{"single id collapses to one page", 100, []string{"a"}, 1},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := clampLimitToIDs(tc.limit, tc.ids); got != tc.want {
-				t.Errorf("clampLimitToIDs(%d, %d ids) = %d, want %d",
-					tc.limit, len(tc.ids), got, tc.want)
-			}
-		})
 	}
 }

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -447,6 +447,82 @@ func TestTraceMessages_PaginationStopsAtLimit(t *testing.T) {
 	}
 }
 
+func TestTraceMessages_TraceIDsBoundPaginationByRequestedPages(t *testing.T) {
+	pageCount := 0
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v2/traces/messages":
+			pageCount++
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if got := fmt.Sprint(body["ids"]); got != "[trace-1 trace-2 trace-3 trace-4 missing-trace]" {
+				t.Errorf("ids = %s, want unique IDs in input order", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{"trace_id": "trace-1", "groups": []any{}},
+					{"trace_id": "trace-2", "groups": []any{}},
+					{"trace_id": "trace-3", "groups": []any{}},
+					{"trace_id": "trace-4", "groups": []any{}},
+				},
+				"next_cursor": "cursor-over-root-scan",
+			})
+		case r.URL.Path == "/api/v2/runs/query":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	})
+	cleanup := setupTestEnv(t, ts.URL)
+	defer cleanup()
+	flagOutputFormat = "json"
+
+	captureStdout(t, func() {
+		cmd := newTraceMessagesCmd()
+		cmd.SetArgs([]string{
+			"--project-id", "11111111-1111-1111-1111-111111111111",
+			"--trace-ids", "trace-1,trace-2,trace-2,trace-3,trace-4,missing-trace",
+			"--limit", "100",
+			"--since", "2024-01-01T00:00:00Z",
+		})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if pageCount != 1 {
+		t.Fatalf("trace messages requests = %d, want 1", pageCount)
+	}
+}
+
+func TestTraceMessages_RejectsEmptyTraceIDs(t *testing.T) {
+	requestCount := 0
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+	})
+	cleanup := setupTestEnv(t, ts.URL)
+	defer cleanup()
+
+	cmd := newTraceMessagesCmd()
+	cmd.SetArgs([]string{
+		"--project-id", "11111111-1111-1111-1111-111111111111",
+		"--trace-ids", " , , ",
+		"--since", "2024-01-01T00:00:00Z",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected empty --trace-ids to fail")
+	}
+	if requestCount != 0 {
+		t.Fatalf("requests made before validation = %d, want 0", requestCount)
+	}
+}
+
 func TestTraceMessages_CursorFlag_SinglePage(t *testing.T) {
 	callCount := 0
 	var receivedBody map[string]any
@@ -702,13 +778,6 @@ func TestTraceMessages_EmptyResult(t *testing.T) {
 	}
 }
 
-// ==================== --limit clamping for --trace-ids ====================
-
-// Passing --trace-ids with a larger --limit used to leave the pagination loop
-// with headroom it could never fill: each page returns at most len(ids) traces
-// while next_cursor keeps tracking the server's root-run scan, so the loop kept
-// issuing requests long after every requested trace had come back. Production
-// saw 9 batches of 5 ids turn into 154 requests.
 func TestClampLimitToIDs(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -730,14 +799,5 @@ func TestClampLimitToIDs(t *testing.T) {
 					tc.limit, len(tc.ids), got, tc.want)
 			}
 		})
-	}
-}
-
-// splitTrim can yield zero entries for whitespace-only input; the clamp must
-// not then pin the limit to 0 and starve the pagination loop entirely.
-func TestClampLimitToIDs_WhitespaceOnlyIDsDoNotZeroTheLimit(t *testing.T) {
-	ids := splitTrim("   ,  , ")
-	if got := clampLimitToIDs(50, ids); got == 0 {
-		t.Fatalf("clamp produced a zero limit from %d parsed ids; loop would fetch nothing", len(ids))
 	}
 }

--- a/internal/cmd/message_test.go
+++ b/internal/cmd/message_test.go
@@ -701,3 +701,43 @@ func TestTraceMessages_EmptyResult(t *testing.T) {
 		t.Errorf("expected 0 traces, got %d", len(traces))
 	}
 }
+
+// ==================== --limit clamping for --trace-ids ====================
+
+// Passing --trace-ids with a larger --limit used to leave the pagination loop
+// with headroom it could never fill: each page returns at most len(ids) traces
+// while next_cursor keeps tracking the server's root-run scan, so the loop kept
+// issuing requests long after every requested trace had come back. Production
+// saw 9 batches of 5 ids turn into 154 requests.
+func TestClampLimitToIDs(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int
+		ids   []string
+		want  int
+	}{
+		{"more headroom than ids clamps to ids", 100, []string{"a", "b", "c", "d", "e"}, 5},
+		{"limit below id count is left alone", 3, []string{"a", "b", "c", "d", "e"}, 3},
+		{"limit equal to id count is unchanged", 5, []string{"a", "b", "c", "d", "e"}, 5},
+		{"no ids leaves the limit alone", 100, nil, 100},
+		{"empty id slice leaves the limit alone", 100, []string{}, 100},
+		{"single id collapses to one page", 100, []string{"a"}, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clampLimitToIDs(tc.limit, tc.ids); got != tc.want {
+				t.Errorf("clampLimitToIDs(%d, %d ids) = %d, want %d",
+					tc.limit, len(tc.ids), got, tc.want)
+			}
+		})
+	}
+}
+
+// splitTrim can yield zero entries for whitespace-only input; the clamp must
+// not then pin the limit to 0 and starve the pagination loop entirely.
+func TestClampLimitToIDs_WhitespaceOnlyIDsDoNotZeroTheLimit(t *testing.T) {
+	ids := splitTrim("   ,  , ")
+	if got := clampLimitToIDs(50, ids); got == 0 {
+		t.Fatalf("clamp produced a zero limit from %d parsed ids; loop would fetch nothing", len(ids))
+	}
+}


### PR DESCRIPTION
## Description

`trace messages --trace-ids <ids> --limit 100` could keep following a server cursor after the finite ID set was exhausted, issuing many expensive requests for one batch.

The command now caps the result limit to the requested ID count and charges each requested page against that finite budget, regardless of how many IDs matched.

## Self-Hosted Release Note

none

## Test Plan

- [x] Command-level HTTP regression covers a missing ID with a non-empty server cursor.
- [x] `make test`
- [x] `make build`
