### PR TITLE
ci: derive release Go toolchain from go.mod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3


### PR DESCRIPTION
## Problem

The `v0.2.53` release failed in GoReleaser's *loading go mod information* step:

```
⨯ release failed after 0s
  error=
  │ failed to get module path: exit status 1: go: go.mod requires go >= 1.26.7 (running go 1.24.13; GOTOOLCHAIN=local)
```

## Root cause

Two changes combined:

1. **Latent (Aug 24, 5f1a118)** — the `langsmith-go v0.26.0` bump also raised `go.mod` from `go 1.25.0` to `go 1.26.7`. `ci.yml` was updated to match; `release.yml` was left pinned at `go-version: '1.24'`.
2. **Trigger (73f2257)** — Dependabot's major bump of `actions/setup-go` 5.6.0 → 7.0.0 swapped only the action SHA. setup-go v6+ sets `GOTOOLCHAIN=local` by default, which turned the stale `'1.24'` pin from a soft floor into a hard ceiling.

Under setup-go v5 the mismatch was invisible: `GOTOOLCHAIN` defaulted to `auto`, so Go 1.24 read the `go 1.26.7` directive and transparently downloaded the newer toolchain. That's why `v0.2.52` released fine a week after the `go.mod` bump.

CI never flagged it — `ci.yml` pins 1.26.7/1.26, so `release.yml` was the only place holding the old version, and it only runs on `v*` tags.

## Fix

Replace the literal version with `go-version-file: go.mod`, so the release toolchain tracks the module's own requirement and cannot drift out of sync again.

## Follow-up

The `v0.2.53` tag points at `40b596e`, which predates this fix, and GoReleaser validates git state against the tag — re-running the failed job as-is will fail identically. After this merges, the tag needs to be moved to the new `main` (or the release cut as `v0.2.54`).