### PR TITLE
Fix Windows watcher process cleanup

### DIFF
--- a/internal/cmd/apps_dev.go
+++ b/internal/cmd/apps_dev.go
@@ -110,7 +110,7 @@ func runAppsDev(ctx context.Context, c *client.Client, dir, entrypoint string, n
 	if info, statErr := os.Stat(entrypointPath); statErr == nil {
 		prevBuildTime = info.ModTime()
 	}
-	if startWatchProcess(ctx, dir) {
+	if started, _ := startWatchProcess(ctx, dir); started {
 		// Build tools empty their output dir before rebuilding, which would
 		// briefly hide an existing entrypoint — wait for a fresh build first.
 		waitForFreshEntrypoint(ctx, entrypointPath, prevBuildTime, 10*time.Second)
@@ -146,22 +146,23 @@ func runAppsDev(ctx context.Context, c *client.Client, dir, entrypoint string, n
 }
 
 // startWatchProcess runs package.json's "watch" script tied to ctx. Never
-// fails runAppsDev — returns false (with a note) if it can't start one.
-func startWatchProcess(ctx context.Context, dir string) bool {
+// fails runAppsDev — returns false (with a note) if it can't start one. The
+// returned channel closes after a successfully started watcher exits.
+func startWatchProcess(ctx context.Context, dir string) (bool, <-chan struct{}) {
 	script, pkgJSONExists, err := packageJSONScript(dir, "watch")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: couldn't read package.json to find a \"watch\" script: %v\n", err)
-		return false
+		return false, nil
 	}
 	if script == "" {
 		if pkgJSONExists {
 			fmt.Fprintln(os.Stderr, `note: no "watch" script in package.json — start your own build/watch process to see live updates`)
 		}
-		return false
+		return false, nil
 	}
 	if _, lookErr := exec.LookPath("npm"); lookErr != nil {
 		fmt.Fprintln(os.Stderr, `note: npm not found on PATH — run "npm run watch" yourself to see live updates`)
-		return false
+		return false, nil
 	}
 
 	fmt.Fprintln(os.Stderr, "Starting build watcher: npm run watch")
@@ -169,12 +170,17 @@ func startWatchProcess(ctx context.Context, dir string) bool {
 	watchCmd.Dir = dir
 	watchCmd.Stdout = os.Stderr
 	watchCmd.Stderr = os.Stderr
+	watchCmd.Cancel = func() error { return terminateWatchProcess(watchCmd.Process) }
 	if startErr := watchCmd.Start(); startErr != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to start \"npm run watch\": %v\n", startErr)
-		return false
+		return false, nil
 	}
-	go func() { _ = watchCmd.Wait() }()
-	return true
+	done := make(chan struct{})
+	go func() {
+		_ = watchCmd.Wait()
+		close(done)
+	}()
+	return true, done
 }
 
 // waitForFreshEntrypoint blocks until path's mtime is newer than after, ctx

--- a/internal/cmd/apps_dev_test.go
+++ b/internal/cmd/apps_dev_test.go
@@ -443,7 +443,8 @@ func TestStartWatchProcess_SpawnsWatchScriptAndIsKilledOnContextCancel(t *testin
 	fakeNpmOnPath(t, marker)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	if started := startWatchProcess(ctx, dir); !started {
+	started, done := startWatchProcess(ctx, dir)
+	if !started {
 		t.Fatal("expected startWatchProcess to report started=true")
 	}
 
@@ -460,7 +461,11 @@ func TestStartWatchProcess_SpawnsWatchScriptAndIsKilledOnContextCancel(t *testin
 
 	// ctx cancellation should kill the process, not hang.
 	cancel()
-	time.Sleep(200 * time.Millisecond)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("watch process did not exit after context cancellation")
+	}
 }
 
 func TestStartWatchProcess_NoWatchScriptDoesNotSpawn(t *testing.T) {
@@ -469,7 +474,7 @@ func TestStartWatchProcess_NoWatchScriptDoesNotSpawn(t *testing.T) {
 	marker := filepath.Join(dir, "watch-ran.marker")
 	fakeNpmOnPath(t, marker)
 
-	if started := startWatchProcess(context.Background(), dir); started {
+	if started, _ := startWatchProcess(context.Background(), dir); started {
 		t.Error("expected started=false when package.json has no \"watch\" script")
 	}
 	time.Sleep(100 * time.Millisecond)
@@ -484,7 +489,7 @@ func TestStartWatchProcess_NoPackageJSONDoesNotSpawn(t *testing.T) {
 	marker := filepath.Join(dir, "watch-ran.marker")
 	fakeNpmOnPath(t, marker)
 
-	if started := startWatchProcess(context.Background(), dir); started {
+	if started, _ := startWatchProcess(context.Background(), dir); started {
 		t.Error("expected started=false when there's no package.json")
 	}
 	time.Sleep(100 * time.Millisecond)

--- a/internal/cmd/watch_process_unix.go
+++ b/internal/cmd/watch_process_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package cmd
+
+import "os"
+
+func terminateWatchProcess(process *os.Process) error {
+	return process.Kill()
+}

--- a/internal/cmd/watch_process_windows.go
+++ b/internal/cmd/watch_process_windows.go
@@ -1,0 +1,12 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func terminateWatchProcess(process *os.Process) error {
+	return exec.CommandContext(context.Background(), "taskkill", "/T", "/F", "/PID", fmt.Sprint(process.Pid)).Run()
+}


### PR DESCRIPTION
## Summary

- terminate the full `npm run watch` process tree on Windows when the command context is canceled
- expose watcher completion so the regression test waits for actual shutdown instead of sleeping for 200 ms
- preserve the existing direct-process termination behavior on non-Windows platforms

## Failure reproduced

The Windows Go test job intermittently failed in `TestStartWatchProcess_SpawnsWatchScriptAndIsKilledOnContextCancel` during `t.TempDir()` cleanup:

```text
TempDir RemoveAll cleanup:
The process cannot access the file because it is being used by another process.
```

The fake `npm.cmd` starts a long-running child process. Canceling `exec.CommandContext` killed the immediate command process but could leave that child alive with the temp directory as its working directory. The test then slept for a fixed 200 ms and attempted cleanup.

## Validation

- `go test ./internal/cmd -run TestStartWatchProcess -count=10`
- `GOOS=windows GOARCH=amd64 go test -c -o /private/tmp/langsmith-cli-cmd-windows.test.exe ./internal/cmd`
- `go test ./...`
- `go vet ./...`
- `/Users/shamik/go/bin/golangci-lint run`
- `git diff --check`