### PR TITLE
feat(flags): accept --project-id on every command that takes --project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ The module targets the Go version declared in `go.mod`.
 
 Keep commands scriptable and preserve established output formats. Add focused tests for new commands, flags, request parameters, and output behavior.
 
+A command that selects a project takes both `--project` and `--project-id`; register the pair with `addProjectFlags` (or `addCommonFilterFlags`, which calls it) and resolve it with `resolveSessionID`. Callers building a command line programmatically should pass the UUID, since project names are user-authored and may contain shell metacharacters. `TestEveryProjectCommandAcceptsProjectID` fails if a new command offers only one of the two.
+
 ## LangSmith API access
 
 Use the generated Go SDK through the shared client's `SDK` field. Do not add raw API calls when the endpoint is available in `langsmith-go`, and do not copy existing raw-call patterns for new code.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ langsmith --format=json trace list --project my-app
 langsmith trace list --project my-app -o traces.json
 ```
 
+## Selecting a project
+
+Every command that operates on a project takes either `--project <name>` or
+`--project-id <session UUID>`, and `$LANGSMITH_PROJECT` supplies the name when
+neither is set. The two flags are mutually exclusive.
+
+```bash
+langsmith trace list --project 'my-app'
+langsmith trace list --project-id 519bb9dd-079b-4488-8610-e330951ea3e4
+```
+
+Prefer `--project-id` when a program is building the command line. Project names
+are free-form — users can create one containing spaces, quotes, or shell
+metacharacters — so a name has to be quoted correctly at every call site, and a
+name that is quoted wrongly matches nothing and returns an empty result rather
+than an error. A UUID needs no quoting. `--project-id` also skips the name
+lookup, saving a round-trip.
+
+`langsmith project list` returns the `id` to use.
+
 ## Command Reference
 
 ### `project` — List tracing projects

--- a/internal/cmd/evaluator.go
+++ b/internal/cmd/evaluator.go
@@ -194,14 +194,15 @@ func newEvaluatorListCmd() *cobra.Command {
 
 func newEvaluatorUploadCmd() *cobra.Command {
 	var (
-		name          string
-		funcName      string
-		targetDataset string
-		targetProject string
-		samplingRate  float64
-		traceFilter   string
-		replace       bool
-		yes           bool
+		name            string
+		funcName        string
+		targetDataset   string
+		targetProject   string
+		targetProjectID string
+		samplingRate    float64
+		traceFilter     string
+		replace         bool
+		yes             bool
 	)
 
 	cmd := &cobra.Command{
@@ -211,7 +212,7 @@ func newEvaluatorUploadCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			evaluatorFile := args[0]
 
-			if err := validateEvaluatorTargetFlags(targetDataset, targetProject); err != nil {
+			if err := validateEvaluatorTargetFlags(targetDataset, targetProject, targetProjectID); err != nil {
 				return err
 			}
 
@@ -226,8 +227,8 @@ func newEvaluatorUploadCmd() *cobra.Command {
 				}
 				datasetID = ds.ID
 			}
-			if targetProject != "" {
-				sid, err := c.ResolveSessionID(ctx, targetProject)
+			if targetProject != "" || targetProjectID != "" {
+				sid, err := resolveSessionID(ctx, c, targetProject, targetProjectID, "evaluator upload")
 				if err != nil {
 					ExitErrorf("%v", err)
 				}
@@ -329,6 +330,8 @@ func newEvaluatorUploadCmd() *cobra.Command {
 	cmd.Flags().StringVar(&funcName, "function", "", "Name of the function to upload (required)")
 	cmd.Flags().StringVar(&targetDataset, "dataset", "", "Target dataset name (offline evaluator)")
 	cmd.Flags().StringVar(&targetProject, "project", "", "Target project name (online evaluator)")
+	cmd.Flags().StringVar(&targetProjectID, "project-id", "", "Target project (session) UUID; skips the name lookup")
+	cmd.MarkFlagsMutuallyExclusive("project", "project-id")
 	cmd.Flags().Float64Var(&samplingRate, "sampling-rate", 1.0, "Fraction of runs to evaluate (0.0-1.0)")
 	cmd.Flags().StringVar(&traceFilter, "trace-filter", "", "Filter expression for which runs to evaluate")
 	cmd.Flags().BoolVar(&replace, "replace", false, "Replace existing evaluator with same name")
@@ -345,6 +348,7 @@ func newEvaluatorCreateLLMCmd() *cobra.Command {
 		name            string
 		targetDataset   string
 		targetProject   string
+		targetProjectID string
 		samplingRate    float64
 		traceFilter     string
 		hubRef          string
@@ -373,7 +377,7 @@ Examples:
 			c := MustGetClient()
 			ctx := context.Background()
 
-			target, err := resolveLLMEvaluatorTarget(ctx, c, targetDataset, targetProject)
+			target, err := resolveLLMEvaluatorTarget(ctx, c, targetDataset, targetProject, targetProjectID)
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -421,6 +425,8 @@ Examples:
 	cmd.Flags().StringVar(&name, "name", "", "Display name (required)")
 	cmd.Flags().StringVar(&targetDataset, "dataset", "", "Target dataset name")
 	cmd.Flags().StringVar(&targetProject, "project", "", "Target project name")
+	cmd.Flags().StringVar(&targetProjectID, "project-id", "", "Target project (session) UUID; skips the name lookup")
+	cmd.MarkFlagsMutuallyExclusive("project", "project-id")
 	cmd.Flags().Float64Var(&samplingRate, "sampling-rate", 1.0, "Fraction of runs to evaluate (0.0-1.0)")
 	cmd.Flags().StringVar(&traceFilter, "trace-filter", "", "Filter expression for which runs to evaluate")
 	cmd.Flags().StringVar(&hubRef, "hub-ref", "", "Prompt Hub reference; replaces --prompt and --schema (e.g. my-org/prompt:latest)")

--- a/internal/cmd/evaluator_llm.go
+++ b/internal/cmd/evaluator_llm.go
@@ -94,19 +94,25 @@ func parseVariableMapping(raw string) (map[string]string, error) {
 	return mapping, nil
 }
 
-func validateEvaluatorTargetFlags(dataset, project string) error {
-	if dataset == "" && project == "" {
-		return fmt.Errorf("must specify --dataset or --project (global evaluators not supported)")
+func validateEvaluatorTargetFlags(dataset, project, projectID string) error {
+	set := 0
+	for _, v := range []string{dataset, project, projectID} {
+		if v != "" {
+			set++
+		}
 	}
-	if dataset != "" && project != "" {
-		return fmt.Errorf("cannot specify both --dataset and --project")
+	if set == 0 {
+		return fmt.Errorf("must specify --dataset, --project, or --project-id (global evaluators not supported)")
+	}
+	if set > 1 {
+		return fmt.Errorf("specify only one of --dataset, --project, or --project-id")
 	}
 	return nil
 }
 
 // Finds the dataset or project this evaluator should run on.
-func resolveLLMEvaluatorTarget(ctx context.Context, c *client.Client, dataset, project string) (llmEvaluatorTarget, error) {
-	if err := validateEvaluatorTargetFlags(dataset, project); err != nil {
+func resolveLLMEvaluatorTarget(ctx context.Context, c *client.Client, dataset, project, projectID string) (llmEvaluatorTarget, error) {
+	if err := validateEvaluatorTargetFlags(dataset, project, projectID); err != nil {
 		return llmEvaluatorTarget{}, err
 	}
 	var target llmEvaluatorTarget
@@ -117,8 +123,8 @@ func resolveLLMEvaluatorTarget(ctx context.Context, c *client.Client, dataset, p
 		}
 		target.datasetID = ds.ID
 	}
-	if project != "" {
-		sid, err := c.ResolveSessionID(ctx, project)
+	if project != "" || projectID != "" {
+		sid, err := resolveSessionID(ctx, c, project, projectID, "evaluator llm create")
 		if err != nil {
 			return llmEvaluatorTarget{}, err
 		}

--- a/internal/cmd/evaluator_test.go
+++ b/internal/cmd/evaluator_test.go
@@ -371,20 +371,25 @@ func TestValidateEvaluatorTargetFlags(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		dataset string
-		project string
-		wantErr string
+		name      string
+		dataset   string
+		project   string
+		projectID string
+		wantErr   string
 	}{
 		{name: "requires one target", wantErr: "must specify"},
-		{name: "rejects both targets", dataset: "ds", project: "proj", wantErr: "cannot specify both"},
+		{name: "rejects dataset and project", dataset: "ds", project: "proj", wantErr: "only one of"},
+		{name: "rejects dataset and project-id", dataset: "ds", projectID: "id", wantErr: "only one of"},
+		{name: "rejects project and project-id", project: "proj", projectID: "id", wantErr: "only one of"},
+		{name: "rejects all three", dataset: "ds", project: "proj", projectID: "id", wantErr: "only one of"},
 		{name: "dataset only", dataset: "ds"},
 		{name: "project only", project: "proj"},
+		{name: "project-id only", projectID: "id"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := validateEvaluatorTargetFlags(tt.dataset, tt.project)
+			err := validateEvaluatorTargetFlags(tt.dataset, tt.project, tt.projectID)
 			if tt.wantErr == "" {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
@@ -590,7 +595,7 @@ func TestEvaluatorUploadCmd_InvalidTargetReturnsError(t *testing.T) {
 	_ = cmd.Flags().Set("project", "project")
 
 	runErr := runTestCommand(t, cmd, []string{"evaluator.py"})
-	if runErr == nil || !contains(runErr.Error(), "cannot specify both") {
+	if runErr == nil || !contains(runErr.Error(), "only one of") {
 		t.Fatalf("unexpected error: %v", runErr)
 	}
 }

--- a/internal/cmd/filters.go
+++ b/internal/cmd/filters.go
@@ -32,11 +32,26 @@ type FilterFlags struct {
 	RawFilter    string
 }
 
+const (
+	projectFlagUsage   = "Project name [env: LANGSMITH_PROJECT]"
+	projectIDFlagUsage = "Project (session) UUID; skips the name lookup. Mutually exclusive with --project; overrides $LANGSMITH_PROJECT"
+)
+
+// addProjectFlags attaches the --project / --project-id pair to a command that
+// does not use the shared filter flags. Every command that resolves a project
+// takes both, so an agent building a command line never has to quote a project
+// name it did not choose. Resolve them with resolveSessionID.
+func addProjectFlags(cmd *cobra.Command, project, projectID *string) {
+	cmd.Flags().StringVar(project, "project", "", projectFlagUsage)
+	cmd.Flags().StringVar(projectID, "project-id", "", projectIDFlagUsage)
+	cmd.MarkFlagsMutuallyExclusive("project", "project-id")
+}
+
 // addCommonFilterFlags attaches shared filter flags to a command.
 func addCommonFilterFlags(cmd *cobra.Command, f *FilterFlags, includeRunType bool) {
 	cmd.Flags().StringVar(&f.TraceIDs, "trace-ids", "", "Comma-separated trace IDs to filter by")
 	cmd.Flags().IntVarP(&f.Limit, "limit", "n", 0, "Maximum number of results to return")
-	cmd.Flags().StringVar(&f.Project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
+	addProjectFlags(cmd, &f.Project, &f.ProjectID)
 	cmd.Flags().IntVar(&f.LastNMinutes, "last-n-minutes", 0, "Only include runs from the last N minutes, e.g. 60 (overrides 7-day default)")
 	cmd.Flags().StringVar(&f.Since, "since", "", "Only include runs after this timestamp, e.g. 2024-01-15T00:00:00Z (overrides 7-day default)")
 	cmd.Flags().StringVar(&f.Before, "before", "", "Only include runs before this timestamp, e.g. 2024-01-15T00:00:00Z (for pagination)")

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -26,16 +26,24 @@ import (
 // the "required" error message.
 func resolveSessionID(ctx context.Context, c *client.Client, projectName, projectID, cmdName string) (string, error) {
 	if projectID != "" {
-		if _, err := uuid.Parse(projectID); err != nil {
-			return "", fmt.Errorf("invalid --project-id %q: must be a project (session) UUID", projectID)
-		}
-		return projectID, nil
+		return validateProjectID(projectID)
 	}
 	name := ResolveProject(projectName)
 	if name == "" {
 		return "", fmt.Errorf("--project or --project-id is required for %s (or set LANGSMITH_PROJECT)", cmdName)
 	}
 	return c.ResolveSessionID(ctx, name)
+}
+
+// validateProjectID returns a --project-id value unchanged once it is a
+// well-formed UUID, so a malformed one fails here rather than as a server 4xx.
+// Callers that filter by session ID without going through resolveSessionID
+// (see `project issues list`) use this directly.
+func validateProjectID(projectID string) (string, error) {
+	if _, err := uuid.Parse(projectID); err != nil {
+		return "", fmt.Errorf("invalid --project-id %q: must be a project (session) UUID", projectID)
+	}
+	return projectID, nil
 }
 
 // queryRuns queries runs with the given params, scoped to sessionID when non-empty.

--- a/internal/cmd/insights.go
+++ b/internal/cmd/insights.go
@@ -39,6 +39,7 @@ Examples:
 func newInsightsListCmd() *cobra.Command {
 	var (
 		project    string
+		projectID  string
 		limit      int
 		outputFile string
 	)
@@ -58,12 +59,7 @@ for full details including the executive summary and category breakdown.`,
 			c := MustGetClient()
 			ctx := context.Background()
 
