### PR TITLE
feat(cmd): add project issues overview pull

### DIFF
--- a/internal/cmd/issues.go
+++ b/internal/cmd/issues.go
@@ -84,7 +84,8 @@ Examples:
   langsmith project issues list --project my-app
   langsmith project issues get <issue-id>
   langsmith project issues list --project my-app --status open --priority high
-  langsmith project issues events --project my-app`,
+  langsmith project issues events --project my-app
+  langsmith project issues overview pull --project my-app`,
 	}
 
 	cmd.AddCommand(newProjectIssuesListCmd())
@@ -93,6 +94,7 @@ Examples:
 	cmd.AddCommand(newProjectIssuesUpdateCmd())
 	cmd.AddCommand(newProjectIssuesRunsCmd())
 	cmd.AddCommand(newProjectIssuesExamplesCmd())
+	cmd.AddCommand(newProjectIssuesOverviewCmd())
 	return cmd
 }
 

--- a/internal/cmd/overview.go
+++ b/internal/cmd/overview.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/langchain-ai/langsmith-cli/internal/output"
+	langsmith "github.com/langchain-ai/langsmith-go"
+	"github.com/spf13/cobra"
+)
+
+// overviewRepoOwner is the pseudo-owner Engine's Agent Overview repos are
+// created under — they're internal, session-scoped hub repos with no real
+// owner, mirroring the "-" convention already used for hub get/pull.
+const overviewRepoOwner = "-"
+
+// overviewRepoHandle mirrors the Python agent's own handle derivation
+// (smith_issues_agent/graph.py: f"ao-{session_id[:8]}").
+func overviewRepoHandle(sessionID string) string {
+	n := 8
+	if len(sessionID) < n {
+		n = len(sessionID)
+	}
+	return "ao-" + sessionID[:n]
+}
+
+func newProjectIssuesOverviewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "overview",
+		Short: "Read a project's Agent Overview",
+		Long: `Read a project's Agent Overview — Engine's per-project knowledge doc.
+
+The Agent Overview is stored as a Prompt Hub commit under the hood; this
+command hides that so callers get back plain markdown. Saving is done via
+Engine's own save_ao tool, not this CLI.
+
+Examples:
+  langsmith project issues overview pull --project my-app`,
+	}
+
+	cmd.AddCommand(newProjectIssuesOverviewPullCmd())
+	return cmd
+}
+
+func newProjectIssuesOverviewPullCmd() *cobra.Command {
+	var (
+		project    string
+		projectID  string
+		outputFile string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "pull",
+		Short: "Fetch the current Agent Overview as plain markdown",
+		Long: `Fetch the current Agent Overview for a project and write it as plain markdown.
+
+Extracts the template text out of whatever shape the backing Prompt Hub
+commit happens to be in — an agent-authored PromptTemplate, or a
+ChatPromptTemplate/RunnableSequence produced by editing it in the Hub UI —
+so the caller always gets back plain markdown, never a manifest to unwrap.
+
+Fails if the project has no Agent Overview yet (first scan).
+
+Examples:
+  langsmith project issues overview pull --project my-app
+  langsmith project issues overview pull --project my-app -o /tmp/scan/agent_overview.md`,
+		Run: func(cmd *cobra.Command, args []string) {
+			c := MustGetClient()
+			ctx := context.Background()
+
+			sessionID, err := resolveSessionID(ctx, c, project, projectID, "project issues overview pull")
+			if err != nil {
+				ExitErrorf("%v", err)
+			}
+			projectLabel := ResolveProject(project)
+			if projectLabel == "" {
+				projectLabel = sessionID
+			}
+
+			repo := overviewRepoHandle(sessionID)
+			resp, err := c.SDK.Commits.Get(ctx, overviewRepoOwner, repo, "latest", langsmith.CommitGetParams{})
+			if err != nil {
+				ExitErrorf("no Agent Overview exists yet for %q: %v", projectLabel, err)
+			}
+
+			manifest, _ := resp.Manifest.(map[string]interface{})
+			template := extractOverviewTemplate(manifest)
+			if template == "" {
+				ExitErrorf("Agent Overview commit for %q has no readable template", projectLabel)
+			}
+
+			if outputFile == "" {
+				fmt.Print(template)
+				return
+			}
+			if err := os.WriteFile(outputFile, []byte(template), 0o644); err != nil {
+				ExitErrorf("writing %s: %v", outputFile, err)
+			}
+			output.OutputJSON(map[string]any{
+				"status":      "pulled",
+				"project":     projectLabel,
+				"commit_hash": resp.CommitHash,
+				"file":        outputFile,
+				"bytes":       len(template),
+			}, "")
+		},
+	}
+
+	addProjectFlags(cmd, &project, &projectID)
+	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write markdown to this file instead of stdout")
+	return cmd
+}
+
+// extractOverviewTemplate extracts template text from a hub commit manifest.
+// Mirrors smith_issues_agent/_prompt_hub.py::extract_template — keep the two
+// in sync if either changes. Handles three formats the hub UI / SDK produce:
+//   - PromptTemplate: kwargs.template (our canonical AO format)
+//   - ChatPromptTemplate: kwargs.messages[0].kwargs.prompt.kwargs.template
+//   - RunnableSequence (prompt+model): kwargs.first.kwargs.messages[0]...
+func extractOverviewTemplate(manifest map[string]interface{}) string {
+	if manifest == nil {
+		return ""
+	}
+	kwargs, _ := manifest["kwargs"].(map[string]interface{})
+	if kwargs == nil {
+		return ""
+	}
+
+	if template, ok := kwargs["template"].(string); ok {
+		return template
+	}
+
+	if messages, ok := kwargs["messages"].([]interface{}); ok && len(messages) > 0 {
+		if msg, ok := messages[0].(map[string]interface{}); ok {
+			return overviewTemplateFromMessage(msg)
+		}
+	}
+
+	if first, ok := kwargs["first"].(map[string]interface{}); ok {
+		return extractOverviewTemplate(first)
+	}
+
+	return ""
+}
+
+func overviewTemplateFromMessage(msg map[string]interface{}) string {
+	kwargs, _ := msg["kwargs"].(map[string]interface{})
+	if kwargs == nil {
+		return ""
+	}
+	prompt, ok := kwargs["prompt"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	promptKwargs, _ := prompt["kwargs"].(map[string]interface{})
+	if promptKwargs == nil {
+		return ""
+	}
+	template, _ := promptKwargs["template"].(string)
+	return template
+}

--- a/internal/cmd/overview_test.go
+++ b/internal/cmd/overview_test.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ==================== extractOverviewTemplate ====================
+
+func TestExtractOverviewTemplate_PromptTemplate(t *testing.T) {
+	manifest := map[string]interface{}{
+		"kwargs": map[string]interface{}{
+			"template": "# Agent Overview\n\n## Purpose\n...",
+		},
+	}
+	got := extractOverviewTemplate(manifest)
+	want := "# Agent Overview\n\n## Purpose\n..."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractOverviewTemplate_ChatPromptTemplate(t *testing.T) {
+	manifest := map[string]interface{}{
+		"kwargs": map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{
+					"kwargs": map[string]interface{}{
+						"prompt": map[string]interface{}{
+							"kwargs": map[string]interface{}{
+								"template": "# Agent Overview (hub-edited)",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	got := extractOverviewTemplate(manifest)
+	want := "# Agent Overview (hub-edited)"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractOverviewTemplate_RunnableSequence(t *testing.T) {
+	manifest := map[string]interface{}{
+		"kwargs": map[string]interface{}{
+			"first": map[string]interface{}{
+				"kwargs": map[string]interface{}{
+					"template": "# Agent Overview (prompt+model)",
+				},
+			},
+		},
+	}
+	got := extractOverviewTemplate(manifest)
+	want := "# Agent Overview (prompt+model)"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractOverviewTemplate_Unreadable(t *testing.T) {
+	for _, manifest := range []map[string]interface{}{
+		nil,
+		{},
+		{"kwargs": map[string]interface{}{}},
+		{"kwargs": map[string]interface{}{"messages": []interface{}{}}},
+	} {
+		if got := extractOverviewTemplate(manifest); got != "" {
+			t.Errorf("extractOverviewTemplate(%v) = %q, want empty", manifest, got)
+		}
+	}
+}
+
+// ==================== overviewRepoHandle ====================
+
+func TestOverviewRepoHandle(t *testing.T) {
+	cases := []struct {
+		sessionID string
+		want      string
+	}{
+		{"abcdef1234567890", "ao-abcdef12"},
+		{"short", "ao-short"},
+	}
+	for _, tc := range cases {
+		if got := overviewRepoHandle(tc.sessionID); got != tc.want {
+			t.Errorf("overviewRepoHandle(%q) = %q, want %q", tc.sessionID, got, tc.want)
+		}
+	}
+}
+
+// ==================== overview pull ====================
+
+// newOverviewTestServer mocks /sessions (project name -> session ID) and the
+// commits get-latest endpoint for the derived ao-<id> repo handle.
+func newOverviewTestServer(t *testing.T, sessions map[string]string, manifest map[string]interface{}, commitHash string) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/sessions", func(w http.ResponseWriter, r *http.Request) {
+		name := r.URL.Query().Get("name")
+		id, ok := sessions[name]
+		w.Header().Set("Content-Type", "application/json")
+		if !ok {
+			w.WriteHeader(404)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{{"id": id, "name": name}})
+	})
+	mux.HandleFunc("/api/v1/commits/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if manifest == nil {
+			w.WriteHeader(404)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"commit_hash": commitHash,
+			"manifest":    manifest,
+		})
+	})
+	return mux
+}
+
+func TestOverviewPull_WritesFileAndReportsStatus(t *testing.T) {
+	manifest := map[string]interface{}{
+		"kwargs": map[string]interface{}{"template": "# Agent Overview\n\nbody"},
+	}
+	mux := newOverviewTestServer(t, map[string]string{"my-app": "session-abcdef1234"}, manifest, "hash123")
+	srv := newTestServer(t, mux.ServeHTTP)
+	defer setupTestEnv(t, srv.URL)()
+	flagOutputFormat = "json"
+
+	dir := t.TempDir()
+	out := filepath.Join(dir, "overview.md")
+
+	cmd := newProjectIssuesOverviewPullCmd()
+	_ = cmd.Flags().Set("project", "my-app")
+	_ = cmd.Flags().Set("output", out)
+
+	stdout := captureStdout(t, func() { cmd.Run(cmd, nil) })
+	if !strings.Contains(stdout, `"status": "pulled"`) {
+		t.Errorf("missing pulled status in output:\n%s", stdout)
+	}
+
+	content, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("reading written file: %v", err)
+	}
+	if string(content) != "# Agent Overview\n\nbody" {
+		t.Errorf("file content = %q", content)
+	}
+}
+
+func TestOverviewPull_NoOutputFile_PrintsToStdout(t *testing.T) {
+	manifest := map[string]interface{}{
+		"kwargs": map[string]interface{}{"template": "plain markdown"},
+	}
+	mux := newOverviewTestServer(t, map[string]string{"my-app": "session-abcdef1234"}, manifest, "hash123")
+	srv := newTestServer(t, mux.ServeHTTP)
+	defer setupTestEnv(t, srv.URL)()
+
+	cmd := newProjectIssuesOverviewPullCmd()
+	_ = cmd.Flags().Set("project", "my-app")
+
+	stdout := captureStdout(t, func() { cmd.Run(cmd, nil) })
+	if stdout != "plain markdown" {
+		t.Errorf("stdout = %q, want %q", stdout, "plain markdown")
+	}
+}


### PR DESCRIPTION
Part of a larger Engine change: moving Agent Overview reading out of the LangGraph process (and out of the system prompt) into the sandbox, so the agent can pull the current AO to a file and edit it as a file instead of regenerating the whole 10-section document from a system-prompt copy every run.

- `overview pull --project <name>` — resolves the project's `ao-<session_id>` Prompt Hub repo, fetches the latest commit, and writes plain markdown (to `--output` or stdout). Unwraps whichever of the three manifest shapes the commit happens to be in (agent-authored `PromptTemplate`, or a `ChatPromptTemplate`/`RunnableSequence` produced by a Hub UI edit) — mirrors `smith_issues_agent/_prompt_hub.py::extract_template` so callers never have to unwrap a manifest by hand.

No push/save command here: saving stays on the existing `save_ao` LangGraph tool, which is a proper tool call the agent's middleware stack (secret guarding, etc.) already inspects. Adding a CLI-side push would just be a second, unobserved write path with no current caller — cut it.

No new permissions work needed: the read side falls under the existing read-key wildcard in `smith_issues_agent/_sandbox.py`.

## Test Plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] New unit tests: all three manifest shapes for template extraction, repo handle derivation, pull (file + stdout) — `go test ./internal/cmd/...`
- [x] Full `go test ./...` passes