### PR TITLE
fix: --include-feedback has no effect on default (table) output format

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -78,7 +78,7 @@ func newRunListCmd() *cobra.Command {
 
 			if fmt_ == "pretty" {
 				data := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)
-				output.PrintRunsTable(os.Stdout, data, includeMetadata, "Runs")
+				output.PrintRunsTable(os.Stdout, data, includeMetadata, includeFeedback, "Runs")
 			} else {
 				data := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)
 				if err := output.OutputJSON(data, outputFile); err != nil {

--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -249,7 +249,7 @@ func newThreadGetCmd() *cobra.Command {
 			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
-				output.PrintRunsTable(os.Stdout, extracted, includeMetadata, fmt.Sprintf("Thread %s", threadID))
+				output.PrintRunsTable(os.Stdout, extracted, includeMetadata, includeFeedback, fmt.Sprintf("Thread %s", threadID))
 			} else {
 				data := map[string]any{
 					"thread_id": threadID,

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -113,7 +113,7 @@ func newTraceListCmd() *cobra.Command {
 					}
 				} else {
 					data := extractRunsToMaps(runs, includeMetadata, includeIO, includeFeedback)
-					output.PrintRunsTable(os.Stdout, data, includeMetadata, "Traces")
+					output.PrintRunsTable(os.Stdout, data, includeMetadata, includeFeedback, "Traces")
 				}
 			} else {
 				if showHierarchy {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -183,7 +183,7 @@ func PrintError(msg string) {
 }
 
 // PrintRunsTable prints a table of runs in pretty format.
-func PrintRunsTable(w io.Writer, runs []map[string]any, includeMetadata bool, title string) {
+func PrintRunsTable(w io.Writer, runs []map[string]any, includeMetadata, includeFeedback bool, title string) {
 	if title != "" {
 		fmt.Fprintln(w, title)
 		fmt.Fprintln(w, strings.Repeat("─", len(title)))
@@ -192,6 +192,9 @@ func PrintRunsTable(w io.Writer, runs []map[string]any, includeMetadata bool, ti
 	columns := []string{"Time", "Name", "Type", "Trace ID", "Run ID"}
 	if includeMetadata {
 		columns = append(columns, "Duration", "Status", "Tokens")
+	}
+	if includeFeedback {
+		columns = append(columns, "Feedback")
 	}
 
 	table := tablewriter.NewWriter(w)
@@ -238,10 +241,76 @@ func PrintRunsTable(w io.Writer, runs []map[string]any, includeMetadata bool, ti
 			row = append(row, duration, status, tokens)
 		}
 
+		if includeFeedback {
+			feedback := "N/A"
+			if fb, ok := r["feedback_stats"].(map[string]map[string]interface{}); ok {
+				feedback = formatFeedbackStats(fb)
+			}
+			row = append(row, feedback)
+		}
+
 		table.Append(row)
 	}
 
 	table.Render()
+}
+
+// formatFeedbackStats renders a compact, single-line summary of a run's
+// feedback_stats for the table's "Feedback" column: "key=avg (n=N)" for
+// numeric feedback, or "key{label=count,...}" for categorical feedback.
+// Multiple keys are joined with "; ". Keys with no recorded feedback points
+// are skipped.
+func formatFeedbackStats(fb map[string]map[string]interface{}) string {
+	if len(fb) == 0 {
+		return "N/A"
+	}
+
+	keys := make([]string, 0, len(fb))
+	for k := range fb {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		stat := fb[k]
+
+		if values, ok := stat["values"].(map[string]interface{}); ok && len(values) > 0 {
+			labels := make([]string, 0, len(values))
+			for label := range values {
+				labels = append(labels, label)
+			}
+			sort.Strings(labels)
+
+			counts := make([]string, 0, len(labels))
+			for _, label := range labels {
+				counts = append(counts, fmt.Sprintf("%s=%v", label, values[label]))
+			}
+			parts = append(parts, fmt.Sprintf("%s{%s}", k, strings.Join(counts, ",")))
+			continue
+		}
+
+		n := feedbackStatFloat(stat, "n")
+		if n == 0 {
+			continue
+		}
+		avg := feedbackStatFloat(stat, "avg")
+		parts = append(parts, fmt.Sprintf("%s=%.2g (n=%d)", k, avg, int64(n)))
+	}
+
+	if len(parts) == 0 {
+		return "N/A"
+	}
+	return strings.Join(parts, "; ")
+}
+
+// feedbackStatFloat safely reads a numeric field out of a single feedback
+// key's loosely-typed stats map, returning 0 if absent or non-numeric.
+func feedbackStatFloat(stat map[string]interface{}, key string) float64 {
+	if v, ok := stat[key].(float64); ok {
+		return v
+	}
+	return 0
 }
 
 // FormatDuration formats milliseconds as human-readable duration.

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -113,7 +113,7 @@ func TestPrintRunsTable(t *testing.T) {
 		},
 	}
 
-	PrintRunsTable(&buf, runs, false, "Test Runs")
+	PrintRunsTable(&buf, runs, false, false, "Test Runs")
 
 	output := buf.String()
 	if !strings.Contains(output, "Test Runs") {
@@ -121,6 +121,114 @@ func TestPrintRunsTable(t *testing.T) {
 	}
 	if !strings.Contains(output, "ChatOpenAI") {
 		t.Error("expected run name in output")
+	}
+	if strings.Contains(output, "Feedback") {
+		t.Error("did not expect a Feedback column when includeFeedback is false")
+	}
+}
+
+func TestPrintRunsTable_WithFeedback(t *testing.T) {
+	var buf bytes.Buffer
+
+	runs := []map[string]any{
+		{
+			"start_time": "2024-01-15T10:30:00Z",
+			"name":       "ChatOpenAI",
+			"run_type":   "llm",
+			"trace_id":   "abc123def456789012",
+			"run_id":     "run123def456789012",
+			"feedback_stats": map[string]map[string]interface{}{
+				"correctness": {
+					"avg": 0.75,
+					"n":   float64(4),
+				},
+				"category": {
+					"n": float64(2),
+					"values": map[string]interface{}{
+						"good": float64(1),
+						"bad":  float64(1),
+					},
+				},
+			},
+		},
+		{
+			"start_time": "2024-01-15T10:31:00Z",
+			"name":       "NoFeedbackRun",
+			"run_type":   "llm",
+			"trace_id":   "abc123def456789099",
+			"run_id":     "run123def456789099",
+		},
+	}
+
+	PrintRunsTable(&buf, runs, false, true, "Test Runs With Feedback")
+
+	output := buf.String()
+	if !strings.Contains(output, "Feedback") {
+		t.Error("expected a Feedback column header when includeFeedback is true")
+	}
+	if !strings.Contains(output, "correctness=0.75 (n=4)") {
+		t.Errorf("expected numeric feedback summary in output, got: %s", output)
+	}
+	if !strings.Contains(output, "category{bad=1,good=1}") {
+		t.Errorf("expected categorical feedback summary in output, got: %s", output)
+	}
+	if !strings.Contains(output, "NoFeedbackRun") {
+		t.Error("expected run with no feedback_stats to still be printed")
+	}
+}
+
+func TestFormatFeedbackStats(t *testing.T) {
+	tests := []struct {
+		name     string
+		fb       map[string]map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "empty map",
+			fb:       map[string]map[string]interface{}{},
+			expected: "N/A",
+		},
+		{
+			name: "numeric feedback",
+			fb: map[string]map[string]interface{}{
+				"correctness": {"avg": 0.5, "n": float64(2)},
+			},
+			expected: "correctness=0.5 (n=2)",
+		},
+		{
+			name: "categorical feedback",
+			fb: map[string]map[string]interface{}{
+				"tone": {"n": float64(3), "values": map[string]interface{}{
+					"friendly": float64(2),
+					"neutral":  float64(1),
+				}},
+			},
+			expected: "tone{friendly=2,neutral=1}",
+		},
+		{
+			name: "multiple keys are sorted and joined",
+			fb: map[string]map[string]interface{}{
+				"zeta":  {"avg": 1.0, "n": float64(1)},
+				"alpha": {"avg": 2.0, "n": float64(1)},
+			},
+			expected: "alpha=2 (n=1); zeta=1 (n=1)",
+		},
+		{
+			name: "key with no recorded points is skipped",
+			fb: map[string]map[string]interface{}{
+				"empty": {"n": float64(0)},
+			},
+			expected: "N/A",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatFeedbackStats(tt.fb)
+			if got != tt.expected {
+				t.Errorf("formatFeedbackStats(%v) = %q, want %q", tt.fb, got, tt.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #186

## Problem
`output.PrintRunsTable` never accepted an `includeFeedback` parameter,
so none of its three call sites (`run list`, `trace list`, `thread get`)
could pass through the `--include-feedback` / `--full` flag that
already exists on those commands. `feedback_stats` was already being
fetched and placed into each run's map by `extract.ExtractRun` — it
just never reached the table renderer.

## Fix
- `output.PrintRunsTable(w, runs, includeMetadata, includeFeedback, title)`
  now adds a "Feedback" column when `includeFeedback` is true.
- Added `formatFeedbackStats()`: renders numeric feedback as
  `key=avg (n=N)` and categorical feedback as `key{label=count,...}`,
  joining multiple keys with `; ` in sorted order.
- Updated the three call sites to pass the already-in-scope
  `includeFeedback` variable.

## Tests
- Updated `TestPrintRunsTable` for the new signature; added an
  assertion that no Feedback column appears when the flag is off.
- Added `TestPrintRunsTable_WithFeedback` and table-driven
  `TestFormatFeedbackStats` (empty, numeric, categorical, multi-key
  sort order, zero-`n` key skipped).

## Verification
My sandbox can't install Go 1.25 (this repo's go.mod requirement),
so I verified by copying the real `internal/output/{output.go,
output_test.go}` into an isolated module pinning this repo's exact
tablewriter/treeprint versions, and ran `go build` + `go test -v`
with go1.23 — all 9 tests passed. Also independently compiled/ran the
new `formatFeedbackStats` logic against 6 cases, and confirmed
`gofmt -l` is clean on every touched file. Please still run
`go build ./...` / `go test ./...` in CI/locally before merging.