### PR TITLE
fix: fleet skills pull allows path traversal and can destroy an existing install on write failure

### DIFF
--- a/internal/cmd/skill.go
+++ b/internal/cmd/skill.go
@@ -98,17 +98,50 @@ Use --copy to copy instead of symlink.`,
 				return fmt.Errorf("%q is not a skill", skillName)
 			}
 
-			// Wipe before writing so removed upstream files don't linger.
-			if err := os.RemoveAll(canonicalDir); err != nil {
-				return fmt.Errorf("cleaning %s: %w", canonicalDir, err)
+			for filePath, entry := range resp.Files {
+				if entry.Type != "file" {
+					continue
+				}
+				if err := validateHubFilePath(filePath); err != nil {
+					return err
+				}
 			}
+
+			canonicalAbs, err := filepath.Abs(canonicalDir)
+			if err != nil {
+				return fmt.Errorf("resolving canonical path: %w", err)
+			}
+
+			// Stage every write in a temporary sibling directory first, and
+			// only wipe + replace canonicalDir once every file has been
+			// written successfully. This mirrors hub pull: writing directly
+			// into canonicalDir after wiping it would leave a previously
+			// installed skill half-wiped if any single write failed partway
+			// through (disk full, permission error, etc.).
+			parent := filepath.Dir(canonicalAbs)
+			if err := os.MkdirAll(parent, 0o755); err != nil {
+				return fmt.Errorf("creating %s: %w", parent, err)
+			}
+			staging, err := os.MkdirTemp(parent, ".skill-pull-*")
+			if err != nil {
+				return fmt.Errorf("creating staging directory: %w", err)
+			}
+			replaced := false
+			defer func() {
+				if !replaced {
+					os.RemoveAll(staging)
+				}
+			}()
 
 			var written []string
 			for filePath, entry := range resp.Files {
 				if entry.Type != "file" {
 					continue
 				}
-				dest := filepath.Join(canonicalDir, filePath)
+				dest := filepath.Join(staging, filepath.FromSlash(filePath))
+				if rel, relErr := filepath.Rel(staging, dest); relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+					return fmt.Errorf("path %q would escape %s", filePath, canonicalDir)
+				}
 				if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 					return fmt.Errorf("creating directory for %s: %w", filePath, err)
 				}
@@ -119,10 +152,15 @@ Use --copy to copy instead of symlink.`,
 			}
 			sort.Strings(written)
 
