### PR TITLE
Propagate output write failures [LSDK-426]

### DIFF
--- a/internal/cmd/apps_claim.go
+++ b/internal/cmd/apps_claim.go
@@ -55,13 +55,12 @@ you need when this workspace already has an app by that name.`,
 					name = as
 				}
 			}
-			output.OutputJSON(map[string]any{
+			return output.OutputJSON(map[string]any{
 				"status": "claimed",
 				"app_id": id,
 				"name":   name,
 				"scope":  appScopeWorkspace,
 			}, "")
-			return nil
 		},
 	}
 

--- a/internal/cmd/apps_crud_test.go
+++ b/internal/cmd/apps_crud_test.go
@@ -82,6 +82,21 @@ func TestAppsListCmd_HasOutputFlag(t *testing.T) {
 	}
 }
 
+func TestAppsList_ReturnsOutputWriteError(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	})
+	defer setupTestEnv(t, srv.URL)()
+	flagOutputFormat = "json"
+
+	cmd := newAppsCmd()
+	cmd.SetArgs([]string{"list", "--output", t.TempDir()})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected output write error")
+	}
+}
+
 func TestAppsDelete_SkipsConfirmationWithYes(t *testing.T) {
 	const id = "11111111-1111-1111-1111-111111111111"
 	var sawDelete bool

--- a/internal/cmd/apps_delete.go
+++ b/internal/cmd/apps_delete.go
@@ -43,12 +43,11 @@ func newAppsDeleteCmd() *cobra.Command {
 				}
 				return fmt.Errorf("deleting custom app %s: %w", id, err)
 			}
-			output.OutputJSON(map[string]any{
+			return output.OutputJSON(map[string]any{
 				"status": "deleted",
 				"app_id": id,
 				"name":   name,
 			}, "")
-			return nil
 		},
 	}
 

--- a/internal/cmd/apps_dev.go
+++ b/internal/cmd/apps_dev.go
@@ -122,10 +122,12 @@ func runAppsDev(ctx context.Context, c *client.Client, dir, entrypoint string, n
 	if !noOpen {
 		_ = openBrowser(previewURL)
 	}
-	output.OutputJSON(map[string]any{
+	if err := output.OutputJSON(map[string]any{
 		"status": "serving",
 		"url":    previewURL,
-	}, "")
+	}, ""); err != nil {
+		return err
+	}
 	fmt.Fprintf(os.Stderr, "Serving %s at %s (sandboxed) — press Ctrl+C to stop\n", dir, previewURL)
 	fmt.Fprintln(os.Stderr, appsDevLogModeBanner())
 

--- a/internal/cmd/apps_init.go
+++ b/internal/cmd/apps_init.go
@@ -164,14 +164,13 @@ Installs dependencies as the last step, so you can cd in and run
 				return err
 			}
 			fmt.Fprintf(os.Stderr, "Next: cd %s && langsmith apps dev.\n", slug)
-			output.OutputJSON(map[string]any{
+			return output.OutputJSON(map[string]any{
 				"status":   "scaffolded",
 				"dir":      dir,
 				"name":     name,
 				"template": templateName,
 				"files":    written,
 			}, "")
-			return nil
 		},
 	}
 

--- a/internal/cmd/apps_list.go
+++ b/internal/cmd/apps_list.go
@@ -56,8 +56,7 @@ func newAppsListCmd() *cobra.Command {
 					"organization_id": a.OrganizationID,
 				})
 			}
-			output.OutputJSON(data, outputFile)
-			return nil
+			return output.OutputJSON(data, outputFile)
 		},
 	}
 

--- a/internal/cmd/apps_pull.go
+++ b/internal/cmd/apps_pull.go
@@ -89,7 +89,7 @@ organization. Pass --scope to force one tier.`,
 
 			fmt.Fprintf(os.Stderr, "Pulled %q into %s (%d files).\n", app.Name, dest, len(written))
 			fmt.Fprintf(os.Stderr, "Next: cd %s && npm install && langsmith apps dev.\n", dirName)
