### PR TITLE
fix(auth): support delegated BYOC OAuth issuers

### DIFF
--- a/internal/client/oauth.go
+++ b/internal/client/oauth.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -21,7 +22,10 @@ const (
 // document. It is distinct from a transport or 5xx failure, which says nothing
 // about whether the document exists and so must not trigger the legacy
 // fallback.
-var errNoOAuthMetadata = errors.New("no authorization server metadata")
+var (
+	errNoOAuthMetadata      = errors.New("no authorization server metadata")
+	errInvalidOAuthMetadata = errors.New("invalid authorization server metadata")
+)
 
 // OAuthMetadata holds absolute authorization server endpoints. The AS lives at
 // <origin>/oauth on SaaS and <origin>/api/oauth on self-hosted, so callers use
@@ -75,19 +79,19 @@ func oauthDiscoveryCandidates(apiURL string) []string {
 // reported in preference to errNoOAuthMetadata so callers do not mistake an
 // outage for a legacy backend.
 func DiscoverOAuth(ctx context.Context, apiURL string) (*OAuthMetadata, error) {
-	var transientErr error
+	var discoveryErr error
 	for _, base := range oauthDiscoveryCandidates(apiURL) {
 		meta, err := fetchOAuthMetadata(ctx, base+wellKnownOAuthPath, base)
 		switch {
 		case err == nil:
 			return meta, nil
 		case errors.Is(err, errNoOAuthMetadata):
-		case transientErr == nil:
-			transientErr = err
+		case discoveryErr == nil:
+			discoveryErr = err
 		}
 	}
-	if transientErr != nil {
-		return nil, fmt.Errorf("discovering OAuth authorization server: %w", transientErr)
+	if discoveryErr != nil {
+		return nil, fmt.Errorf("discovering OAuth authorization server: %w", discoveryErr)
 	}
 	return nil, fmt.Errorf("discovering OAuth authorization server for %q: %w", apiURL, errNoOAuthMetadata)
 }
@@ -115,6 +119,10 @@ func ResolveOAuth(ctx context.Context, apiURL string) (*OAuthMetadata, error) {
 }
 
 func fetchOAuthMetadata(ctx context.Context, metadataURL, base string) (*OAuthMetadata, error) {
+	return fetchOAuthMetadataWithDelegation(ctx, metadataURL, base, true)
+}
+
+func fetchOAuthMetadataWithDelegation(ctx context.Context, metadataURL, base string, allowDelegation bool) (*OAuthMetadata, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
 	if err != nil {
 		return nil, err
@@ -148,6 +156,25 @@ func fetchOAuthMetadata(ctx context.Context, metadataURL, base string) (*OAuthMe
 	if doc.TokenEndpoint == "" || doc.DeviceAuthorizationEndpoint == "" {
 		return nil, fmt.Errorf("%s: metadata missing required endpoints: %w", metadataURL, errNoOAuthMetadata)
 	}
+	if strings.TrimRight(doc.Issuer, "/") != strings.TrimRight(base, "/") {
+		if !allowDelegation {
+			return nil, fmt.Errorf("%s: issuer %q does not match %q: %w", metadataURL, doc.Issuer, base, errInvalidOAuthMetadata)
+		}
+		if err := validateDelegatedOAuthMetadata(&doc); err != nil {
+			return nil, fmt.Errorf("%s: %v: %w", metadataURL, err, errInvalidOAuthMetadata)
+		}
+		issuer := strings.TrimRight(doc.Issuer, "/")
+		canonical, err := fetchOAuthMetadataWithDelegation(ctx, issuer+wellKnownOAuthPath, issuer, false)
+		if err != nil {
+			return nil, fmt.Errorf("validating delegated OAuth issuer %q: %v: %w", issuer, err, errInvalidOAuthMetadata)
+		}
+		if canonical.DeviceAuthorizationEndpoint != doc.DeviceAuthorizationEndpoint ||
+			canonical.TokenEndpoint != doc.TokenEndpoint ||
+			canonical.RegistrationEndpoint != doc.RegistrationEndpoint {
+			return nil, fmt.Errorf("%s: delegated metadata does not match issuer metadata: %w", metadataURL, errInvalidOAuthMetadata)
+		}
+		return canonical, nil
+	}
 	if err := validateOAuthMetadata(&doc, base); err != nil {
 		return nil, fmt.Errorf("%s: %w: %w", metadataURL, err, errNoOAuthMetadata)
 	}
@@ -159,6 +186,21 @@ func fetchOAuthMetadata(ctx context.Context, metadataURL, base string) (*OAuthMe
 		RegistrationEndpoint:        doc.RegistrationEndpoint,
 		Resource:                    doc.Issuer,
 	}, nil
+}
+
+func validateDelegatedOAuthMetadata(doc *oauthServerMetadata) error {
+	issuer, err := validateOAuthEndpointOrigins(doc)
+	if err != nil {
+		return err
+	}
+	if issuer.Scheme == "https" {
+		return nil
+	}
+	ip := net.ParseIP(issuer.Hostname())
+	if issuer.Scheme == "http" && (issuer.Hostname() == "localhost" || ip != nil && ip.IsLoopback()) {
+		return nil
+	}
+	return fmt.Errorf("delegated issuer %q must use HTTPS", doc.Issuer)
 }
 
 func isTransientStatus(code int) bool {
@@ -174,9 +216,14 @@ func validateOAuthMetadata(doc *oauthServerMetadata, base string) error {
 	if strings.TrimRight(doc.Issuer, "/") != strings.TrimRight(base, "/") {
 		return fmt.Errorf("issuer %q does not match %q", doc.Issuer, base)
 	}
+	_, err := validateOAuthEndpointOrigins(doc)
+	return err
+}
+
+func validateOAuthEndpointOrigins(doc *oauthServerMetadata) (*url.URL, error) {
 	issuer, err := url.Parse(doc.Issuer)
-	if err != nil {
-		return fmt.Errorf("unparseable issuer %q", doc.Issuer)
+	if err != nil || issuer.Scheme == "" || issuer.Host == "" || issuer.User != nil || issuer.Fragment != "" || issuer.RawQuery != "" {
+		return nil, fmt.Errorf("unparseable issuer %q", doc.Issuer)
 	}
 	for _, ep := range []string{doc.DeviceAuthorizationEndpoint, doc.TokenEndpoint, doc.RegistrationEndpoint} {
 		if ep == "" {
@@ -184,11 +231,11 @@ func validateOAuthMetadata(doc *oauthServerMetadata, base string) error {
 		}
 		u, err := url.Parse(ep)
 		if err != nil {
-			return fmt.Errorf("unparseable endpoint %q", ep)
+			return nil, fmt.Errorf("unparseable endpoint %q", ep)
 		}
 		if u.Scheme != issuer.Scheme || u.Host != issuer.Host {
-			return fmt.Errorf("endpoint %q is not on issuer origin %s://%s", ep, issuer.Scheme, issuer.Host)
+			return nil, fmt.Errorf("endpoint %q is not on issuer origin %s://%s", ep, issuer.Scheme, issuer.Host)
 		}
 	}
-	return nil
+	return issuer, nil
 }

--- a/internal/client/oauth_test.go
+++ b/internal/client/oauth_test.go
@@ -103,6 +103,75 @@ func TestDiscoverOAuth_SaaSAtRoot(t *testing.T) {
 	}
 }
 
+func TestDiscoverOAuth_DelegatedAuthorizationServer(t *testing.T) {
+	var authServer *httptest.Server
+	authServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/oauth-authorization-server" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                        authServer.URL,
+			"device_authorization_endpoint": authServer.URL + "/oauth/device/code",
+			"token_endpoint":                authServer.URL + "/oauth/token",
+			"registration_endpoint":         authServer.URL + "/oauth/register",
+		})
+	}))
+	t.Cleanup(authServer.Close)
+
+	dataPlane := metadataServer(t, func(string) map[string]any {
+		return map[string]any{
+			"issuer":                        authServer.URL,
+			"device_authorization_endpoint": authServer.URL + "/oauth/device/code",
+			"token_endpoint":                authServer.URL + "/oauth/token",
+			"registration_endpoint":         authServer.URL + "/oauth/register",
+		}
+	})
+
+	meta, err := DiscoverOAuth(context.Background(), dataPlane.URL)
+	if err != nil {
+		t.Fatalf("DiscoverOAuth: %v", err)
+	}
+	if got, want := meta.Issuer, authServer.URL; got != want {
+		t.Errorf("Issuer = %q, want %q", got, want)
+	}
+	if got, want := meta.Resource, authServer.URL; got != want {
+		t.Errorf("Resource = %q, want %q", got, want)
+	}
+	if got, want := meta.TokenEndpoint, authServer.URL+"/oauth/token"; got != want {
+		t.Errorf("TokenEndpoint = %q, want %q", got, want)
+	}
+}
+
+func TestResolveOAuth_RejectsDelegatedEndpointMismatch(t *testing.T) {
+	var authServer *httptest.Server
+	authServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/oauth-authorization-server" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                        authServer.URL,
+			"device_authorization_endpoint": authServer.URL + "/oauth/device/code",
+			"token_endpoint":                authServer.URL + "/oauth/token",
+		})
+	}))
+	t.Cleanup(authServer.Close)
+
+	dataPlane := metadataServer(t, func(string) map[string]any {
+		return map[string]any{
+			"issuer":                        authServer.URL,
+			"device_authorization_endpoint": authServer.URL + "/oauth/device/code",
+			"token_endpoint":                authServer.URL + "/oauth/other-token",
+		}
+	})
+
+	if _, err := ResolveOAuth(context.Background(), dataPlane.URL); err == nil {
+		t.Fatal("expected delegated endpoint mismatch to be rejected")
+	}
+}
+
 // No metadata document must surface an error so callers can fall back.
 func TestDiscoverOAuth_NoMetadataReturnsError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -167,9 +236,8 @@ func metadataServer(t *testing.T, doc func(base string) map[string]any) *httptes
 	return srv
 }
 
