### PR TITLE
feat(sandbox): --description on snapshot build and capture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,9 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
-      - name: Install golangci-lint (built with Go 1.25)
+      - name: Install golangci-lint (built with Go 1.26)
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
       - name: Run lint

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/langchain-ai/langsmith-cli
 
-go 1.25.0
+go 1.26.7
 
 require (
 	github.com/google/uuid v1.6.0
 	github.com/itchyny/gojq v0.12.15
-	github.com/langchain-ai/langsmith-go v0.25.6
+	github.com/langchain-ai/langsmith-go v0.26.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/langchain-ai/langsmith-go v0.25.5 h1:uLEpOMfWEHH72eVf3Mx/WxEMgTGhRbvA
 github.com/langchain-ai/langsmith-go v0.25.5/go.mod h1:oBp+dsngsLpTAiaIT8ZC+5H5qV8PrTt+gY1dQixp2HM=
 github.com/langchain-ai/langsmith-go v0.25.6 h1:enWqO/IW+/7u0uLuanNeNVXifPfWADSZoktTe9LysuU=
 github.com/langchain-ai/langsmith-go v0.25.6/go.mod h1:oBp+dsngsLpTAiaIT8ZC+5H5qV8PrTt+gY1dQixp2HM=
+github.com/langchain-ai/langsmith-go v0.26.0 h1:31YtzYT71w2Tu2fwnd1AjQyHydkzxXBOnZiwcF17Muo=
+github.com/langchain-ai/langsmith-go v0.26.0/go.mod h1:76du7VxLPs5lEZXrMc7DyyN+izHHQRaa4hvGl7+J9hY=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=

--- a/internal/cmd/sandbox_box.go
+++ b/internal/cmd/sandbox_box.go
@@ -363,11 +363,15 @@ var sandboxListCommand = structured.Command[struct{}]{
 			return nil, err
 		}
 
-		resp, err := c.SDK.Sandboxes.Boxes.List(ctx, langsmith.SandboxBoxListParams{})
-		if err != nil {
+		var sandboxes []langsmith.SandboxResponse
+		pager := c.SDK.Sandboxes.Boxes.ListAutoPaging(ctx, langsmith.SandboxBoxListParams{})
+		for pager.Next() {
+			sandboxes = append(sandboxes, pager.Current())
+		}
+		if err := pager.Err(); err != nil {
 			return nil, fmt.Errorf("listing sandboxes: %w", err)
 		}
-		return resp.Sandboxes, nil
+		return sandboxes, nil
 	},
 	Render: structured.Table{
 		Title: "Sandboxes",

--- a/internal/cmd/sandbox_snapshot.go
+++ b/internal/cmd/sandbox_snapshot.go
@@ -48,11 +48,15 @@ var snapshotListCommand = structured.Command[struct{}]{
 			return nil, err
 		}
 
-		resp, err := c.SDK.Sandboxes.Snapshots.List(ctx, langsmith.SandboxSnapshotListParams{})
-		if err != nil {
+		var snapshots []langsmith.SnapshotResponse
+		pager := c.SDK.Sandboxes.Snapshots.ListAutoPaging(ctx, langsmith.SandboxSnapshotListParams{})
+		for pager.Next() {
+			snapshots = append(snapshots, pager.Current())
+		}
+		if err := pager.Err(); err != nil {
 			return nil, fmt.Errorf("listing snapshots: %w", err)
 		}
-		return resp.Snapshots, nil
+		return snapshots, nil
 	},
 	Render: structured.Table{
 		Title: "Snapshots",

--- a/internal/cmd/sandbox_snapshot.go
+++ b/internal/cmd/sandbox_snapshot.go
@@ -73,6 +73,7 @@ type snapshotBuildInput struct {
 	DockerImage string
 	Capacity    string
 	RegistryID  string
+	Description string
 }
 
 var snapshotBuildCommand = structured.Command[*snapshotBuildInput]{
@@ -86,7 +87,8 @@ Docker image's tag (ubuntu:24.04 becomes 24.04), else "latest".
 	Examples:
 	  langsmith sandbox snapshot build my-snap --docker-image ubuntu:24.04
 	  langsmith sandbox snapshot build my-snap:v2 --docker-image ubuntu:24.04
-	  langsmith sandbox snapshot build my-snap --docker-image ubuntu:24.04 --capacity 8gb`,
+	  langsmith sandbox snapshot build my-snap --docker-image ubuntu:24.04 --capacity 8gb
+	  langsmith sandbox snapshot build my-snap --docker-image ubuntu:24.04 --description "Python 3.12 with uv and ruff"`,
 	Args: cobra.ExactArgs(1),
 	Input: func(cmd *cobra.Command) *snapshotBuildInput {
 		in := &snapshotBuildInput{
@@ -95,6 +97,7 @@ Docker image's tag (ubuntu:24.04 becomes 24.04), else "latest".
 		cmd.Flags().StringVar(&in.DockerImage, "docker-image", in.DockerImage, "Docker image to build from (required)")
 		cmd.Flags().StringVar(&in.Capacity, "capacity", in.Capacity, "Filesystem capacity with unit (e.g. 4gb, 8gb)")
 		cmd.Flags().StringVar(&in.RegistryID, "registry-id", in.RegistryID, "Registry ID for private images")
+		cmd.Flags().StringVar(&in.Description, "description", in.Description, "What the snapshot's image can do, for handing to an agent (max 1024 chars)")
 		return in
 	},
 	Action: func(ctx context.Context, cmd *cobra.Command, in *snapshotBuildInput, args []string) (any, error) {
@@ -124,6 +127,9 @@ Docker image's tag (ubuntu:24.04 becomes 24.04), else "latest".
 		if in.RegistryID != "" {
 			params.RegistryID = langsmith.F(in.RegistryID)
 		}
+		if in.Description != "" {
+			params.Description = langsmith.F(in.Description)
+		}
 
 		resp, err := c.SDK.Sandboxes.Snapshots.New(ctx, params)
 		if err != nil {
@@ -132,19 +138,21 @@ Docker image's tag (ubuntu:24.04 becomes 24.04), else "latest".
 
 		return resp, nil
 	},
-	Render: structured.Template(`ID:      {{.ID}}
-Name:    {{.Name}}
-Tags:    {{joinOrDash .Tags}}
-Image:   {{dash .DockerImage}}
-Status:  {{.Status}}
-Size:    {{formatBytesOrDash .FsUsedBytes}}
-Created: {{formatTime .CreatedAt}}
+	Render: structured.Template(`ID:          {{.ID}}
+Name:        {{.Name}}
+Tags:        {{joinOrDash .Tags}}
+Image:       {{dash .DockerImage}}
+Description: {{dash .Description}}
+Status:      {{.Status}}
+Size:        {{formatBytesOrDash .FsUsedBytes}}
+Created:     {{formatTime .CreatedAt}}
 `),
 }
 
 type snapshotCaptureInput struct {
-	BoxName    string
-	Checkpoint string
+	BoxName     string
+	Checkpoint  string
+	Description string
 }
 
 var snapshotCaptureCommand = structured.Command[*snapshotCaptureInput]{
@@ -159,12 +167,14 @@ An omitted tag means "latest".
 	Examples:
 	  langsmith sandbox snapshot capture my-snap --box my-vm
 	  langsmith sandbox snapshot capture my-snap:2026081101 --box my-vm
-	  langsmith sandbox snapshot capture my-snap --box my-vm --checkpoint 2026-03-29T00:09:28Z`,
+	  langsmith sandbox snapshot capture my-snap --box my-vm --checkpoint 2026-03-29T00:09:28Z
+	  langsmith sandbox snapshot capture my-snap --box my-vm --description "repo cloned, deps installed"`,
 	Args: cobra.ExactArgs(1),
 	Input: func(cmd *cobra.Command) *snapshotCaptureInput {
 		in := &snapshotCaptureInput{}
 		cmd.Flags().StringVar(&in.BoxName, "box", in.BoxName, "Sandbox name to capture from (required)")
 		cmd.Flags().StringVar(&in.Checkpoint, "checkpoint", in.Checkpoint, "Checkpoint timestamp to use (omit for fresh checkpoint)")
+		cmd.Flags().StringVar(&in.Description, "description", in.Description, "What the snapshot's image can do, for handing to an agent (max 1024 chars)")
 		return in
 	},
 	Action: func(ctx context.Context, cmd *cobra.Command, in *snapshotCaptureInput, args []string) (any, error) {
@@ -187,6 +197,9 @@ An omitted tag means "latest".
 		if in.Checkpoint != "" {
 			params.Checkpoint = langsmith.F(in.Checkpoint)
 		}
+		if in.Description != "" {
+			params.Description = langsmith.F(in.Description)
+		}
 
 		resp, err := c.SDK.Sandboxes.Boxes.NewSnapshot(ctx, in.BoxName, params)
 		if err != nil {
@@ -195,13 +208,14 @@ An omitted tag means "latest".
 
 		return resp, nil
 	},
-	Render: structured.Template(`ID:      {{.ID}}
-Name:    {{.Name}}
-Tags:    {{joinOrDash .Tags}}
-Image:   {{dash .DockerImage}}
-Status:  {{.Status}}
-Size:    {{formatBytesOrDash .FsUsedBytes}}
-Created: {{formatTime .CreatedAt}}
+	Render: structured.Template(`ID:          {{.ID}}
+Name:        {{.Name}}
+Tags:        {{joinOrDash .Tags}}
+Image:       {{dash .DockerImage}}
+Description: {{dash .Description}}
+Status:      {{.Status}}
+Size:        {{formatBytesOrDash .FsUsedBytes}}
+Created:     {{formatTime .CreatedAt}}
 `),
 }
 
@@ -222,13 +236,14 @@ var snapshotGetCommand = structured.Command[struct{}]{
 
 		return resp, nil
 	},
-	Render: structured.Template(`ID:      {{.ID}}
-Name:    {{.Name}}
-Tags:    {{joinOrDash .Tags}}
-Image:   {{dash .DockerImage}}
-Status:  {{.Status}}
-Size:    {{formatBytesOrDash .FsUsedBytes}}
-Created: {{formatTime .CreatedAt}}
+	Render: structured.Template(`ID:          {{.ID}}
+Name:        {{.Name}}
+Tags:        {{joinOrDash .Tags}}
+Image:       {{dash .DockerImage}}
+Description: {{dash .Description}}
+Status:      {{.Status}}
+Size:        {{formatBytesOrDash .FsUsedBytes}}
+Created:     {{formatTime .CreatedAt}}
 `),
 }
 

--- a/internal/cmd/sandbox_snapshot_test.go
+++ b/internal/cmd/sandbox_snapshot_test.go
@@ -36,15 +36,41 @@ func TestSplitSnapshotRef(t *testing.T) {
 	}
 }
 
+func TestSnapshotRenderDescription(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		want        string
+	}{
+		{name: "empty is dangling", description: "", want: "Description: -"},
+		{name: "set", description: "Python 3.12 with uv", want: "Description: Python 3.12 with uv"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+
+			err := snapshotGetCommand.Render.RenderText(&out, langsmith.SnapshotResponse{
+				ID:          "snap-1",
+				Name:        "my-snap",
+				Description: tc.description,
+			})
+
+			require.NoError(t, err)
+			assert.Contains(t, out.String(), tc.want)
+		})
+	}
+}
+
 func TestJoinOrDashRendersSnapshotTags(t *testing.T) {
 	tests := []struct {
 		name string
 		tags []string
 		want string
 	}{
-		{name: "no tags is dangling", tags: nil, want: "Tags:    -"},
-		{name: "one tag", tags: []string{"latest"}, want: "Tags:    latest"},
-		{name: "many tags", tags: []string{"latest", "v2"}, want: "Tags:    latest, v2"},
+		{name: "no tags is dangling", tags: nil, want: "Tags:        -"},
+		{name: "one tag", tags: []string{"latest"}, want: "Tags:        latest"},
+		{name: "many tags", tags: []string{"latest", "v2"}, want: "Tags:        latest, v2"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Adds `--description` to `langsmith sandbox snapshot build` and `langsmith sandbox snapshot capture`, and surfaces `Description` in the build, capture, and get detail output. The `list` table is unchanged — it already carries seven columns and free-form prose wraps badly there.

The field needs `langsmith-go` v0.26.0, and that bump drags in three things that are not part of the feature but are required to keep the build green:

- **Cursor pagination on the sandbox and snapshot list endpoints.** `List` now returns `*pagination.ItemsCursorGetPagination[T]` with an `Items` field instead of `resp.Sandboxes` / `resp.Snapshots`. Both list commands move to `ListAutoPaging`, matching how `dataset`, `project`, `experiment`, and `insights` already page. This also fixes silent truncation at the first page.
- **`go` directive 1.25.0 → 1.26.7**, forced by `langsmith-go`'s own go.mod.
- **Lint job Go 1.25 → 1.26**, because `golangci-lint` refuses to run when it was built with an older Go than the module targets (`the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26.7)`).

The detail-view column labels widened to fit `Description:`, so the snapshot render test's expectations moved with them.

## Test Plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean (all 9 packages)
- [x] `make vet` clean
- [x] `gofmt` clean
- [x] New `TestSnapshotRenderDescription` covers the dangling-dash and set cases for the new field
- [x] Existing `TestJoinOrDashRendersSnapshotTags` updated for the widened labels and passing
