### PR TITLE
chore(templates): bump scaffolded app template to Vite 8

### DIFF
--- a/internal/cmd/templates/package.json.tmpl
+++ b/internal/cmd/templates/package.json.tmpl
@@ -17,11 +17,11 @@
   "devDependencies": {
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^5.1.4",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.5.3",
-    "vite": "^5.4.0"
+    "vite": "^8.1.2"
   }
 }


### PR DESCRIPTION
bumping new custom apps to now use Vite 8 off scaffold (matches smith-frontend).
existing apps are unaffected.