### PR TITLE
make dataset transfers lossless and backward compatible [LSDK-428]

### DIFF
--- a/internal/cmd/dataset.go
+++ b/internal/cmd/dataset.go
@@ -9,8 +9,23 @@ import (
 
 	"github.com/langchain-ai/langsmith-cli/internal/output"
 	langsmith "github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/shared"
 	"github.com/spf13/cobra"
 )
+
+const datasetExportVersion = 1
+
+type datasetTransferFile struct {
+	Version  int                      `json:"version"`
+	Examples []datasetTransferExample `json:"examples"`
+}
+
+type datasetTransferExample struct {
+	Inputs   map[string]any `json:"inputs"`
+	Outputs  map[string]any `json:"outputs,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+	Splits   []string       `json:"splits,omitempty"`
+}
 
 func newDatasetCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -285,15 +300,35 @@ func newDatasetExportCmd() *cobra.Command {
 				ExitErrorf("listing examples: %v", err)
 			}
 
-			var data []map[string]any
+			splitsByExample := make(map[string][]string)
+			splitNames, err := c.SDK.Datasets.Splits.Get(ctx, ds.ID, langsmith.DatasetSplitGetParams{})
+			if err != nil {
+				ExitErrorf("listing dataset splits: %v", err)
+			}
+			for _, splitName := range *splitNames {
+				splitPager := c.SDK.Examples.ListAutoPaging(ctx, langsmith.ExampleListParams{
+					Dataset: langsmith.F(ds.ID), Splits: langsmith.F([]string{splitName}), Limit: langsmith.F(int64(100)),
+				})
+				for splitPager.Next() {
+					ex := splitPager.Current()
+					splitsByExample[ex.ID] = append(splitsByExample[ex.ID], splitName)
+				}
+				if err := splitPager.Err(); err != nil {
+					ExitErrorf("listing examples in split %q: %v", splitName, err)
+				}
+			}
+
+			data := datasetTransferFile{Version: datasetExportVersion}
 			for _, ex := range allExamples {
-				data = append(data, map[string]any{
-					"inputs":  ex.Inputs,
-					"outputs": ex.Outputs,
+				data.Examples = append(data.Examples, datasetTransferExample{
+					Inputs: ex.Inputs, Outputs: ex.Outputs, Metadata: ex.Metadata, Splits: splitsByExample[ex.ID],
 				})
 			}
 
-			jsonBytes, _ := json.MarshalIndent(data, "", "  ")
+			jsonBytes, err := json.MarshalIndent(data, "", "  ")
+			if err != nil {
+				ExitErrorf("serializing dataset: %v", err)
+			}
 			if err := os.WriteFile(outputFile, jsonBytes, 0644); err != nil {
 				ExitErrorf("writing file: %v", err)
 			}
@@ -301,7 +336,7 @@ func newDatasetExportCmd() *cobra.Command {
 			output.OutputJSON(map[string]any{
 				"status":  "exported",
 				"dataset": ds.Name,
-				"count":   len(data),
+				"count":   len(data.Examples),
 				"path":    outputFile,
 			}, "")
 		},
@@ -332,23 +367,9 @@ func newDatasetUploadCmd() *cobra.Command {
 				ExitErrorf("reading file: %v", err)
 			}
 
-			var rawData any
-			if err := json.Unmarshal(fileData, &rawData); err != nil {
+			items, err := parseDatasetUpload(fileData)
+			if err != nil {
 				ExitErrorf("parsing JSON: %v", err)
-			}
-
-			var items []map[string]any
-			switch v := rawData.(type) {
-			case []any:
-				for _, item := range v {
-					if m, ok := item.(map[string]any); ok {
-						items = append(items, m)
-					}
-				}
-			case map[string]any:
-				items = []map[string]any{v}
-			default:
-				ExitError("JSON file must be an array or object")
 			}
 
 			// Create dataset
@@ -364,30 +385,8 @@ func newDatasetUploadCmd() *cobra.Command {
 				ExitErrorf("creating dataset: %v", err)
 			}
 
-			// Create examples
-			for _, item := range items {
-				var inputs, outputs map[string]any
-				if inp, ok := item["inputs"].(map[string]any); ok {
-					inputs = inp
-				} else {
-					inputs = item
-				}
-				if out, ok := item["outputs"].(map[string]any); ok {
-					outputs = out
-				}
-
-				exParams := langsmith.ExampleNewParams{
-					DatasetID: langsmith.F(ds.ID),
-					Inputs:    langsmith.F(inputs),
-				}
-				if outputs != nil {
-					exParams.Outputs = langsmith.F(outputs)
-				}
-
-				_, err := c.SDK.Examples.New(ctx, exParams)
-				if err != nil {
-					ExitErrorf("creating example: %v", err)
-				}
+			if err := uploadExamplesWithCleanup(ctx, c.SDK, ds.ID, items); err != nil {
+				ExitError(err.Error())
 			}
 
 			output.OutputJSON(map[string]any{
@@ -404,4 +403,65 @@ func newDatasetUploadCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("name")
 
 	return cmd
+}
+
+func uploadExamplesWithCleanup(ctx context.Context, sdk *langsmith.Client, datasetID string, items []datasetTransferExample) error {
+	bulk := langsmith.ExampleBulkNewParams{Body: make([]langsmith.ExampleBulkNewParamsBody, 0, len(items))}
+	for _, item := range items {
+		body := langsmith.ExampleBulkNewParamsBody{DatasetID: langsmith.F(datasetID), Inputs: langsmith.F(item.Inputs)}
+		if item.Outputs != nil {
+			body.Outputs = langsmith.F(item.Outputs)
+		}
+		if item.Metadata != nil {
+			body.Metadata = langsmith.F(item.Metadata)
+		}
+		if len(item.Splits) == 1 {
+			body.Split = langsmith.F[langsmith.ExampleBulkNewParamsBodySplitUnion](shared.UnionString(item.Splits[0]))
+		} else if len(item.Splits) > 1 {
+			body.Split = langsmith.F[langsmith.ExampleBulkNewParamsBodySplitUnion](langsmith.ExampleBulkNewParamsBodySplitArray(item.Splits))
+		}
+		bulk.Body = append(bulk.Body, body)
+	}
+	if _, err := sdk.Examples.Bulk.New(ctx, bulk); err != nil {
+		if _, cleanupErr := sdk.Datasets.Delete(ctx, datasetID); cleanupErr != nil {
+			return fmt.Errorf("creating examples: %v; cleaning up dataset %s: %v", err, datasetID, cleanupErr)
+		}
+		return fmt.Errorf("creating examples: %v (new dataset was removed)", err)
+	}
+	return nil
+}
+
+func parseDatasetUpload(data []byte) ([]datasetTransferExample, error) {
+	var envelope datasetTransferFile
+	if err := json.Unmarshal(data, &envelope); err == nil && envelope.Version != 0 {
+		if envelope.Version != datasetExportVersion {
+			return nil, fmt.Errorf("unsupported dataset export version %d", envelope.Version)
+		}
+		return validateDatasetTransferExamples(envelope.Examples)
+	}
+	var rawItems []json.RawMessage
+	if err := json.Unmarshal(data, &rawItems); err != nil {
+		return nil, fmt.Errorf("expected a versioned dataset export or an array of examples: %w", err)
+	}
+	items := make([]datasetTransferExample, 0, len(rawItems))
+	for i, raw := range rawItems {
+		var item datasetTransferExample
+		if err := json.Unmarshal(raw, &item); err != nil {
+			return nil, fmt.Errorf("example at index %d must be an object: %w", i, err)
+		}
+		if len(raw) == 0 || raw[0] != '{' {
+			return nil, fmt.Errorf("example at index %d must be an object", i)
+		}
+		items = append(items, item)
+	}
+	return validateDatasetTransferExamples(items)
+}
+
+func validateDatasetTransferExamples(items []datasetTransferExample) ([]datasetTransferExample, error) {
+	for i, item := range items {
+		if item.Inputs == nil {
+			return nil, fmt.Errorf("example at index %d must contain an object-valued inputs field", i)
+		}
+	}
+	return items, nil
 }

--- a/internal/cmd/dataset.go
+++ b/internal/cmd/dataset.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -432,29 +433,74 @@ func uploadExamplesWithCleanup(ctx context.Context, sdk *langsmith.Client, datas
 }
 
 func parseDatasetUpload(data []byte) ([]datasetTransferExample, error) {
-	var envelope datasetTransferFile
-	if err := json.Unmarshal(data, &envelope); err == nil && envelope.Version != 0 {
-		if envelope.Version != datasetExportVersion {
-			return nil, fmt.Errorf("unsupported dataset export version %d", envelope.Version)
-		}
-		return validateDatasetTransferExamples(envelope.Examples)
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 {
+		return nil, fmt.Errorf("expected a versioned dataset export, an example object, or an array of examples")
 	}
-	var rawItems []json.RawMessage
-	if err := json.Unmarshal(data, &rawItems); err != nil {
-		return nil, fmt.Errorf("expected a versioned dataset export or an array of examples: %w", err)
-	}
-	items := make([]datasetTransferExample, 0, len(rawItems))
-	for i, raw := range rawItems {
-		var item datasetTransferExample
-		if err := json.Unmarshal(raw, &item); err != nil {
-			return nil, fmt.Errorf("example at index %d must be an object: %w", i, err)
+
+	switch data[0] {
+	case '{':
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(data, &fields); err != nil {
+			return nil, err
 		}
-		if len(raw) == 0 || raw[0] != '{' {
-			return nil, fmt.Errorf("example at index %d must be an object", i)
+		if _, versioned := fields["version"]; versioned {
+			if _, ok := fields["examples"]; !ok {
+				return nil, fmt.Errorf("versioned dataset export must contain an examples array")
+			}
+			var envelope datasetTransferFile
+			if err := json.Unmarshal(data, &envelope); err != nil {
+				return nil, fmt.Errorf("invalid versioned dataset export: %w", err)
+			}
+			if envelope.Version != datasetExportVersion {
+				return nil, fmt.Errorf("unsupported dataset export version %d", envelope.Version)
+			}
+			if envelope.Examples == nil {
+				return nil, fmt.Errorf("versioned dataset export must contain an examples array")
+			}
+			return validateDatasetTransferExamples(envelope.Examples)
 		}
-		items = append(items, item)
+		item, err := parseLegacyDatasetExample(data, 0)
+		if err != nil {
+			return nil, err
+		}
+		return []datasetTransferExample{item}, nil
+	case '[':
+		var rawItems []json.RawMessage
+		if err := json.Unmarshal(data, &rawItems); err != nil {
+			return nil, err
+		}
+		items := make([]datasetTransferExample, 0, len(rawItems))
+		for i, raw := range rawItems {
+			item, err := parseLegacyDatasetExample(raw, i)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, item)
+		}
+		return validateDatasetTransferExamples(items)
+	default:
+		return nil, fmt.Errorf("expected a versioned dataset export, an example object, or an array of examples")
 	}
-	return validateDatasetTransferExamples(items)
+}
+
+func parseLegacyDatasetExample(data []byte, index int) (datasetTransferExample, error) {
+	var object map[string]any
+	if err := json.Unmarshal(data, &object); err != nil || object == nil {
+		return datasetTransferExample{}, fmt.Errorf("example at index %d must be an object", index)
+	}
+	if _, wrapped := object["inputs"].(map[string]any); wrapped {
+		item := datasetTransferExample{Inputs: object["inputs"].(map[string]any)}
+		if outputs, ok := object["outputs"].(map[string]any); ok {
+			item.Outputs = outputs
+		}
+		return item, nil
+	}
+	item := datasetTransferExample{Inputs: object}
+	if outputs, ok := object["outputs"].(map[string]any); ok {
+		item.Outputs = outputs
+	}
+	return item, nil
 }
 
 func validateDatasetTransferExamples(items []datasetTransferExample) ([]datasetTransferExample, error) {

--- a/internal/cmd/dataset_test.go
+++ b/internal/cmd/dataset_test.go
@@ -1,8 +1,60 @@
 package cmd
 
 import (
+	"encoding/json"
+	"net/http"
+	"strings"
 	"testing"
 )
+
+func TestParseDatasetUpload_RejectsInvalidItemWithIndex(t *testing.T) {
+	_, err := parseDatasetUpload([]byte(`[{"inputs":{"x":1}}, "bad"]`))
+	if err == nil || !strings.Contains(err.Error(), "index 1") {
+		t.Fatalf("expected indexed validation error, got %v", err)
+	}
+}
+
+func TestDatasetTransfer_RoundTripsMetadataAndSplits(t *testing.T) {
+	want := datasetTransferFile{Version: datasetExportVersion, Examples: []datasetTransferExample{{
+		Inputs: map[string]any{"x": "y"}, Outputs: map[string]any{"answer": "yes"},
+		Metadata: map[string]any{"owner": "me"}, Splits: []string{"test", "regression"},
+	}}}
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := parseDatasetUpload(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Metadata["owner"] != "me" || len(got[0].Splits) != 2 {
+		t.Fatalf("round trip lost fields: %#v", got)
+	}
+}
+
+func TestUploadExamplesWithCleanup_DeletesDatasetAfterBulkFailure(t *testing.T) {
+	deleted := false
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/examples/bulk" && r.Method == http.MethodPost:
+			http.Error(w, "bulk failed", http.StatusInternalServerError)
+		case r.URL.Path == "/api/v1/datasets/dataset-id" && r.Method == http.MethodDelete:
+			deleted = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer setupTestEnv(t, srv.URL)()
+	err := uploadExamplesWithCleanup(t.Context(), MustGetClient().SDK, "dataset-id", []datasetTransferExample{{Inputs: map[string]any{"x": 1}}})
+	if err == nil || !strings.Contains(err.Error(), "was removed") {
+		t.Fatalf("expected cleaned-up bulk error, got %v", err)
+	}
+	if !deleted {
+		t.Fatal("dataset delete was not attempted")
+	}
+}
 
 // ==================== Command structure ====================
 

--- a/internal/cmd/dataset_test.go
+++ b/internal/cmd/dataset_test.go
@@ -14,6 +14,59 @@ func TestParseDatasetUpload_RejectsInvalidItemWithIndex(t *testing.T) {
 	}
 }
 
+func TestParseDatasetUpload_AcceptsLegacySingleObject(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want any
+	}{
+		{name: "wrapped example", data: `{"inputs":{"x":1},"outputs":{"y":2}}`, want: float64(1)},
+		{name: "plain inputs", data: `{"question":"hello"}`, want: "hello"},
+		{name: "plain inputs array", data: `[{"question":"hello"}]`, want: "hello"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDatasetUpload([]byte(tt.data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("got %d examples, want 1", len(got))
+			}
+			key := "x"
+			if tt.name != "wrapped example" {
+				key = "question"
+			}
+			if got[0].Inputs[key] != tt.want {
+				t.Fatalf("inputs = %#v", got[0].Inputs)
+			}
+		})
+	}
+}
+
+func TestParseDatasetUpload_PreservesLegacyPlainObjectOutputs(t *testing.T) {
+	got, err := parseDatasetUpload([]byte(`{"question":"hello","outputs":{"answer":"hi"}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Inputs["question"] != "hello" || got[0].Outputs["answer"] != "hi" {
+		t.Fatalf("legacy example semantics changed: %#v", got[0])
+	}
+}
+
+func TestParseDatasetUpload_RejectsMalformedVersionedExport(t *testing.T) {
+	tests := []string{
+		`{"version":2,"examples":[]}`,
+		`{"version":1}`,
+		`{"version":1,"examples":null}`,
+	}
+	for _, data := range tests {
+		if _, err := parseDatasetUpload([]byte(data)); err == nil {
+			t.Fatalf("expected %s to be rejected", data)
+		}
+	}
+}
+
 func TestDatasetTransfer_RoundTripsMetadataAndSplits(t *testing.T) {
 	want := datasetTransferFile{Version: datasetExportVersion, Examples: []datasetTransferExample{{
 		Inputs: map[string]any{"x": "y"}, Outputs: map[string]any{"answer": "yes"},

--- a/internal/cmd/example.go
+++ b/internal/cmd/example.go
@@ -77,10 +77,11 @@ func newExampleListCmd() *cobra.Command {
 			fmt_ := GetFormat()
 
 			if fmt_ == "pretty" {
-				columns := []string{"ID", "Created", "Inputs Preview"}
+				columns := []string{"ID", "Split", "Created", "Inputs Preview"}
 				var rows [][]string
 				for _, ex := range examples {
 					id := ex.ID
+					splitVal := exampleSplitDisplay(ex.Metadata)
 					created := "N/A"
 					if !ex.CreatedAt.IsZero() {
 						created = ex.CreatedAt.Format("2006-01-02")
@@ -93,7 +94,7 @@ func newExampleListCmd() *cobra.Command {
 							inputsPreview = inputsPreview[:60] + "..."
 						}
 					}
-					rows = append(rows, []string{id, created, inputsPreview})
+					rows = append(rows, []string{id, splitVal, created, inputsPreview})
 				}
 				output.OutputTable(columns, rows, fmt.Sprintf("Examples in %s", ds.Name))
 			} else {
@@ -121,6 +122,33 @@ func newExampleListCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("dataset")
 
 	return cmd
+}
+
+func exampleSplitDisplay(metadata map[string]any) string {
+	if metadata == nil {
+		return "N/A"
+	}
+	switch splits := metadata["dataset_split"].(type) {
+	case []any:
+		values := make([]string, 0, len(splits))
+		for _, split := range splits {
+			if value, ok := split.(string); ok {
+				values = append(values, value)
+			}
+		}
+		if len(values) > 0 {
+			return strings.Join(values, ", ")
+		}
+	case []string:
+		if len(splits) > 0 {
+			return strings.Join(splits, ", ")
+		}
+	case string:
+		if splits != "" {
+			return splits
+		}
+	}
+	return "N/A"
 }
 
 func newExampleCreateCmd() *cobra.Command {

--- a/internal/cmd/example.go
+++ b/internal/cmd/example.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/langchain-ai/langsmith-cli/internal/output"
 	langsmith "github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/shared"
 	"github.com/spf13/cobra"
 )
 
@@ -61,13 +62,7 @@ func newExampleListCmd() *cobra.Command {
 			if limit > 0 && int64(limit) < pageSize {
 				pageSize = int64(limit)
 			}
-			params := langsmith.ExampleListParams{
-				Dataset: langsmith.F(ds.ID),
-				Limit:   langsmith.F(pageSize),
-			}
-			if offset > 0 {
-				params.Offset = langsmith.F(int64(offset))
-			}
+			params := exampleListParams(ds.ID, pageSize, offset, split)
 			var examples []langsmith.Example
 			pager := c.SDK.Examples.ListAutoPaging(ctx, params)
 			for pager.Next() {
@@ -81,31 +76,11 @@ func newExampleListCmd() *cobra.Command {
 			}
 			fmt_ := GetFormat()
 
-			// Filter by split if specified
-			if split != "" {
-				var filtered []langsmith.Example
-				for _, ex := range examples {
-					// The split field may be in metadata
-					if ex.Metadata != nil {
-						if s, ok := ex.Metadata["split"].(string); ok && s == split {
-							filtered = append(filtered, ex)
-						}
-					}
-				}
-				examples = filtered
-			}
-
 			if fmt_ == "pretty" {
-				columns := []string{"ID", "Split", "Created", "Inputs Preview"}
+				columns := []string{"ID", "Created", "Inputs Preview"}
 				var rows [][]string
 				for _, ex := range examples {
 					id := ex.ID
-					splitVal := "N/A"
-					if ex.Metadata != nil {
-						if s, ok := ex.Metadata["split"].(string); ok {
-							splitVal = s
-						}
-					}
 					created := "N/A"
 					if !ex.CreatedAt.IsZero() {
 						created = ex.CreatedAt.Format("2006-01-02")
@@ -118,7 +93,7 @@ func newExampleListCmd() *cobra.Command {
 							inputsPreview = inputsPreview[:60] + "..."
 						}
 					}
-					rows = append(rows, []string{id, splitVal, created, inputsPreview})
+					rows = append(rows, []string{id, created, inputsPreview})
 				}
 				output.OutputTable(columns, rows, fmt.Sprintf("Examples in %s", ds.Name))
 			} else {
@@ -193,21 +168,7 @@ func newExampleCreateCmd() *cobra.Command {
 				ExitErrorf("%v", err)
 			}
 
-			params := langsmith.ExampleNewParams{
-				DatasetID: langsmith.F(ds.ID),
-				Inputs:    langsmith.F(parsedInputs),
-			}
-			if parsedOutputs != nil {
-				params.Outputs = langsmith.F(parsedOutputs)
-			}
-			if parsedMetadata != nil {
-				if split != "" {
-					parsedMetadata["split"] = split
-				}
-				params.Metadata = langsmith.F(parsedMetadata)
-			} else if split != "" {
-				params.Metadata = langsmith.F(map[string]any{"split": split})
-			}
+			params := exampleCreateParams(ds.ID, parsedInputs, parsedOutputs, parsedMetadata, split)
 
 			ex, err := c.SDK.Examples.New(ctx, params)
 			if err != nil {
@@ -233,6 +194,31 @@ func newExampleCreateCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("inputs")
 
 	return cmd
+}
+
+func exampleListParams(datasetID string, pageSize int64, offset int, split string) langsmith.ExampleListParams {
+	params := langsmith.ExampleListParams{Dataset: langsmith.F(datasetID), Limit: langsmith.F(pageSize)}
+	if offset > 0 {
+		params.Offset = langsmith.F(int64(offset))
+	}
+	if split != "" {
+		params.Splits = langsmith.F([]string{split})
+	}
+	return params
+}
+
+func exampleCreateParams(datasetID string, inputs, outputs, metadata map[string]any, split string) langsmith.ExampleNewParams {
+	params := langsmith.ExampleNewParams{DatasetID: langsmith.F(datasetID), Inputs: langsmith.F(inputs)}
+	if outputs != nil {
+		params.Outputs = langsmith.F(outputs)
+	}
+	if metadata != nil {
+		params.Metadata = langsmith.F(metadata)
+	}
+	if split != "" {
+		params.Split = langsmith.F[langsmith.ExampleNewParamsSplitUnion](shared.UnionString(split))
+	}
+	return params
 }
 
 func newExampleDeleteCmd() *cobra.Command {

--- a/internal/cmd/example_test.go
+++ b/internal/cmd/example_test.go
@@ -26,6 +26,16 @@ func TestExampleParams_UseNativeSplitFields(t *testing.T) {
 	}
 }
 
+func TestExampleSplitDisplay_UsesAPIDatasetSplitNotUserMetadata(t *testing.T) {
+	metadata := map[string]any{
+		"dataset_split": []any{"test", "regression"},
+		"split":         "metadata-only",
+	}
+	if got := exampleSplitDisplay(metadata); got != "test, regression" {
+		t.Fatalf("split display = %q", got)
+	}
+}
+
 // ==================== Command structure ====================
 
 func TestExampleCmd_Subcommands(t *testing.T) {

--- a/internal/cmd/example_test.go
+++ b/internal/cmd/example_test.go
@@ -1,8 +1,30 @@
 package cmd
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 )
+
+func TestExampleParams_UseNativeSplitFields(t *testing.T) {
+	list := exampleListParams("dataset-id", 20, 0, "test")
+	if got := list.URLQuery().Get("splits"); got != "test" {
+		t.Fatalf("list split query = %q, want test", got)
+	}
+	metadata := map[string]any{"split": "metadata-value", "owner": "me"}
+	create := exampleCreateParams("dataset-id", map[string]any{"x": 1}, nil, metadata, "test")
+	body, err := json.Marshal(create)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jsonBody := string(body)
+	if !strings.Contains(jsonBody, `"split":"test"`) {
+		t.Fatalf("native split missing from create body: %s", jsonBody)
+	}
+	if metadata["split"] != "metadata-value" {
+		t.Fatalf("metadata split was overwritten: %#v", metadata)
+	}
+}
 
 // ==================== Command structure ====================
 


### PR DESCRIPTION
## Summary

- export a versioned dataset envelope that preserves inputs, outputs, metadata, and split membership
- keep legacy upload support for wrapped objects, plain input objects, and arrays
- create examples in one bulk request and remove the newly created dataset if that request fails

Stacked on #276 for native split handling.

## Legacy/final repro

Ran disposable CLI binaries against a local mock LangSmith API.

| Input | Legacy CLI | Final branch |
| --- | --- | --- |
| wrapped legacy object | exit 0, empty stderr, 2 API requests | exit 0, empty stderr, 2 API requests |
| plain legacy object | exit 0, empty stderr, 2 API requests | exit 0, empty stderr, 2 API requests |
| plain legacy array | exit 0, empty stderr, 2 API requests | exit 0, empty stderr, 2 API requests |
| versioned export | accepted as one plain input object | parsed as a versioned export with fields preserved |

This confirms the final upload path retains the legacy CLI input behavior while adding correct round-trip support for the new versioned export.

## Test plan

- `make fmt`
- `go test ./internal/cmd -count=1`
- `make vet`
- disposable process-level legacy/final repro against a local mock API