### PR TITLE
fix: hub pull can destroy an existing directory on a mid-write failure

### DIFF
--- a/internal/cmd/hub_pull.go
+++ b/internal/cmd/hub_pull.go
@@ -102,19 +102,36 @@ func writeFilesToDirectory(dest string, files map[string]hubFileEntry, yes bool)
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolving %s: %w", dest, err)
 	}
-	if err := os.RemoveAll(dest); err != nil {
-		return nil, nil, fmt.Errorf("cleaning %s: %w", dest, err)
+
+	// Stage every write in a temporary sibling directory first. dest is
+	// only wiped and replaced once every file has been written
+	// successfully, so a mid-write failure (disk full, permission error,
+	// interrupted process, etc.) can never leave dest half-wiped or
+	// containing only a partial set of files: the pre-existing dest is
+	// left untouched on any error, and the staging directory is cleaned
+	// up.
+	parent := filepath.Dir(absDest)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return nil, nil, fmt.Errorf("creating %s: %w", parent, err)
 	}
-	if err := os.MkdirAll(dest, 0o755); err != nil {
-		return nil, nil, fmt.Errorf("creating %s: %w", dest, err)
+	staging, err := os.MkdirTemp(parent, ".hub-pull-*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating staging directory: %w", err)
 	}
+	replaced := false
+	defer func() {
+		if !replaced {
+			os.RemoveAll(staging)
+		}
+	}()
+
 	for path, entry := range files {
 		if entry.Type != "file" {
 			linked = append(linked, fmt.Sprintf("%s (%s)", path, entry.Type))
 			continue
 		}
-		out := filepath.Join(absDest, filepath.FromSlash(path))
-		if rel, relErr := filepath.Rel(absDest, out); relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		out := filepath.Join(staging, filepath.FromSlash(path))
+		if rel, relErr := filepath.Rel(staging, out); relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			return nil, nil, fmt.Errorf("path %q would escape %s", path, dest)
 		}
 		if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
@@ -125,6 +142,16 @@ func writeFilesToDirectory(dest string, files map[string]hubFileEntry, yes bool)
 		}
 		written = append(written, path)
 	}
+
+	// Every file staged successfully; now replace dest.
+	if err := os.RemoveAll(dest); err != nil {
+		return nil, nil, fmt.Errorf("cleaning %s: %w", dest, err)
+	}
+	if err := os.Rename(staging, dest); err != nil {
+		return nil, nil, fmt.Errorf("replacing %s: %w", dest, err)
+	}
+	replaced = true
+
 	return written, linked, nil
 }
 

--- a/internal/cmd/hub_pull_test.go
+++ b/internal/cmd/hub_pull_test.go
@@ -192,3 +192,63 @@ func TestHubPull_AcceptsNonHubDirWithYes(t *testing.T) {
 		t.Errorf("SKILL.md should be written: %v", err)
 	}
 }
+
+// TestHubPull_PreservesExistingDirOnMidWriteFailure exercises the case where
+// a file write fails partway through pulling a new set of files (here,
+// triggered deterministically by a path collision: "bad" is requested as
+// both a file and, via "bad/x", a directory). Before staging writes in a
+// temporary sibling directory, this used to leave dest wiped-but-incomplete
+// since files were written directly into dest after it was removed and
+// recreated. The pre-existing dest contents must survive untouched, and the
+// command must report an error rather than a partial success.
+func TestHubPull_PreservesExistingDirOnMidWriteFailure(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"commit_hash": "h1",
+			"files": map[string]any{
+				"good.txt": map[string]any{"type": "file", "content": "fine"},
+				"bad/x":    map[string]any{"type": "file", "content": "will fail"},
+				"bad":      map[string]any{"type": "file", "content": "collides with bad/x's parent dir"},
+			},
+		})
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("original content"), 0o644); err != nil {
+		t.Fatalf("seed SKILL.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "old.txt"), []byte("old file"), 0o644); err != nil {
+		t.Fatalf("seed old.txt: %v", err)
+	}
+
+	cmd := newHubCmd()
+	cmd.SetArgs([]string{"pull", "my-skill", "--dir", dir, "--yes"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected an error from the colliding paths, got nil")
+	}
+
+	if data, err := os.ReadFile(filepath.Join(dir, "SKILL.md")); err != nil {
+		t.Errorf("original SKILL.md should be preserved: %v", err)
+	} else if string(data) != "original content" {
+		t.Errorf("SKILL.md content = %q, want %q", string(data), "original content")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "old.txt")); err != nil {
+		t.Errorf("original old.txt should be preserved: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "good.txt")); !os.IsNotExist(err) {
+		t.Errorf("good.txt should NOT have been partially applied to dest, got err=%v", err)
+	}
+
+	// No leftover staging directory next to dir.
+	entries, err := os.ReadDir(filepath.Dir(dir))
+	if err != nil {
+		t.Fatalf("reading parent dir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != filepath.Base(dir) && strings.HasPrefix(e.Name(), ".hub-pull-") {
+			t.Errorf("leftover staging directory not cleaned up: %s", e.Name())
+		}
+	}
+}


### PR DESCRIPTION
## Problem
`writeFilesToDirectory` wiped `dest` (`os.RemoveAll` + `os.MkdirAll`)
then wrote files directly into it. A failure partway through the
write loop (disk full, permission error, a path collision, an
interrupted process) left `dest` wiped-but-incomplete, with no way to
recover the pre-existing content.

Same bug class as #225 ("apps pull destroys the destination before
archive validation succeeds"), applied to `hub pull`.

## Fix
Stage every write in a temporary sibling directory. `dest` is only
removed and replaced (`os.RemoveAll` + `os.Rename`) once every file
has been staged successfully. On any error, staging is cleaned up via
a deferred `os.RemoveAll` and `dest` is left untouched.

## Tests
Added `TestHubPull_PreservesExistingDirOnMidWriteFailure`, which
deterministically forces a mid-loop failure (server returns both
"bad" and "bad/x" as file entries) and asserts the pre-existing
content survives byte-for-byte, no partial files leak into `dest`,
and no staging directory is left behind.

## Verification
My sandbox can't run Go 1.25 (this repo's requirement). I verified
the core logic by copying the exact function bodies into a standalone
go1.23 program (stdlib-only, no external deps) and:
1. Ran the *original* code through the same failure scenario —
   confirmed it destroys the pre-existing SKILL.md.
2. Ran the *new* staged-write code through the same scenario —
   confirmed the original content survives and no partial files leak.
3. Verified the normal (success) path still works correctly.

`gofmt -l` is clean. Please still run `go build ./...` and
`go test ./...` before merging.