-			output.OutputJSON(map[string]any{
+			return output.OutputJSON(map[string]any{
 				"status": "pulled",
 				"app_id": app.ID,
 				"name":   app.Name,
@@ -97,7 +97,6 @@ organization. Pass --scope to force one tier.`,
 				"dir":    dest,
 				"files":  written,
 			}, "")
-			return nil
 		},
 	}
 

--- a/internal/cmd/apps_push.go
+++ b/internal/cmd/apps_push.go
@@ -160,7 +160,9 @@ same app too.
 				"entrypoint": app.Entrypoint,
 				"files":      paths,
 			}
-			output.OutputJSON(result, "")
+			if err := output.OutputJSON(result, ""); err != nil {
+				return err
+			}
 
 			workspaceID := app.TenantID
 			if workspaceID == "" {

--- a/internal/cmd/apps_share.go
+++ b/internal/cmd/apps_share.go
@@ -37,13 +37,12 @@ workspaces can copy one into their own with "langsmith apps claim".`,
 				return fmt.Errorf("sharing custom app %s: %w", app.ID, err)
 			}
 
-			output.OutputJSON(map[string]any{
+			return output.OutputJSON(map[string]any{
 				"status": "shared",
 				"app_id": app.ID,
 				"name":   app.Name,
 				"scope":  appScopeOrg,
 			}, "")
-			return nil
 		},
 	}
 	return cmd

--- a/internal/cmd/dataset.go
+++ b/internal/cmd/dataset.go
@@ -152,9 +152,13 @@ func newDatasetGetCmd() *cobra.Command {
 
 			fmt_ := GetFormat()
 			if fmt_ == "pretty" {
-				output.PrintOutput(data, "pretty", outputFile)
+				if err := output.PrintOutput(data, "pretty", outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			} else {
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}

--- a/internal/cmd/dataset.go
+++ b/internal/cmd/dataset.go
@@ -113,7 +113,9 @@ func newDatasetListCmd() *cobra.Command {
 						"created_at":    formatTimeISO(ds.CreatedAt),
 					})
 				}
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}
@@ -192,13 +194,15 @@ func newDatasetCreateCmd() *cobra.Command {
 				ExitErrorf("creating dataset: %v", err)
 			}
 
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status":      "created",
 				"id":          ds.ID,
 				"name":        ds.Name,
 				"description": nilStr(ds.Description),
 				"created_at":  formatTimeISO(ds.CreatedAt),
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 
@@ -239,11 +243,13 @@ func newDatasetDeleteCmd() *cobra.Command {
 				ExitErrorf("deleting dataset: %v", err)
 			}
 
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status": "deleted",
 				"id":     ds.ID,
 				"name":   ds.Name,
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 
@@ -302,12 +308,14 @@ func newDatasetExportCmd() *cobra.Command {
 				ExitErrorf("writing file: %v", err)
 			}
 
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status":  "exported",
 				"dataset": ds.Name,
 				"count":   len(data),
 				"path":    outputFile,
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 
@@ -394,12 +402,14 @@ func newDatasetUploadCmd() *cobra.Command {
 				}
 			}
 
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status":        "uploaded",
 				"dataset_id":    ds.ID,
 				"dataset_name":  name,
 				"example_count": len(items),
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 

--- a/internal/cmd/evaluator.go
+++ b/internal/cmd/evaluator.go
@@ -93,9 +93,11 @@ Examples:
 			}
 
 			if len(matching) == 0 {
-				output.OutputJSON(map[string]any{
+				if err := output.OutputJSON(map[string]any{
 					"error": "no matching evaluators found",
-				}, "")
+				}, ""); err != nil {
+					ExitErrorf("%v", err)
+				}
 				return
 			}
 