-			canonicalAbs, err := filepath.Abs(canonicalDir)
-			if err != nil {
-				return fmt.Errorf("resolving canonical path: %w", err)
+			// Every file staged successfully; now replace canonicalDir.
+			// Wipe before writing so removed upstream files don't linger.
+			if err := os.RemoveAll(canonicalDir); err != nil {
+				return fmt.Errorf("cleaning %s: %w", canonicalDir, err)
 			}
+			if err := os.Rename(staging, canonicalDir); err != nil {
+				return fmt.Errorf("replacing %s: %w", canonicalDir, err)
+			}
+			replaced = true
 
 			var linked []string
 			for _, agent := range agents {

--- a/internal/cmd/skill_test.go
+++ b/internal/cmd/skill_test.go
@@ -1,0 +1,212 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSkillPull_WritesFiles(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v1/platform/hub/repos/-/my-skill/directories" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"commit_hash": "h1",
+			"files": map[string]any{
+				"SKILL.md":  map[string]any{"type": "file", "content": "# hi"},
+				"sub/x.txt": map[string]any{"type": "file", "content": "abc"},
+			},
+		})
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	captureStdout(t, func() {
+		cmd := newFleetCmd()
+		cmd.SetArgs([]string{"skills", "pull", "my-skill", "--global=false", "--agent", "claude"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	target := filepath.Join(dir, ".agents", "skills", "my-skill")
+	if data, err := os.ReadFile(filepath.Join(target, "SKILL.md")); err != nil {
+		t.Fatalf("SKILL.md: %v", err)
+	} else if string(data) != "# hi" {
+		t.Errorf("SKILL.md content = %q", string(data))
+	}
+	if data, err := os.ReadFile(filepath.Join(target, "sub", "x.txt")); err != nil {
+		t.Fatalf("sub/x.txt: %v", err)
+	} else if string(data) != "abc" {
+		t.Errorf("sub/x.txt content = %q", string(data))
+	}
+}
+
+func TestSkillPull_RejectsPathTraversal(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"commit_hash": "h1",
+			"files": map[string]any{
+				"SKILL.md":      map[string]any{"type": "file", "content": "# hi"},
+				"../escape.txt": map[string]any{"type": "file", "content": "nope"},
+			},
+		})
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cmd := newFleetCmd()
+	cmd.SetArgs([]string{"skills", "pull", "my-skill", "--global=false"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "escape") {
+		t.Errorf("expected traversal error; got %v", err)
+	}
+
+	// The traversal write must never have happened, and nothing should
+	// have been installed at all (validation runs before any write).
+	if _, statErr := os.Stat(filepath.Join(dir, ".agents", "escape.txt")); !os.IsNotExist(statErr) {
+		t.Errorf("traversal write was NOT prevented")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, ".agents", "skills", "my-skill")); !os.IsNotExist(statErr) {
+		t.Errorf("skill directory should not have been created when validation fails")
+	}
+}
+
+func TestSkillPull_RejectsAbsolutePath(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"commit_hash": "h1",
+			"files": map[string]any{
+				"SKILL.md":    map[string]any{"type": "file", "content": "# hi"},
+				"/etc/passwd": map[string]any{"type": "file", "content": "nope"},
+			},
+		})
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cmd := newFleetCmd()
+	cmd.SetArgs([]string{"skills", "pull", "my-skill", "--global=false"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "absolute") {
+		t.Errorf("expected absolute-path error; got %v", err)
+	}
+}
+
+func TestSkillPull_WipesRemovedFilesOnReinstall(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"commit_hash": "h1",
+			"files": map[string]any{
+				"SKILL.md": map[string]any{"type": "file", "content": "# v2"},
+			},
+		})
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	target := filepath.Join(dir, ".agents", "skills", "my-skill")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("seed dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "stale.txt"), []byte("v1 leftover"), 0o644); err != nil {
+		t.Fatalf("seed stale.txt: %v", err)
+	}
+
+	captureStdout(t, func() {
+		cmd := newFleetCmd()
+		cmd.SetArgs([]string{"skills", "pull", "my-skill", "--global=false"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if _, err := os.Stat(filepath.Join(target, "stale.txt")); !os.IsNotExist(err) {
+		t.Errorf("stale.txt from the previous install should be wiped, got err=%v", err)
+	}
+	if data, err := os.ReadFile(filepath.Join(target, "SKILL.md")); err != nil || string(data) != "# v2" {
+		t.Errorf("SKILL.md should be the new content, got data=%q err=%v", data, err)
+	}
+}
+
+// TestSkillPull_PreservesExistingSkillOnMidWriteFailure exercises a
+// deterministic mid-loop write failure (the server returns both "bad" and
+// "bad/x" as file entries, so whichever one lands second in map iteration
+// order fails). Before staging writes in a temporary sibling directory,
+// this used to leave the previously installed skill wiped-but-incomplete,
+// since files were written directly into the target dir after it was
+// removed. The pre-existing installation must survive untouched, and the
+// command must report an error rather than a partial success.
+func TestSkillPull_PreservesExistingSkillOnMidWriteFailure(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"commit_hash": "h1",
+			"files": map[string]any{
+				"SKILL.md": map[string]any{"type": "file", "content": "# hi"},
+				"good.txt": map[string]any{"type": "file", "content": "fine"},
+				"bad/x":    map[string]any{"type": "file", "content": "will fail"},
+				"bad":      map[string]any{"type": "file", "content": "collides with bad/x's parent dir"},
+			},
+		})
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	target := filepath.Join(dir, ".agents", "skills", "my-skill")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("seed dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "SKILL.md"), []byte("original content"), 0o644); err != nil {
+		t.Fatalf("seed SKILL.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "old.txt"), []byte("old file"), 0o644); err != nil {
+		t.Fatalf("seed old.txt: %v", err)
+	}
+
+	cmd := newFleetCmd()
+	cmd.SetArgs([]string{"skills", "pull", "my-skill", "--global=false"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected an error from the colliding paths, got nil")
+	}
+
+	if data, err := os.ReadFile(filepath.Join(target, "SKILL.md")); err != nil {
+		t.Errorf("original SKILL.md should be preserved: %v", err)
+	} else if string(data) != "original content" {
+		t.Errorf("SKILL.md content = %q, want %q", string(data), "original content")
+	}
+	if _, err := os.Stat(filepath.Join(target, "old.txt")); err != nil {
+		t.Errorf("original old.txt should be preserved: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "good.txt")); !os.IsNotExist(err) {
+		t.Errorf("good.txt should NOT have been partially applied to the skill dir, got err=%v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(target))
+	if err != nil {
+		t.Fatalf("reading parent dir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != filepath.Base(target) && strings.HasPrefix(e.Name(), ".skill-pull-") {
+			t.Errorf("leftover staging directory not cleaned up: %s", e.Name())
+		}
+	}
+}


### PR DESCRIPTION
## Problem
`newSkillPullCmd` (`langsmith fleet skills pull <name>`) had two bugs
already fixed for the near-identical `hub pull` command but never
applied here — and had zero test coverage.

1. **Path traversal (security)**: file paths from the API were joined
   directly onto the target dir with no validation. A response
   containing `"../../.ssh/authorized_keys"` would write outside the
   skill directory. Verified against the unmodified original code:
   a `"../escape.txt"` entry was written one level up with no error.

2. **Data loss on mid-write failure**: `os.RemoveAll(target)` ran
   before writing, directly into the (now empty) target. Any single
   write failing partway through left the target wiped-but-incomplete
   with no recovery. Verified against the unmodified original code:
   a pre-existing `SKILL.md` was deleted after a forced failure.

## Fix
- Validate every path with the existing `validateHubFilePath` helper
  (already used by `hub pull`) before touching the filesystem.
- Stage writes in a temp sibling directory; only replace the target
  (`RemoveAll` + `Rename`) once every file is staged successfully.

## Tests
Added `internal/cmd/skill_test.go` (previously no tests existed):
happy path, traversal rejection, absolute-path rejection, stale-file
cleanup on reinstall, and a deterministic mid-write-failure test that
confirms the pre-existing install survives untouched.

## Verification
Sandbox can't run Go 1.25 (repo requirement). Verified the exact
logic in an isolated go1.23 program (stdlib only): ran the *original*
code through both bug scenarios and confirmed both bugs reproduce;
ran the *new* code through the same scenarios and confirmed both are
fixed, plus the normal path still works. `gofmt -l` clean. Please
still run `go build ./...` / `go test ./...` before merging.