-// Credentials are POSTed to these endpoints, so a document claiming an issuer
-// other than the host we probed must not be trusted.
-func TestDiscoverOAuth_RejectsIssuerMismatch(t *testing.T) {
+// Every advertised endpoint must be on the issuer's origin.
+func TestDiscoverOAuth_RejectsIssuerEndpointMismatch(t *testing.T) {
 	srv := metadataServer(t, func(base string) map[string]any {
 		return map[string]any{
 			"issuer":                        "https://evil.example.com",

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -101,7 +101,7 @@ var authTokenCommand = structured.Command[struct{}]{
 			if ctx == nil {
 				ctx = context.Background()
 			}
-			token, err := refreshProfileToken(ctx, apiURL, profile.OAuth.RefreshToken)
+			token, err := refreshProfileToken(ctx, apiURL, profile.OAuth.Issuer, profile.OAuth.RefreshToken)
 			if err != nil {
 				return "", fmt.Errorf("refreshing OAuth token for profile %q: %w; run 'langsmith auth login --profile %s' to reauthenticate", profileName, err, profileName)
 			}

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -150,6 +150,7 @@ func runLogin(cmd *cobra.Command, noBrowser bool, timeout time.Duration, workspa
 	if workspaceID != "" {
 		profile.WorkspaceID = workspaceID
 	}
+	profile.OAuth.Issuer = oauthMeta.Issuer
 	applyTokenResponse(&profile, token, time.Now())
 	cfg.Profiles[profileName] = profile
 	cfg.CurrentProfile = profileName
@@ -327,8 +328,12 @@ func requestDeviceCode(ctx context.Context, meta *client.OAuthMetadata) (*device
 	return &resp, nil
 }
 
-func refreshProfileToken(ctx context.Context, apiURL, refreshToken string) (*oauthTokenResponse, error) {
-	meta, err := client.ResolveOAuth(ctx, apiURL)
+func refreshProfileToken(ctx context.Context, apiURL, issuer, refreshToken string) (*oauthTokenResponse, error) {
+	oauthURL := apiURL
+	if issuer != "" {
+		oauthURL = issuer
+	}
+	meta, err := client.ResolveOAuth(ctx, oauthURL)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -131,6 +131,9 @@ func TestLoginDeviceFlowSavesOAuthProfile(t *testing.T) {
 	if profile.OAuth.RefreshToken != "test-refresh-token" {
 		t.Fatalf("refresh token was not saved")
 	}
+	if profile.OAuth.Issuer != ts.URL {
+		t.Fatalf("expected OAuth issuer %q, got %q", ts.URL, profile.OAuth.Issuer)
+	}
 	if profile.WorkspaceID != workspaceID {
 		t.Fatalf("workspace ID was not saved")
 	}
@@ -464,12 +467,51 @@ func TestRefreshProfileToken(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	token, err := refreshProfileToken(t.Context(), ts.URL+"/api/v1", "old-refresh-token")
+	token, err := refreshProfileToken(t.Context(), ts.URL+"/api/v1", "", "old-refresh-token")
 	if err != nil {
 		t.Fatalf("refreshProfileToken returned error: %v", err)
 	}
 	if token.AccessToken != "new-access-token" || token.RefreshToken != "new-refresh-token" {
 		t.Fatalf("unexpected token response: %+v", token)
+	}
+}
+
+func TestRefreshProfileTokenUsesPinnedIssuer(t *testing.T) {
+	dataPlane := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("refresh unexpectedly contacted data plane at %s", r.URL.Path)
+	}))
+	defer dataPlane.Close()
+
+	var authServer *httptest.Server
+	authServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                        authServer.URL,
+				"device_authorization_endpoint": authServer.URL + "/oauth/device/code",
+				"token_endpoint":                authServer.URL + "/oauth/token",
+			})
+		case "/oauth/token":
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			if got := r.FormValue("refresh_token"); got != "old-refresh-token" {
+				t.Fatalf("unexpected refresh token %q", got)
+			}
+			assertOAuthResource(t, r)
+			_ = json.NewEncoder(w).Encode(oauthTokenResponse{AccessToken: "new-access-token"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer authServer.Close()
+
+	token, err := refreshProfileToken(t.Context(), dataPlane.URL, authServer.URL, "old-refresh-token")
+	if err != nil {
+		t.Fatalf("refreshProfileToken returned error: %v", err)
+	}
+	if token.AccessToken != "new-access-token" {
+		t.Fatalf("unexpected access token %q", token.AccessToken)
 	}
 }
 
@@ -486,7 +528,7 @@ func TestRefreshProfileTokenRequiresAccessToken(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	_, err := refreshProfileToken(t.Context(), ts.URL, "old-refresh-token")
+	_, err := refreshProfileToken(t.Context(), ts.URL, "", "old-refresh-token")
 	if err == nil || !strings.Contains(err.Error(), "access token") {
 		t.Fatalf("expected missing access token error, got %v", err)
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -200,7 +200,7 @@ func resolveClientOptions(refreshOAuth bool) (client.Options, error) {
 	case hasProfile && (profile.AccessToken() != "" || (refreshOAuth && profile.OAuth.RefreshToken != "")):
 		if refreshOAuth && profile.OAuth.RefreshToken != "" &&
 			(profile.AccessToken() == "" || profile.TokenExpiresSoon(time.Now(), time.Minute)) {
-			token, err := refreshProfileToken(context.Background(), opts.APIURL, profile.OAuth.RefreshToken)
+			token, err := refreshProfileToken(context.Background(), opts.APIURL, profile.OAuth.Issuer, profile.OAuth.RefreshToken)
 			if err != nil {
 				return opts, fmt.Errorf("refreshing OAuth token for profile %q: %w; run 'langsmith auth login --profile %s' to reauthenticate", profileName, err, profileName)
 			}

--- a/internal/cmdutil/resolve.go
+++ b/internal/cmdutil/resolve.go
@@ -177,7 +177,7 @@ func ResolveClientOptions(cmd *cobra.Command, refreshOAuth bool) (client.Options
 			if ctx == nil {
 				ctx = context.Background()
 			}
-			token, err := refreshProfileToken(ctx, opts.APIURL, profile.OAuth.RefreshToken)
+			token, err := refreshProfileToken(ctx, opts.APIURL, profile.OAuth.Issuer, profile.OAuth.RefreshToken)
 			if err != nil {
 				return opts, fmt.Errorf("refreshing OAuth token for profile %q: %w; run 'langsmith auth login --profile %s' to reauthenticate", profileName, err, profileName)
 			}
@@ -203,8 +203,12 @@ func ResolveClientOptions(cmd *cobra.Command, refreshOAuth bool) (client.Options
 	return opts, nil
 }
 
-func refreshProfileToken(ctx context.Context, apiURL, refreshToken string) (*oauthTokenResponse, error) {
-	meta, err := client.ResolveOAuth(ctx, apiURL)
+func refreshProfileToken(ctx context.Context, apiURL, issuer, refreshToken string) (*oauthTokenResponse, error) {
+	oauthURL := apiURL
+	if issuer != "" {
+		oauthURL = issuer
+	}
+	meta, err := client.ResolveOAuth(ctx, oauthURL)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -417,6 +417,65 @@ func TestResolveClientOptionsRefreshesProfileWithoutAccessToken(t *testing.T) {
 	}
 }
 
+func TestResolveClientOptionsRefreshesThroughPinnedIssuer(t *testing.T) {
+	dataPlane := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("refresh unexpectedly contacted data plane at %s", r.URL.Path)
+	}))
+	defer dataPlane.Close()
+
+	var authServer *httptest.Server
+	authServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                        authServer.URL,
+				"device_authorization_endpoint": authServer.URL + "/oauth/device/code",
+				"token_endpoint":                authServer.URL + "/oauth/token",
+			})
+		case "/oauth/token":
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			if got := r.FormValue("refresh_token"); got != "old-refresh-token" {
+				t.Fatalf("unexpected refresh token %q", got)
+			}
+			assertOAuthResource(t, r)
+			_ = json.NewEncoder(w).Encode(oauthTokenResponse{AccessToken: "new-access-token"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer authServer.Close()
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("LANGSMITH_CONFIG_FILE", path)
+	t.Setenv("LANGSMITH_API_KEY", "")
+	t.Setenv("LANGSMITH_ENDPOINT", "")
+	if err := os.WriteFile(path, []byte(`{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_url": "`+dataPlane.URL+`",
+      "oauth": {
+        "issuer": "`+authServer.URL+`",
+        "refresh_token": "old-refresh-token"
+      }
+    }
+  }
+}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	opts, err := ResolveClientOptions(newTestCmd(), true)
+	if err != nil {
+		t.Fatalf("ResolveClientOptions returned error: %v", err)
+	}
+	if opts.OAuthAccessToken != "new-access-token" {
+		t.Fatalf("expected refreshed OAuth token, got %q", opts.OAuthAccessToken)
+	}
+}
+
 func assertOAuthResource(t *testing.T, r *http.Request) {
 	t.Helper()
 	expected := "http://" + r.Host

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type OAuth struct {
 	AccessToken  string `json:"access_token,omitempty"`
 	RefreshToken string `json:"refresh_token,omitempty"`
 	ExpiresAt    string `json:"expires_at,omitempty"`
+	Issuer       string `json:"issuer,omitempty"`
 }
 
 // Config is the on-disk LangSmith CLI config.


### PR DESCRIPTION
Supports OAuth login when a BYOC data-plane API delegates authentication to a managed control-plane issuer.

The CLI now validates delegated authorization-server metadata against the issuer's canonical RFC 8414 document, rejects invalid delegation instead of falling back to legacy endpoints, and saves the validated issuer separately from the profile API URL. Refresh flows use that pinned issuer while older profiles continue falling back to `api_url`.

## Test Plan

- [x] Added a delegated data-plane/authorization-server discovery regression test.
- [x] Added rejection coverage for mismatched delegated endpoints.
- [x] Added profile persistence and pinned-refresh coverage for both command resolver paths.
- [x] Verified a live device-code request against the BYOC AWS E2E data plane reaches `https://aws.smith.langchain.com/activate` instead of returning `invalid_target`.