@@ -124,9 +126,13 @@ Examples:
 			}
 
 			if len(data) == 1 {
-				output.OutputJSON(data[0], outputFile)
+				if err := output.OutputJSON(data[0], outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			} else {
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}
@@ -183,7 +189,9 @@ func newEvaluatorListCmd() *cobra.Command {
 						"session_id":    nilStr(rule.SessionID),
 					})
 				}
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}
@@ -212,7 +220,9 @@ func newEvaluatorUploadCmd() *cobra.Command {
 			evaluatorFile := args[0]
 
 			if err := validateEvaluatorTargetFlags(targetDataset, targetProject); err != nil {
-				output.OutputJSON(map[string]any{"error": err.Error()}, "")
+				if err := output.OutputJSON(map[string]any{"error": err.Error()}, ""); err != nil {
+					ExitErrorf("%v", err)
+				}
 				return
 			}
 
@@ -292,10 +302,12 @@ func newEvaluatorUploadCmd() *cobra.Command {
 			existing := findEvaluator(*rules, name, datasetID, projectID)
 			if existing != nil {
 				if !replace {
-					output.OutputJSON(map[string]any{
+					if err := output.OutputJSON(map[string]any{
 						"error": fmt.Sprintf("Evaluator '%s' already exists (use --replace to overwrite)", name),
 						"id":    existing.ID,
-					}, "")
+					}, ""); err != nil {
+						ExitErrorf("%v", err)
+					}
 					return
 				}
 				if !yes {
@@ -321,12 +333,14 @@ func newEvaluatorUploadCmd() *cobra.Command {
 			if datasetID != "" {
 				targetLabel = "dataset"
 			}
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status": "uploaded",
 				"id":     result["id"],
 				"name":   name,
 				"target": targetLabel,
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 
@@ -399,7 +413,9 @@ Examples:
 					ExitError("aborted")
 				}
 				if existing != nil {
-					output.OutputJSON(map[string]any{"error": err.Error(), "id": existing.ID}, "")
+					if err := output.OutputJSON(map[string]any{"error": err.Error(), "id": existing.ID}, ""); err != nil {
+						ExitErrorf("%v", err)
+					}
 					return
 				}
 				ExitErrorf("%v", err)
@@ -417,10 +433,12 @@ Examples:
 			if target.datasetID != "" {
 				targetLabel = "dataset"
 			}
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status": "created", "type": "llm",
 				"id": result["id"], "name": name, "target": targetLabel,
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 
@@ -468,7 +486,9 @@ func newEvaluatorDeleteCmd() *cobra.Command {
 			}
 
 			if len(matching) == 0 {
-				output.OutputJSON(map[string]any{"error": fmt.Sprintf("Evaluator '%s' not found", name)}, "")
+				if err := output.OutputJSON(map[string]any{"error": fmt.Sprintf("Evaluator '%s' not found", name)}, ""); err != nil {
+					ExitErrorf("%v", err)
+				}
 				return
 			}
 
@@ -488,12 +508,13 @@ func newEvaluatorDeleteCmd() *cobra.Command {
 				}
 				deleted++
 			}
-
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status": "deleted",
 				"name":   name,
 				"count":  deleted,
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 

--- a/internal/cmd/example.go
+++ b/internal/cmd/example.go
@@ -133,7 +133,9 @@ func newExampleListCmd() *cobra.Command {
 					}
 					data = append(data, entry)
 				}
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}
@@ -167,14 +169,18 @@ func newExampleCreateCmd() *cobra.Command {
 			// Parse JSON inputs
 			var parsedInputs map[string]any
 			if err := json.Unmarshal([]byte(inputs), &parsedInputs); err != nil {
-				output.OutputJSON(map[string]any{"error": fmt.Sprintf("Invalid JSON for --inputs: %v", err)}, "")
+				if err := output.OutputJSON(map[string]any{"error": fmt.Sprintf("Invalid JSON for --inputs: %v", err)}, ""); err != nil {
+					ExitErrorf("%v", err)
+				}
 				return
 			}
 
 			var parsedOutputs map[string]any
 			if outputs != "" {
 				if err := json.Unmarshal([]byte(outputs), &parsedOutputs); err != nil {
-					output.OutputJSON(map[string]any{"error": fmt.Sprintf("Invalid JSON for --outputs: %v", err)}, "")
+					if err := output.OutputJSON(map[string]any{"error": fmt.Sprintf("Invalid JSON for --outputs: %v", err)}, ""); err != nil {
+						ExitErrorf("%v", err)
+					}
 					return
 				}
 			}
@@ -182,12 +188,15 @@ func newExampleCreateCmd() *cobra.Command {
 			var parsedMetadata map[string]any
 			if metadata != "" {
 				if err := json.Unmarshal([]byte(metadata), &parsedMetadata); err != nil {
-					output.OutputJSON(map[string]any{"error": fmt.Sprintf("Invalid JSON for --metadata: %v", err)}, "")
+					if err := output.OutputJSON(map[string]any{"error": fmt.Sprintf("Invalid JSON for --metadata: %v", err)}, ""); err != nil {
+						ExitErrorf("%v", err)
+
+						// Resolve dataset
+					}
 					return
 				}
 			}
 
-			// Resolve dataset
 			ds, err := resolveDataset(ctx, c, datasetName)
 			if err != nil {
 				ExitErrorf("%v", err)
@@ -213,14 +222,15 @@ func newExampleCreateCmd() *cobra.Command {
 			if err != nil {
 				ExitErrorf("creating example: %v", err)
 			}
-
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status":     "created",
 				"id":         ex.ID,
 				"dataset_id": ex.DatasetID,
 				"inputs":     ex.Inputs,
 				"outputs":    ex.Outputs,
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 
@@ -261,11 +271,12 @@ func newExampleDeleteCmd() *cobra.Command {
 			if err != nil {
 				ExitErrorf("deleting example: %v", err)
 			}
-
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status": "deleted",
 				"id":     exampleID,
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 

--- a/internal/cmd/experiment.go
+++ b/internal/cmd/experiment.go
@@ -185,9 +185,13 @@ func newExperimentGetCmd() *cobra.Command {
 
 			fmt_ := GetFormat()
 			if fmt_ == "pretty" {
-				output.PrintOutput(data, "pretty", outputFile)
+				if err := output.PrintOutput(data, "pretty", outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			} else {
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}

--- a/internal/cmd/experiment.go
+++ b/internal/cmd/experiment.go
@@ -110,7 +110,9 @@ func newExperimentListCmd() *cobra.Command {
 					}
 					data = append(data, entry)
 				}
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}

--- a/internal/cmd/hub_delete.go
+++ b/internal/cmd/hub_delete.go
@@ -39,11 +39,13 @@ func newHubDeleteCmd() *cobra.Command {
 			if err := c.SDK.Repos.Directories.Delete(ctx, owner, name, langsmith.RepoDirectoryDeleteParams{}); err != nil {
 				return fmt.Errorf("deleting %s/%s: %w", owner, name, err)
 			}
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status": "deleted",
 				"owner":  owner,
 				"repo":   name,
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 			return nil
 		},
 	}

--- a/internal/cmd/hub_get.go
+++ b/internal/cmd/hub_get.go
@@ -25,7 +25,9 @@ func newHubGetCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("getting %s/%s: %w", owner, name, err)
 			}
-			output.OutputJSON(sdkRepoToHubRepo(resp.Repo), "")
+			if err := output.OutputJSON(sdkRepoToHubRepo(resp.Repo), ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 			return nil
 		},
 	}

--- a/internal/cmd/hub_init.go
+++ b/internal/cmd/hub_init.go
@@ -36,13 +36,15 @@ func newHubInitCmd() *cobra.Command {
 				return err
 			}
 			sort.Strings(written)
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status": "scaffolded",
 				"dir":    dir,
 				"type":   repoType,
 				"name":   name,
 				"files":  written,
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 			return nil
 		},
 	}

--- a/internal/cmd/hub_list.go
+++ b/internal/cmd/hub_list.go
@@ -85,11 +85,12 @@ func newHubListCmd() *cobra.Command {
 				output.OutputTable(columns, rows, "Hub repos")
 				return nil
 			}
-
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"total": int(resp.Total),
 				"repos": repos,
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 			return nil
 		},
 	}

