### PR TITLE
fix example split handling [LSDK-424]

### DIFF
--- a/internal/cmd/example.go
+++ b/internal/cmd/example.go
@@ -77,10 +77,11 @@ func newExampleListCmd() *cobra.Command {
 			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
-				columns := []string{"ID", "Created", "Inputs Preview"}
+				columns := []string{"ID", "Split", "Created", "Inputs Preview"}
 				var rows [][]string
 				for _, ex := range examples {
 					id := ex.ID
+					splitVal := exampleSplitDisplay(ex.Metadata)
 					created := "N/A"
 					if !ex.CreatedAt.IsZero() {
 						created = ex.CreatedAt.Format("2006-01-02")
@@ -93,7 +94,7 @@ func newExampleListCmd() *cobra.Command {
 							inputsPreview = inputsPreview[:60] + "..."
 						}
 					}
-					rows = append(rows, []string{id, created, inputsPreview})
+					rows = append(rows, []string{id, splitVal, created, inputsPreview})
 				}
 				output.OutputTable(columns, rows, fmt.Sprintf("Examples in %s", ds.Name))
 			} else {
@@ -123,6 +124,33 @@ func newExampleListCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("dataset")
 
 	return cmd
+}
+
+func exampleSplitDisplay(metadata map[string]any) string {
+	if metadata == nil {
+		return "N/A"
+	}
+	switch splits := metadata["dataset_split"].(type) {
+	case []any:
+		values := make([]string, 0, len(splits))
+		for _, split := range splits {
+			if value, ok := split.(string); ok {
+				values = append(values, value)
+			}
+		}
+		if len(values) > 0 {
+			return strings.Join(values, ", ")
+		}
+	case []string:
+		if len(splits) > 0 {
+			return strings.Join(splits, ", ")
+		}
+	case string:
+		if splits != "" {
+			return splits
+		}
+	}
+	return "N/A"
 }
 
 func newExampleCreateCmd() *cobra.Command {

--- a/internal/cmd/example.go
+++ b/internal/cmd/example.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/langchain-ai/langsmith-cli/internal/output"
 	langsmith "github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/shared"
 	"github.com/spf13/cobra"
 )
 