-			projectName := ResolveProject(project)
-			if projectName == "" {
-				ExitError("--project is required (or set LANGSMITH_PROJECT)")
-			}
-
-			sessionID, err := c.ResolveSessionID(ctx, projectName)
+			sessionID, err := resolveSessionID(ctx, c, project, projectID, "insights list")
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -107,7 +103,7 @@ for full details including the executive summary and category breakdown.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
+	addProjectFlags(cmd, &project, &projectID)
 	cmd.Flags().IntVarP(&limit, "limit", "n", 0, "Maximum number of reports to return")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 
@@ -117,6 +113,7 @@ for full details including the executive summary and category breakdown.`,
 func newInsightsGetCmd() *cobra.Command {
 	var (
 		project    string
+		projectID  string
 		outputFile string
 	)
 
@@ -136,12 +133,7 @@ statistics (error rates, latency, costs, token usage, feedback scores).`,
 			c := MustGetClient()
 			ctx := context.Background()
 
-			projectName := ResolveProject(project)
-			if projectName == "" {
-				ExitError("--project is required (or set LANGSMITH_PROJECT)")
-			}
-
-			sessionID, err := c.ResolveSessionID(ctx, projectName)
+			sessionID, err := resolveSessionID(ctx, c, project, projectID, "insights get")
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -164,7 +156,7 @@ statistics (error rates, latency, costs, token usage, feedback scores).`,
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
+	addProjectFlags(cmd, &project, &projectID)
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
 
 	return cmd

--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -99,6 +99,7 @@ Examples:
 func newProjectIssuesListCmd() *cobra.Command {
 	var (
 		project    string
+		projectID  string
 		status     string
 		priority   string
 		limit      int
@@ -131,13 +132,20 @@ Examples:
 			c := MustGetClient()
 			ctx := context.Background()
 
-			projectName := ResolveProject(project)
-			if projectName == "" {
-				ExitError("--project is required (or set LANGSMITH_PROJECT)")
-			}
-
-			params := langsmith.IssueListParams{
-				SessionName: langsmith.F(projectName),
+			params := langsmith.IssueListParams{}
+			projectLabel := projectID
+			if projectID != "" {
+				id, err := validateProjectID(projectID)
+				if err != nil {
+					ExitErrorf("%v", err)
+				}
+				params.SessionID = langsmith.F(id)
+			} else {
+				projectLabel = ResolveProject(project)
+				if projectLabel == "" {
+					ExitError("--project or --project-id is required (or set LANGSMITH_PROJECT)")
+				}
+				params.SessionName = langsmith.F(projectLabel)
 			}
 			// Validate both filters before sending: an unknown --status used to
 			// cost a round-trip and return a server 400, and an unknown
@@ -190,7 +198,7 @@ Examples:
 						formatIssueTimestamp(issue.CreatedAt),
 					})
 				}
-				output.OutputTable(columns, rows, fmt.Sprintf("Issues for %s", projectName))
+				output.OutputTable(columns, rows, fmt.Sprintf("Issues for %s", projectLabel))
 			} else {
 				if err := output.OutputJSON(json.RawMessage(page.JSON.RawJSON()), outputFile); err != nil {
 					ExitErrorf("%v", err)
@@ -199,7 +207,7 @@ Examples:
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
+	addProjectFlags(cmd, &project, &projectID)
 	cmd.Flags().StringVar(&status, "status", "", "Filter by status: open, fixing, watching, completed, or ignored")
 	cmd.Flags().StringVar(&priority, "priority", "", "Filter by priority: urgent, high, medium, or low")
 	cmd.Flags().IntVar(&limit, "limit", 50, "Page size (server-side; max 500)")
@@ -256,6 +264,7 @@ type issueEvent struct {
 func newProjectIssuesEventsCmd() *cobra.Command {
 	var (
 		project         string
+		projectID       string
 		lookBackMinutes int
 		limit           int
 		outputFile      string
@@ -280,14 +289,14 @@ Examples:
 			c := MustGetClient()
 			ctx := context.Background()
 
-			projectName := ResolveProject(project)
-			if projectName == "" {
-				ExitError("--project is required (or set LANGSMITH_PROJECT)")
-			}
-
-			sessionID, err := c.ResolveSessionID(ctx, projectName)
+			sessionID, err := resolveSessionID(ctx, c, project, projectID, "project issues events")
 			if err != nil {
-				ExitErrorf("resolving project %q: %v", projectName, err)
+				ExitErrorf("%v", err)
+			}
+			// Name the board by whichever identifier the caller gave.
+			projectLabel := ResolveProject(project)
+			if projectLabel == "" {
+				projectLabel = sessionID
 			}
 
 			path := fmt.Sprintf("/api/v1/platform/sessions/%s/issue-events?look_back_minutes=%d&limit=%d",
@@ -318,7 +327,7 @@ Examples:
 						formatIssueTime(e.CreatedAt),
 					})
 				}
-				output.OutputTable(columns, rows, fmt.Sprintf("Issue events for %s", projectName))
+				output.OutputTable(columns, rows, fmt.Sprintf("Issue events for %s", projectLabel))
 			} else {
 				data := []map[string]any{}
 				for _, e := range events {
@@ -350,7 +359,7 @@ Examples:
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
+	addProjectFlags(cmd, &project, &projectID)
 	cmd.Flags().IntVar(&lookBackMinutes, "look-back-minutes", 10080, "Look-back window in minutes (default 10080 = 7 days)")
 	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of events to return")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")

--- a/internal/cmd/message.go
+++ b/internal/cmd/message.go
@@ -286,9 +286,7 @@ Examples:
 
 	addCommonFilterFlags(cmd, &ff, true)
 	cmd.Flags().StringVar(&ff.Cursor, "cursor", "", "Resume from a pagination cursor returned by a previous call; enables single-page mode with cursors.next in output")
-	cmd.Flags().StringVar(&ff.ProjectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
-	cmd.MarkFlagsMutuallyExclusive("project", "project-id")
 
 	return cmd
 }

--- a/internal/cmd/project_id_flag_test.go
+++ b/internal/cmd/project_id_flag_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// Commands whose --project names a project to write into config rather than one
+// to look up, so there is no session UUID to accept instead. `trace setup` and
+// its per-agent variants record a project name for the tracing SDK, which
+// auto-creates the project by name on first trace.
+var projectIDExemptCommands = map[string]bool{
+	"trace setup":        true,
+	"trace setup claude": true,
+	"trace setup codex":  true,
+}
+
+func walkCommands(cmd *cobra.Command, path []string, fn func(path string, c *cobra.Command)) {
+	if cmd.Runnable() {
+		fn(strings.Join(path, " "), cmd)
+	}
+	for _, sub := range cmd.Commands() {
+		walkCommands(sub, append(path, sub.Name()), fn)
+	}
+}
+
+// Every command that resolves a project must take the UUID as well as the name.
+// The two drifted apart once already: --project-id landed on the trace commands
+// only, which left `run list` and `project issues list` name-only and forced
+// callers to interpolate an arbitrary user-chosen project name into a command
+// line. Fail here rather than let a new command reintroduce the gap.
+func TestEveryProjectCommandAcceptsProjectID(t *testing.T) {
+	t.Parallel()
+
+	root := NewRootCmd("1.0.0", "1.0.0")
+	seen := 0
+	walkCommands(root, []string{}, func(path string, c *cobra.Command) {
+		if c.Flags().Lookup("project") == nil || projectIDExemptCommands[path] {
+			return
+		}
+		seen++
+		if c.Flags().Lookup("project-id") == nil {
+			t.Errorf("%q accepts --project but not --project-id", path)
+		}
+	})
+	if seen == 0 {
+		t.Fatal("walked no commands with a --project flag; the walk is broken")
+	}
+}
+
+// --project and --project-id name the same thing two ways, so passing both is a
+// caller error worth catching locally instead of resolving by precedence.
+func TestProjectAndProjectIDAreMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+
+	root := NewRootCmd("1.0.0", "1.0.0")
+	walkCommands(root, []string{}, func(path string, c *cobra.Command) {
+		if c.Flags().Lookup("project-id") == nil {
+			return
+		}
+		f := c.Flags().Lookup("project")
+		if f == nil {
+			return
+		}
+		if _, ok := f.Annotations["cobra_annotation_mutually_exclusive"]; !ok {
+			t.Errorf("%q does not mark --project and --project-id mutually exclusive", path)
+		}
+	})
+}
+
+// A malformed --project-id should fail before any request goes out.
+func TestValidateProjectIDRejectsNonUUID(t *testing.T) {
+	t.Parallel()
+
+	if _, err := validateProjectID("not-a-uuid"); err == nil {
+		t.Error("expected an error for a non-UUID --project-id")
+	}
+	const id = "519bb9dd-079b-4488-8610-e330951ea3e4"
+	got, err := validateProjectID(id)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != id {
+		t.Errorf("expected %q returned unchanged, got %q", id, got)
+	}
+}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -60,7 +60,7 @@ func newRunListCmd() *cobra.Command {
 
 			c := MustGetClient()
 			ctx := context.Background()
-			sessionID, err := resolveSessionID(ctx, c, ff.Project, "", "run list")
+			sessionID, err := resolveSessionID(ctx, c, ff.Project, ff.ProjectID, "run list")
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -101,6 +101,7 @@ func newRunListCmd() *cobra.Command {
 func newRunGetCmd() *cobra.Command {
 	var (
 		project         string
+		projectID       string
 		since           string
 		lastNMinutes    int
 		includeMetadata bool
@@ -125,7 +126,7 @@ func newRunGetCmd() *cobra.Command {
 
 			c := MustGetClient()
 			ctx := context.Background()
-			sessionID, err := resolveSessionID(ctx, c, project, "", "run get")
+			sessionID, err := resolveSessionID(ctx, c, project, projectID, "run get")
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -161,7 +162,7 @@ func newRunGetCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
+	addProjectFlags(cmd, &project, &projectID)
 	cmd.Flags().StringVar(&since, "since", "", "Only include runs after this timestamp, e.g. 2024-01-15T00:00:00Z (overrides 7-day default)")
 	cmd.Flags().IntVar(&lastNMinutes, "last-n-minutes", 0, "Only include runs from the last N minutes, e.g. 60 (overrides 7-day default)")
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
@@ -201,7 +202,7 @@ func newRunExportCmd() *cobra.Command {
 
 			c := MustGetClient()
 			ctx := context.Background()
-			sessionID, err := resolveSessionID(ctx, c, ff.Project, "", "run export")
+			sessionID, err := resolveSessionID(ctx, c, ff.Project, ff.ProjectID, "run export")
 			if err != nil {
 				ExitErrorf("%v", err)
 			}

--- a/internal/cmd/thread.go
+++ b/internal/cmd/thread.go
@@ -46,6 +46,7 @@ Examples:
 func newThreadListCmd() *cobra.Command {
 	var (
 		project      string
+		projectID    string
 		limit        int
 		rawFilter    string
 		lastNMinutes int
@@ -56,18 +57,17 @@ func newThreadListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List conversation threads in a project (default: 20, newest first)",
 		Run: func(cmd *cobra.Command, args []string) {
-			project = ResolveProject(project)
-			if project == "" {
-				ExitError("--project is required for thread list (or set LANGSMITH_PROJECT)")
-			}
-
 			c := MustGetClient()
 			ctx := context.Background()
 
-			// Resolve project to session ID
-			sessionID, err := c.ResolveSessionID(ctx, project)
+			sessionID, err := resolveSessionID(ctx, c, project, projectID, "thread list")
 			if err != nil {
 				ExitErrorf("%v", err)
+			}
+			// Name the table by whichever identifier the caller gave.
+			projectLabel := ResolveProject(project)
+			if projectLabel == "" {
+				projectLabel = sessionID
 			}
 
 			// Default to last 24h if no time filter
@@ -159,7 +159,7 @@ func newThreadListCmd() *cobra.Command {
 						t.MaxStartTime,
 					})
 				}
-				output.OutputTable(columns, rows, fmt.Sprintf("Threads in %s", project))
+				output.OutputTable(columns, rows, fmt.Sprintf("Threads in %s", projectLabel))
 			} else {
 				var data []map[string]any
 				for _, t := range threads {
@@ -177,7 +177,7 @@ func newThreadListCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
+	addProjectFlags(cmd, &project, &projectID)
 	cmd.Flags().IntVarP(&limit, "limit", "n", 20, "Maximum number of threads to return")
 	cmd.Flags().StringVar(&rawFilter, "filter", "", "Raw LangSmith filter DSL string")
 	cmd.Flags().IntVar(&lastNMinutes, "last-n-minutes", 0, "Only include threads active in last N minutes")
@@ -189,6 +189,7 @@ func newThreadListCmd() *cobra.Command {
 func newThreadGetCmd() *cobra.Command {
 	var (
 		project         string
+		projectID       string
 		includeMetadata bool
 		includeIO       bool
 		includeFeedback bool
@@ -210,16 +211,10 @@ func newThreadGetCmd() *cobra.Command {
 				includeFeedback = true
 			}
 
-			project = ResolveProject(project)
-			if project == "" {
-				ExitError("--project is required for thread get (or set LANGSMITH_PROJECT)")
-			}
-
 			c := MustGetClient()
 			ctx := context.Background()
 
-			// Resolve project to session ID
-			sessionID, err := c.ResolveSessionID(ctx, project)
+			sessionID, err := resolveSessionID(ctx, c, project, projectID, "thread get")
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -263,7 +258,7 @@ func newThreadGetCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
+	addProjectFlags(cmd, &project, &projectID)
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
 	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
@@ -277,6 +272,7 @@ func newThreadGetCmd() *cobra.Command {
 func newThreadMessagesCmd() *cobra.Command {
 	var (
 		project    string
+		projectID  string
 		limit      int
 		cursor     string
 		traceID    string
@@ -303,17 +299,12 @@ Examples:
 		Run: func(cmd *cobra.Command, args []string) {
 			threadID := args[0]
 
-			project = ResolveProject(project)
-			if project == "" {
-				ExitError("--project is required for thread messages (or set LANGSMITH_PROJECT)")
-			}
-
 			c := MustGetClient()
 			ctx := context.Background()
 
 			requireV2Feature(ctx, c, "thread messages")
 
-			sessionID, err := c.ResolveSessionID(ctx, project)
+			sessionID, err := resolveSessionID(ctx, c, project, projectID, "thread messages")
 			if err != nil {
 				ExitErrorf("%v", err)
 			}
@@ -363,7 +354,7 @@ Examples:
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
+	addProjectFlags(cmd, &project, &projectID)
 	cmd.Flags().IntVarP(&limit, "limit", "n", 10, "Maximum number of turns to return (max 100)")
 	cmd.Flags().StringVar(&cursor, "cursor", "", "Pagination cursor from a previous response")
 	cmd.Flags().StringVar(&traceID, "trace-id", "", "Start the page at a specific trace ID")

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -158,7 +158,6 @@ func newTraceListCmd() *cobra.Command {
 	}
 
 	addCommonFilterFlags(cmd, &ff, false)
-	cmd.Flags().StringVar(&ff.ProjectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
 	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
@@ -166,7 +165,6 @@ func newTraceListCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io --include-feedback")
 	cmd.Flags().BoolVar(&showHierarchy, "show-hierarchy", false, "Fetch the full run tree for each trace")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
-	cmd.MarkFlagsMutuallyExclusive("project", "project-id")
 
 	return cmd
 }
@@ -235,8 +233,7 @@ func newTraceGetCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Project name [env: LANGSMITH_PROJECT]")
-	cmd.Flags().StringVar(&projectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
+	addProjectFlags(cmd, &project, &projectID)
 	cmd.Flags().StringVar(&since, "since", "", "Only include runs after this timestamp, e.g. 2024-01-15T00:00:00Z (overrides 7-day default)")
 	cmd.Flags().IntVar(&lastNMinutes, "last-n-minutes", 0, "Only include runs from the last N minutes, e.g. 60 (overrides 7-day default)")
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
@@ -244,7 +241,6 @@ func newTraceGetCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io --include-feedback")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON output to a file")
-	cmd.MarkFlagsMutuallyExclusive("project", "project-id")
 
 	return cmd
 }
@@ -353,14 +349,12 @@ func newTraceExportCmd() *cobra.Command {
 	}
 
 	addCommonFilterFlags(cmd, &ff, false)
-	cmd.Flags().StringVar(&ff.ProjectID, "project-id", "", "Project (session) UUID; skips the name lookup. Takes precedence over --project / $LANGSMITH_PROJECT")
 	cmd.Flags().BoolVar(&includeMetadata, "include-metadata", false, "Add status, duration_ms, first_token_time, token_usage, costs, tags, custom_metadata (incl. revision_id)")
 	cmd.Flags().BoolVar(&includeIO, "include-io", false, "Add inputs, outputs, error, and events fields")
 	cmd.Flags().BoolVar(&includeFeedback, "include-feedback", false, "Add feedback_stats field")
 	cmd.Flags().BoolVar(&full, "full", false, "Shorthand for --include-metadata --include-io --include-feedback")
 	cmd.Flags().StringVar(&filenamePattern, "filename-pattern", "{trace_id}.jsonl",
 		"Filename pattern. Supports {trace_id} and {name} placeholders.")
-	cmd.MarkFlagsMutuallyExclusive("project", "project-id")
 
 	return cmd
 }


### PR DESCRIPTION
## Problem

`--project-id` was added for the trace commands only ([#158](https://github.com/langchain-ai/langsmith-cli/pull/158)). Everything else that selects a project stayed name-only, and `run.go` even called the shared resolver with a hardcoded empty project ID.

## Commands

Twelve commands gain `--project-id`; seventeen accept it after this change.

| Command | Before | After |
| --- | :---: | :---: |
| `run list` | — | **added** |
| `run get` | — | **added** |
| `run export` | — | **added** |
| `thread list` | — | **added** |
| `thread get` | — | **added** |
| `thread messages` | — | **added** |
| `insights list` | — | **added** |
| `insights get` | — | **added** |
| `project issues list` | — | **added** |
| `project issues events` | — | **added** |
| `evaluator upload` | — | **added** |
| `evaluator create-llm` | — | **added** |
| `trace list` | ✅ | ✅ |
| `trace get` | ✅ | ✅ |
| `trace export` | ✅ | ✅ |
| `trace messages` | ✅ | ✅ |
| `trace stats` | ✅ | ✅ |

Deliberately excluded — `trace setup`, `trace setup claude`, `trace setup codex`. Their `--project` records a name for the tracing SDK to auto-create on first trace; there is no existing project being selected, so there is no UUID to accept instead.

## Notes for review

- `--project-id`'s help said "Takes precedence over `--project`", which was never true — cobra rejects both being set. Reworded to name the exclusivity and the `$LANGSMITH_PROJECT` override.
- `thread list` and the two issues commands label their pretty-print tables with the project. The old `thread list` code reassigned `project = ResolveProject(project)`, so the label survived an env-var-only invocation; reading the flag directly would have printed an empty header. All three now derive the label explicitly and fall back to the session UUID.
- Accepting a caller-supplied session UUID does not widen access: the server scopes these reads by `tenant_id` from the authenticated context, not from the supplied ID (e.g. the `issue-events` query in `langchainplus` filters `WHERE tenant_id = $1 AND session_id = $2`). This is the same model the shipped trace `--project-id` already relies on.
- No changelog entry — releases here are tag-driven.

## Test Plan

- [x] .

🤖 Generated with [Claude Code](https://claude.com/claude-code)