--- a/internal/cmd/hub_pull.go
+++ b/internal/cmd/hub_pull.go
@@ -70,7 +70,9 @@ func newHubPullCmd() *cobra.Command {
 			if len(linked) > 0 {
 				out["linked_children"] = linked
 			}
-			output.OutputJSON(out, "")
+			if err := output.OutputJSON(out, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 			return nil
 		},
 	}

--- a/internal/cmd/hub_push.go
+++ b/internal/cmd/hub_push.go
@@ -92,7 +92,7 @@ func newHubPushCmd() *cobra.Command {
 				paths = append(paths, k)
 			}
 			sort.Strings(paths)
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status":      "pushed",
 				"owner":       owner,
 				"repo":        name,
@@ -101,7 +101,9 @@ func newHubPushCmd() *cobra.Command {
 				"commit_hash": resp.Commit.CommitHash,
 				"created_at":  resp.Commit.CreatedAt,
 				"files":       paths,
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 			return nil
 		},
 	}

--- a/internal/cmd/insights.go
+++ b/internal/cmd/insights.go
@@ -100,7 +100,9 @@ for full details including the executive summary and category breakdown.`,
 				for _, job := range jobs {
 					data = append(data, insightJobToMap(job))
 				}
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}
@@ -155,7 +157,9 @@ statistics (error rates, latency, costs, token usage, feedback scores).`,
 				printInsightPretty(detail)
 			} else {
 				data := buildInsightDetailJSON(detail)
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}

--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -192,7 +192,9 @@ Examples:
 				}
 				output.OutputTable(columns, rows, fmt.Sprintf("Issues for %s", projectName))
 			} else {
-				output.OutputJSON(json.RawMessage(page.JSON.RawJSON()), outputFile)
+				if err := output.OutputJSON(json.RawMessage(page.JSON.RawJSON()), outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}
@@ -229,8 +231,9 @@ Examples:
 			if err != nil {
 				ExitErrorf("getting issue: %v", err)
 			}
-
-			output.OutputJSON(json.RawMessage(issue.JSON.RawJSON()), outputFile)
+			if err := output.OutputJSON(json.RawMessage(issue.JSON.RawJSON()), outputFile); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 
@@ -340,7 +343,9 @@ Examples:
 					}
 					data = append(data, m)
 				}
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}
@@ -451,8 +456,9 @@ Examples:
 			if err := c.RawPatch(ctx, path, body, &issue); err != nil {
 				ExitErrorf("updating issue: %v", err)
 			}
-
-			output.OutputJSON(issueToMap(issue), outputFile)
+			if err := output.OutputJSON(issueToMap(issue), outputFile); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 
@@ -796,8 +802,9 @@ Examples:
 			if err := c.RawPost(ctx, path, body, &result); err != nil {
 				ExitErrorf("proposing example: %v", err)
 			}
-
-			output.OutputJSON(result, outputFile)
+			if err := output.OutputJSON(result, outputFile); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -218,12 +218,15 @@ Examples:
 				if fmt_ == "pretty" {
 					printTraceMessages(combined)
 				} else {
-					output.OutputJSON(combined, outputFile)
+					if err := output.OutputJSON(combined, outputFile); err != nil {
+						ExitErrorf("%v", err)
+
+						// Paginate: fetch up to ff.Limit traces using pages of <= maxPageSize
+					}
 				}
 				return
 			}
 
