### PR TITLE
fix: report total_cost in `trace stats` again

### DIFF
--- a/internal/cmd/trace_stats.go
+++ b/internal/cmd/trace_stats.go
@@ -128,10 +128,7 @@ func fetchRunStats(ctx context.Context, c *client.Client, sessionID, since, befo
 				langsmith.RunStatsQueryParamsSelectTotalTokens,
 				langsmith.RunStatsQueryParamsSelectPromptTokens,
 				langsmith.RunStatsQueryParamsSelectCompletionTokens,
-				// total_cost is intentionally excluded: the API returns it as a JSON number
-				// (e.g. 8.2e-6) but the SDK models it as string. The type mismatch causes the
-				// union discriminator to pick RunStatsResponseMap instead of RunStatsResponseRunStats,
-				// yielding all-zero results. Excluding it keeps the flat-object response decodable.
+				langsmith.RunStatsQueryParamsSelectTotalCost,
 				langsmith.RunStatsQueryParamsSelectErrorRate,
 				langsmith.RunStatsQueryParamsSelectFeedbackStats,
 			}),

--- a/internal/cmd/trace_stats_test.go
+++ b/internal/cmd/trace_stats_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"slices"
+	"testing"
+)
+
+// The API serves total_cost as a JSON number, often in exponent form for small
+// values. Decoding has to keep the flat RunStats shape rather than falling
+// through to the map (group_by) variant, which would report zeros.
+const smallExponentCost = 8.2e-6
+
+func TestTraceStatsCmd_RequestsAndDecodesTotalCost(t *testing.T) {
+	var gotSelect []string
+
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/runs/stats" {
+			http.NotFound(w, r)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("reading request body: %v", err)
+		}
+		var req struct {
+			Select []string `json:"select"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		gotSelect = req.Select
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"run_count": 3,
+			"latency_p50": 1.5,
+			"latency_p99": 2.5,
+			"total_tokens": 300,
+			"prompt_tokens": 200,
+			"completion_tokens": 100,
+			"total_cost": 8.2e-6,
+			"error_rate": 0.25,
+			"feedback_stats": {"correctness": {"n": 2}}
+		}`))
+	})
+	defer setupTestEnv(t, ts.URL)()
+
+	stats, err := fetchRunStats(t.Context(), MustGetClient(), "00000000-0000-0000-0000-000000000000", "2026-01-01", "2026-01-02", 0, "")
+	if err != nil {
+		t.Fatalf("fetchRunStats: %v", err)
+	}
+
+	if !slices.Contains(gotSelect, "total_cost") {
+		t.Errorf("select did not request total_cost: %v", gotSelect)
+	}
+
+	cost, ok := stats.TotalCost.(float64)
+	if !ok {
+		t.Fatalf("TotalCost is %T (%v), want float64", stats.TotalCost, stats.TotalCost)
+	}
+	if cost != smallExponentCost {
+		t.Errorf("TotalCost = %v, want %v", cost, smallExponentCost)
+	}
+
+	// A fall-through to the map variant zeroes every field, so assert a couple
+	// of neighbours survived alongside the cost.
+	if stats.RunCount != 3 {
+		t.Errorf("RunCount = %d, want 3 (response decoded as the wrong union variant?)", stats.RunCount)
+	}
+	if len(stats.FeedbackStats) != 1 {
+		t.Errorf("FeedbackStats has %d keys, want 1", len(stats.FeedbackStats))
+	}
+}


### PR DESCRIPTION
## Summary

`langsmith trace stats` has been returning `total_cost: null` on every call, even though the command's own help text advertises costs ("Returns run count, latency percentiles, token usage, costs, error rate…"). The field was dropped from the `select` list.

The comment explaining the exclusion says the SDK models `total_cost` as a string, so requesting it made the response union discriminator fall through to `RunStatsResponseMap` and zero every field. **That is no longer true.** In `langsmith-go v0.26.0` — the version this repo pins — `RunStatsResponseRunStats.TotalCost` is a nullable `float64`:

```go
// run.go:1154
type RunStatsResponseRunStats struct {
	...
	TotalCost float64 `json:"total_cost" api:"nullable"`
```

So the fix is to put the select back.

## Why it matters

This is the only aggregate cost surface in the CLI, and it's what agent workflows are pointed at for a project health snapshot. With cost nulled, no caller can see spend or spend trends over a window without dropping down to raw `/api/v1/runs/stats`. Per-run costs were unaffected (`trace list --include-metadata` and `run list --include-metadata` already return `{prompt_cost, completion_cost, total_cost}`) — only the aggregate was blind.

## Verification

Against a real production project, same window before and after:

| | `run_count` | `prompt_tokens` | `total_cost` |
|---|---|---|---|
| before | 6112 | 1030670275 | `null` |
| after | 6112 | 1030670275 | **1190.461168** |
| direct `/api/v1/runs/stats` | 6112 | 1030670275 | 1190.461168 |

Identical counts, and the cost now matches a direct API call exactly. Everything the old comment worried about still decodes: `latency_p50`, `latency_p99`, `error_rate`, and all 29 `feedback_stats` keys — on both the primary window and a `--compare-since` window (which returned its own 24 feedback keys and `total_cost: 911.0071772`).

## Test Plan

- [x] `go test ./...` — full suite green
- [x] `go vet ./internal/cmd/...`, `gofmt` clean
- [x] New `TestTraceStatsCmd_RequestsAndDecodesTotalCost` asserts `total_cost` is in the request `select` **and** that the response decodes with the value intact. It uses `8.2e-6` — the exact exponent-form value the removed comment cited — and also asserts `run_count` and `feedback_stats` survive, so a regression to the map variant fails loudly instead of silently zeroing.
- [x] Confirmed the test fails with the fix reverted:
      `select did not request total_cost: [run_count latency_p50 ... feedback_stats]`
- [x] Manual: primary and `--compare-since` windows against production, cross-checked against direct API calls