@@ -61,13 +62,7 @@ func newExampleListCmd() *cobra.Command {
 			if limit > 0 && int64(limit) < pageSize {
 				pageSize = int64(limit)
 			}
-			params := langsmith.ExampleListParams{
-				Dataset: langsmith.F(ds.ID),
-				Limit:   langsmith.F(pageSize),
-			}
-			if offset > 0 {
-				params.Offset = langsmith.F(int64(offset))
-			}
+			params := exampleListParams(ds.ID, pageSize, offset, split)
 			var examples []langsmith.Example
 			pager := c.SDK.Examples.ListAutoPaging(ctx, params)
 			for pager.Next() {
@@ -81,31 +76,11 @@ func newExampleListCmd() *cobra.Command {
 			}
 			fmt_ := GetFormat()
 
-			// Filter by split if specified
-			if split != "" {
-				var filtered []langsmith.Example
-				for _, ex := range examples {
-					// The split field may be in metadata
-					if ex.Metadata != nil {
-						if s, ok := ex.Metadata["split"].(string); ok && s == split {
-							filtered = append(filtered, ex)
-						}
-					}
-				}
-				examples = filtered
-			}
-
 			if fmt_ == "pretty" {
-				columns := []string{"ID", "Split", "Created", "Inputs Preview"}
+				columns := []string{"ID", "Created", "Inputs Preview"}
 				var rows [][]string
 				for _, ex := range examples {
 					id := ex.ID
-					splitVal := "N/A"
-					if ex.Metadata != nil {
-						if s, ok := ex.Metadata["split"].(string); ok {
-							splitVal = s
-						}
-					}
 					created := "N/A"
 					if !ex.CreatedAt.IsZero() {
 						created = ex.CreatedAt.Format("2006-01-02")
@@ -118,7 +93,7 @@ func newExampleListCmd() *cobra.Command {
 							inputsPreview = inputsPreview[:60] + "..."
 						}
 					}
-					rows = append(rows, []string{id, splitVal, created, inputsPreview})
+					rows = append(rows, []string{id, created, inputsPreview})
 				}
 				output.OutputTable(columns, rows, fmt.Sprintf("Examples in %s", ds.Name))
 			} else {
@@ -191,21 +166,7 @@ func newExampleCreateCmd() *cobra.Command {
 				ExitErrorf("%v", err)
 			}
 
-			params := langsmith.ExampleNewParams{
-				DatasetID: langsmith.F(ds.ID),
-				Inputs:    langsmith.F(parsedInputs),
-			}
-			if parsedOutputs != nil {
-				params.Outputs = langsmith.F(parsedOutputs)
-			}
-			if parsedMetadata != nil {
-				if split != "" {
-					parsedMetadata["split"] = split
-				}
-				params.Metadata = langsmith.F(parsedMetadata)
-			} else if split != "" {
-				params.Metadata = langsmith.F(map[string]any{"split": split})
-			}
+			params := exampleCreateParams(ds.ID, parsedInputs, parsedOutputs, parsedMetadata, split)
 
 			ex, err := c.SDK.Examples.New(ctx, params)
 			if err != nil {
@@ -230,6 +191,31 @@ func newExampleCreateCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("inputs")
 
 	return cmd
+}
+
+func exampleListParams(datasetID string, pageSize int64, offset int, split string) langsmith.ExampleListParams {
+	params := langsmith.ExampleListParams{Dataset: langsmith.F(datasetID), Limit: langsmith.F(pageSize)}
+	if offset > 0 {
+		params.Offset = langsmith.F(int64(offset))
+	}
+	if split != "" {
+		params.Splits = langsmith.F([]string{split})
+	}
+	return params
+}
+
+func exampleCreateParams(datasetID string, inputs, outputs, metadata map[string]any, split string) langsmith.ExampleNewParams {
+	params := langsmith.ExampleNewParams{DatasetID: langsmith.F(datasetID), Inputs: langsmith.F(inputs)}
+	if outputs != nil {
+		params.Outputs = langsmith.F(outputs)
+	}
+	if metadata != nil {
+		params.Metadata = langsmith.F(metadata)
+	}
+	if split != "" {
+		params.Split = langsmith.F[langsmith.ExampleNewParamsSplitUnion](shared.UnionString(split))
+	}
+	return params
 }
 
 func newExampleDeleteCmd() *cobra.Command {

--- a/internal/cmd/example_test.go
+++ b/internal/cmd/example_test.go
@@ -26,6 +26,16 @@ func TestExampleParams_UseNativeSplitFields(t *testing.T) {
 	}
 }
 
+func TestExampleSplitDisplay_UsesAPIDatasetSplitNotUserMetadata(t *testing.T) {
+	metadata := map[string]any{
+		"dataset_split": []any{"test", "regression"},
+		"split":         "metadata-only",
+	}
+	if got := exampleSplitDisplay(metadata); got != "test, regression" {
+		t.Fatalf("split display = %q", got)
+	}
+}
+
 // ==================== Command structure ====================
 
 func TestExampleCmd_Subcommands(t *testing.T) {

--- a/internal/cmd/example_test.go
+++ b/internal/cmd/example_test.go
@@ -1,9 +1,30 @@
 package cmd
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
+
+func TestExampleParams_UseNativeSplitFields(t *testing.T) {
+	list := exampleListParams("dataset-id", 20, 0, "test")
+	if got := list.URLQuery().Get("splits"); got != "test" {
+		t.Fatalf("list split query = %q, want test", got)
+	}
+	metadata := map[string]any{"split": "metadata-value", "owner": "me"}
+	create := exampleCreateParams("dataset-id", map[string]any{"x": 1}, nil, metadata, "test")
+	body, err := json.Marshal(create)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jsonBody := string(body)
+	if !strings.Contains(jsonBody, `"split":"test"`) {
+		t.Fatalf("native split missing from create body: %s", jsonBody)
+	}
+	if metadata["split"] != "metadata-value" {
+		t.Fatalf("metadata split was overwritten: %#v", metadata)
+	}
+}
 
 // ==================== Command structure ====================
 


### PR DESCRIPTION
## Summary

- create examples using the native LangSmith split request field
- filter example listings through the API native splits query
- keep user metadata independent from split membership
- display API-provided dataset split membership in pretty output

## Functional reproduction

Used one temporary production dataset containing:
- a native test example whose user metadata had split=metadata-only
- a native train example
- a base example whose user metadata had split=test

Before: example list --split test returned the base metadata-only match and omitted the native test example.

After: the same command returned only the native test example, and pretty output showed its API-provided test membership. The temporary dataset was deleted afterward.

## Test plan

- go test ./...
- go vet ./...
- live create/list/filter workflow against a temporary LangSmith dataset

Linear: https://linear.app/langchain/issue/LSDK-424