-			// Paginate: fetch up to ff.Limit traces using pages of <= maxPageSize
 			const maxPageSize = 10
 			remaining := ff.Limit
 			var allTraces []any
@@ -274,7 +277,9 @@ Examples:
 			if fmt_ == "pretty" {
 				printTraceMessages(combined)
 			} else {
-				output.OutputJSON(combined, outputFile)
+				if err := output.OutputJSON(combined, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -124,7 +124,9 @@ func newProjectListCmd() *cobra.Command {
 					}
 					data = append(data, entry)
 				}
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}

--- a/internal/cmd/prompt.go
+++ b/internal/cmd/prompt.go
@@ -148,7 +148,9 @@ func newPromptListCmd() *cobra.Command {
 				for _, r := range repos {
 					data = append(data, repoToMap(r))
 				}
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}
@@ -238,8 +240,9 @@ func newPromptCreateCmd() *cobra.Command {
 			if err != nil {
 				ExitErrorf("creating prompt: %v", err)
 			}
-
-			output.OutputJSON(repoToMap(resp.Repo), "")
+			if err := output.OutputJSON(repoToMap(resp.Repo), ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 
@@ -281,12 +284,13 @@ func newPromptDeleteCmd() *cobra.Command {
 			if err != nil {
 				ExitErrorf("deleting prompt %s/%s: %v", owner, repo, err)
 			}
-
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status": "deleted",
 				"owner":  owner,
 				"repo":   repo,
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 
@@ -336,9 +340,13 @@ func newPromptPullCmd() *cobra.Command {
 
 			fmt_ := GetFormat()
 			if fmt_ == "pretty" {
-				output.PrintOutput(data, "pretty", outputFile)
+				if err := output.PrintOutput(data, "pretty", outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			} else {
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}
@@ -400,15 +408,16 @@ func newPromptPushCmd() *cobra.Command {
 			if err != nil {
 				ExitErrorf("pushing commit to %s/%s: %v", owner, repo, err)
 			}
-
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status":      "pushed",
 				"owner":       owner,
 				"repo":        repo,
 				"commit_hash": resp.Commit.CommitHash,
 				"commit_id":   resp.Commit.ID,
 				"created_at":  formatTimeISO(resp.Commit.CreatedAt),
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 
@@ -489,7 +498,9 @@ func newPromptCommitsCmd() *cobra.Command {
 						"created_at":         formatTimeISO(c.CreatedAt),
 					})
 				}
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}
@@ -574,7 +585,9 @@ func newPromptTagListCmd() *cobra.Command {
 						"updated_at":  t.UpdatedAt,
 					})
 				}
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}
@@ -611,13 +624,14 @@ func newPromptTagCreateCmd() *cobra.Command {
 			if err := c.RawPost(ctx, path, body, &tag); err != nil {
 				ExitErrorf("creating tag %q: %v", tagName, err)
 			}
-
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status":      "created",
 				"tag_name":    tag.TagName,
 				"commit_id":   tag.CommitID,
 				"commit_hash": tag.CommitHash,
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 
@@ -654,13 +668,14 @@ func newPromptTagUpdateCmd() *cobra.Command {
 			if err := c.RawPost(ctx, path, body, &tag); err != nil {
 				ExitErrorf("updating tag %q: %v", tagName, err)
 			}
-
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status":      "updated",
 				"tag_name":    tag.TagName,
 				"commit_id":   tag.CommitID,
 				"commit_hash": tag.CommitHash,
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 

--- a/internal/cmd/prompt.go
+++ b/internal/cmd/prompt.go
@@ -193,9 +193,13 @@ func newPromptGetCmd() *cobra.Command {
 
 			fmt_ := GetFormat()
 			if fmt_ == "pretty" {
-				output.PrintOutput(data, "pretty", outputFile)
+				if err := output.PrintOutput(data, "pretty", outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			} else {
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -81,7 +81,9 @@ func newRunListCmd() *cobra.Command {
 				output.PrintRunsTable(os.Stdout, data, includeMetadata, "Runs")
 			} else {
 				data := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}
@@ -148,9 +150,13 @@ func newRunGetCmd() *cobra.Command {
 			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
-				output.PrintOutput(data, "pretty", outputFile)
+				if err := output.PrintOutput(data, "pretty", outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			} else {
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -210,7 +210,9 @@ func newRunExportCmd() *cobra.Command {
 			}
 
 			data := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)
-			output.OutputJSONL(data, outputFile)
+			if err := output.OutputJSONL(data, outputFile); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 

--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -170,7 +170,9 @@ func newThreadListCmd() *cobra.Command {
 						"max_start_time": t.MaxStartTime,
 					})
 				}
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}
@@ -254,7 +256,9 @@ func newThreadGetCmd() *cobra.Command {
 					"run_count": len(extracted),
 					"runs":      extracted,
 				}
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}
@@ -352,7 +356,9 @@ Examples:
 			if fmt_ == "pretty" {
 				printThreadMessages(result)
 			} else {
-				output.OutputJSON(result, outputFile)
+				if err := output.OutputJSON(result, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -141,13 +141,17 @@ func newTraceListCmd() *cobra.Command {
 							"runs":      extractRunsToMaps(allRuns, includeMetadata, includeIO, includeFeedback),
 						})
 					}
-					output.OutputJSON(result, outputFile)
+					if err := output.OutputJSON(result, outputFile); err != nil {
+						ExitErrorf("%v", err)
+					}
 				} else {
 					data := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)
 					if flaggedByTrace != nil {
 						annotateFlagged(data, flaggedByTrace)
 					}
-					output.OutputJSON(data, outputFile)
+					if err := output.OutputJSON(data, outputFile); err != nil {
+						ExitErrorf("%v", err)
+					}
 				}
 			}
 		},
@@ -224,7 +228,9 @@ func newTraceGetCmd() *cobra.Command {
 					"run_count": len(runs),
 					"runs":      extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback),
 				}
-				output.OutputJSON(data, outputFile)
+				if err := output.OutputJSON(data, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 		},
 	}
@@ -336,12 +342,13 @@ func newTraceExportCmd() *cobra.Command {
 				f.Close()
 				exported++
 			}
-
-			output.OutputJSON(map[string]any{
+			if err := output.OutputJSON(map[string]any{
 				"status":     "exported",
 				"count":      exported,
 				"output_dir": outputDir,
-			}, "")
+			}, ""); err != nil {
+				ExitErrorf("%v", err)
+			}
 		},
 	}
 

--- a/internal/cmd/trace_stats.go
+++ b/internal/cmd/trace_stats.go
@@ -92,7 +92,9 @@ Examples:
 				if hasCompare {
 					result["compare"] = compare
 				}
-				output.OutputJSON(result, outputFile)
+				if err := output.OutputJSON(result, outputFile); err != nil {
+					ExitErrorf("%v", err)
+				}
 			}
 			return nil
 		},

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -26,9 +26,7 @@ func OutputJSON(data any, filePath string) error {
 		}
 		fmt.Fprintf(os.Stderr, `{"status": "written", "path": %q}`+"\n", filePath)
 	} else {
-		if _, err := fmt.Fprintln(os.Stdout, string(jsonBytes)); err != nil {
-			return fmt.Errorf("write JSON: %w", err)
-		}
+		fmt.Println(string(jsonBytes))
 	}
 	return nil
 }
@@ -46,9 +44,7 @@ func OutputJSONL(items []map[string]any, filePath string) error {
 			if err != nil {
 				return fmt.Errorf("encode JSONL item: %w", err)
 			}
-			if _, err := fmt.Fprintln(os.Stdout, string(line)); err != nil {
-				return fmt.Errorf("write JSONL: %w", err)
-			}
+			fmt.Println(string(line))
 		}
 	}
 	return nil
@@ -173,9 +169,7 @@ func PrintOutput(data any, format string, filePath string) error {
 				return fmt.Errorf("write JSON to %q: %w", filePath, err)
 			}
 		} else {
-			if _, err := fmt.Fprintln(os.Stdout, string(jsonBytes)); err != nil {
-				return fmt.Errorf("write JSON: %w", err)
-			}
+			fmt.Println(string(jsonBytes))
 		}
 		return nil
 	} else {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -14,45 +14,67 @@ import (
 
 // OutputJSON writes data as indented JSON to stdout or a file.
 // If filePath is non-empty, writes to file and prints status to stderr.
-func OutputJSON(data any, filePath string) {
+func OutputJSON(data any, filePath string) error {
 	jsonBytes, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
-		PrintError(fmt.Sprintf("JSON encoding error: %v", err))
-		return
+		return fmt.Errorf("encode JSON: %w", err)
 	}
 
 	if filePath != "" {
 		if err := os.WriteFile(filePath, jsonBytes, 0644); err != nil {
-			PrintError(fmt.Sprintf("write error: %v", err))
-			return
+			return fmt.Errorf("write JSON to %q: %w", filePath, err)
 		}
-		fmt.Fprintf(os.Stderr, `{"status": "written", "path": %q}`+"\n", filePath)
+		if _, err := fmt.Fprintf(os.Stderr, `{"status": "written", "path": %q}`+"\n", filePath); err != nil {
+			return fmt.Errorf("write status: %w", err)
+		}
 	} else {
-		fmt.Println(string(jsonBytes))
+		if _, err := fmt.Fprintln(os.Stdout, string(jsonBytes)); err != nil {
+			return fmt.Errorf("write JSON: %w", err)
+		}
 	}
+	return nil
 }
 
 // OutputJSONL writes items as JSONL (one JSON object per line).
-func OutputJSONL(items []map[string]any, filePath string) {
+func OutputJSONL(items []map[string]any, filePath string) error {
 	if filePath != "" {
 		f, err := os.Create(filePath)
 		if err != nil {
-			PrintError(fmt.Sprintf("write error: %v", err))
-			return
+			return fmt.Errorf("create JSONL file %q: %w", filePath, err)
 		}
-		defer f.Close()
 		for _, item := range items {
-			line, _ := json.Marshal(item)
-			_, _ = f.Write(line)
-			_, _ = f.WriteString("\n")
+			line, err := json.Marshal(item)
+			if err != nil {
+				_ = f.Close()
+				return fmt.Errorf("encode JSONL item: %w", err)
+			}
+			if _, err := f.Write(line); err != nil {
+				_ = f.Close()
+				return fmt.Errorf("write JSONL to %q: %w", filePath, err)
+			}
+			if _, err := f.WriteString("\n"); err != nil {
+				_ = f.Close()
+				return fmt.Errorf("write JSONL to %q: %w", filePath, err)
+			}
 		}
-		fmt.Fprintf(os.Stderr, `{"status": "written", "path": %q, "count": %d}`+"\n", filePath, len(items))
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("close JSONL file %q: %w", filePath, err)
+		}
+		if _, err := fmt.Fprintf(os.Stderr, `{"status": "written", "path": %q, "count": %d}`+"\n", filePath, len(items)); err != nil {
+			return fmt.Errorf("write status: %w", err)
+		}
 	} else {
 		for _, item := range items {
-			line, _ := json.Marshal(item)
-			fmt.Println(string(line))
+			line, err := json.Marshal(item)
+			if err != nil {
+				return fmt.Errorf("encode JSONL item: %w", err)
+			}
+			if _, err := fmt.Fprintln(os.Stdout, string(line)); err != nil {
+				return fmt.Errorf("write JSONL: %w", err)
+			}
 		}
 	}
+	return nil
 }
 
 // OutputTable prints a table to stdout using tablewriter.
@@ -139,17 +161,25 @@ func addChildren(node treeprint.Tree, parentID string, childrenMap map[string][]
 }
 
 // PrintOutput dispatches to JSON or pretty output.
-func PrintOutput(data any, format string, filePath string) {
+func PrintOutput(data any, format string, filePath string) error {
 	if format == "pretty" {
 		// Pretty mode: just pretty-print JSON to stdout
-		jsonBytes, _ := json.MarshalIndent(data, "", "  ")
-		if filePath != "" {
-			_ = os.WriteFile(filePath, jsonBytes, 0644)
-		} else {
-			fmt.Println(string(jsonBytes))
+		jsonBytes, err := json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			return fmt.Errorf("encode JSON: %w", err)
 		}
+		if filePath != "" {
+			if err := os.WriteFile(filePath, jsonBytes, 0644); err != nil {
+				return fmt.Errorf("write JSON to %q: %w", filePath, err)
+			}
+		} else {
+			if _, err := fmt.Fprintln(os.Stdout, string(jsonBytes)); err != nil {
+				return fmt.Errorf("write JSON: %w", err)
+			}
+		}
+		return nil
 	} else {
-		OutputJSON(data, filePath)
+		return OutputJSON(data, filePath)
 	}
 }
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -24,9 +24,7 @@ func OutputJSON(data any, filePath string) error {
 		if err := os.WriteFile(filePath, jsonBytes, 0644); err != nil {
 			return fmt.Errorf("write JSON to %q: %w", filePath, err)
 		}
-		if _, err := fmt.Fprintf(os.Stderr, `{"status": "written", "path": %q}`+"\n", filePath); err != nil {
-			return fmt.Errorf("write status: %w", err)
-		}
+		fmt.Fprintf(os.Stderr, `{"status": "written", "path": %q}`+"\n", filePath)
 	} else {
 		if _, err := fmt.Fprintln(os.Stdout, string(jsonBytes)); err != nil {
 			return fmt.Errorf("write JSON: %w", err)
@@ -38,31 +36,10 @@ func OutputJSON(data any, filePath string) error {
 // OutputJSONL writes items as JSONL (one JSON object per line).
 func OutputJSONL(items []map[string]any, filePath string) error {
 	if filePath != "" {
-		f, err := os.Create(filePath)
-		if err != nil {
-			return fmt.Errorf("create JSONL file %q: %w", filePath, err)
+		if err := writeJSONLFile(items, filePath); err != nil {
+			return err
 		}
-		for _, item := range items {
-			line, err := json.Marshal(item)
-			if err != nil {
-				_ = f.Close()
-				return fmt.Errorf("encode JSONL item: %w", err)
-			}
-			if _, err := f.Write(line); err != nil {
-				_ = f.Close()
-				return fmt.Errorf("write JSONL to %q: %w", filePath, err)
-			}
-			if _, err := f.WriteString("\n"); err != nil {
-				_ = f.Close()
-				return fmt.Errorf("write JSONL to %q: %w", filePath, err)
-			}
-		}
-		if err := f.Close(); err != nil {
-			return fmt.Errorf("close JSONL file %q: %w", filePath, err)
-		}
-		if _, err := fmt.Fprintf(os.Stderr, `{"status": "written", "path": %q, "count": %d}`+"\n", filePath, len(items)); err != nil {
-			return fmt.Errorf("write status: %w", err)
-		}
+		fmt.Fprintf(os.Stderr, `{"status": "written", "path": %q, "count": %d}`+"\n", filePath, len(items))
 	} else {
 		for _, item := range items {
 			line, err := json.Marshal(item)
@@ -72,6 +49,29 @@ func OutputJSONL(items []map[string]any, filePath string) error {
 			if _, err := fmt.Fprintln(os.Stdout, string(line)); err != nil {
 				return fmt.Errorf("write JSONL: %w", err)
 			}
+		}
+	}
+	return nil
+}
+
+func writeJSONLFile(items []map[string]any, filePath string) (err error) {
+	f, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("create JSONL file %q: %w", filePath, err)
+	}
+	defer func() {
+		if closeErr := f.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("close JSONL file %q: %w", filePath, closeErr)
+		}
+	}()
+
+	for _, item := range items {
+		line, err := json.Marshal(item)
+		if err != nil {
+			return fmt.Errorf("encode JSONL item: %w", err)
+		}
+		if _, err := fmt.Fprintln(f, string(line)); err != nil {
+			return fmt.Errorf("write JSONL to %q: %w", filePath, err)
 		}
 	}
 	return nil

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -14,7 +14,9 @@ func TestOutputJSON(t *testing.T) {
 		"id":   "123",
 		"name": "test",
 	}
-	OutputJSON(data, "")
+	if err := OutputJSON(data, ""); err != nil {
+		t.Fatalf("OutputJSON: %v", err)
+	}
 }
 
 func TestOutputJSONToFile(t *testing.T) {
@@ -26,7 +28,9 @@ func TestOutputJSONToFile(t *testing.T) {
 		{"id": "2", "name": "second"},
 	}
 
-	OutputJSON(data, fpath)
+	if err := OutputJSON(data, fpath); err != nil {
+		t.Fatalf("OutputJSON: %v", err)
+	}
 
 	content, err := os.ReadFile(fpath)
 	if err != nil {
@@ -47,7 +51,9 @@ func TestOutputJSONL(t *testing.T) {
 		{"id": "2", "name": "second"},
 	}
 
-	OutputJSONL(items, fpath)
+	if err := OutputJSONL(items, fpath); err != nil {
+		t.Fatalf("OutputJSONL: %v", err)
+	}
 
 	content, err := os.ReadFile(fpath)
 	if err != nil {
@@ -57,6 +63,20 @@ func TestOutputJSONL(t *testing.T) {
 	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
 	if len(lines) != 2 {
 		t.Errorf("expected 2 lines, got %d", len(lines))
+	}
+}
+
+func TestOutputJSONReturnsWriteError(t *testing.T) {
+	err := OutputJSON(map[string]any{"status": "ok"}, t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error when output path is a directory")
+	}
+}
+
+func TestOutputJSONLReturnsEncodingError(t *testing.T) {
+	err := OutputJSONL([]map[string]any{{"invalid": make(chan int)}}, "")
+	if err == nil {
+		t.Fatal("expected an error for an unsupported JSON value")
 	}
 }
 


### PR DESCRIPTION
## Summary

- return JSON serialization, file write, stdout/stderr write, and JSONL close errors from the shared output helpers
- propagate output failures through every existing `OutputJSON`, `OutputJSONL`, and `PrintOutput` caller
- emit file-write success status only after output completes successfully
- add helper-level and command-level regression coverage

## Reproduction

A localhost stub returned a valid empty custom-apps response (`[]`), isolating the output path from API behavior. The CLI was then run with an output target that rejects writes:

```console
$ langsmith \
    --api-url http://127.0.0.1:18726 \
    --api-key test \
    --format json \
    apps list \
    --output /dev/full
```

Before:

```text
write error: open /dev/full: operation not permitted
exit_code=0
```

The helper printed the write error but returned normally, so Cobra treated the command as successful.

After:

```text
write JSON to "/dev/full": open /dev/full: operation not permitted
exit_code=1
```

The write error now reaches command error handling and the process exits nonzero. No LangSmith credentials or remote API calls were used for the reproduction.

## Tests

```text
golangci-lint run
go test ./...
go vet ./...
```

All pass locally.

Closes LSDK-426.