### PR TITLE
feat: add thread based custom apps

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -230,6 +230,7 @@ type CustomAppRequest struct {
 	Description   *string           `json:"description,omitempty"`
 	Files         map[string]string `json:"files,omitempty"`
 	Entrypoint    *string           `json:"entrypoint,omitempty"`
+	ContextType   *string           `json:"context_type,omitempty"`
 	SourceArchive *string           `json:"source_archive,omitempty"`
 }
 

--- a/internal/cmd/apps.go
+++ b/internal/cmd/apps.go
@@ -25,8 +25,31 @@ const (
 
 // appLink is the contents of <dir>/.langsmith/app.json.
 type appLink struct {
-	AppID string `json:"app_id"`
-	Name  string `json:"name"`
+	AppID       string `json:"app_id"`
+	Name        string `json:"name"`
+	ContextType string `json:"context_type,omitempty"`
+}
+
+const (
+	appContextNone   = "none"
+	appContextThread = "thread"
+)
+
+func validateAppContextType(s string) error {
+	switch s {
+	case "", appContextNone, appContextThread:
+		return nil
+	default:
+		return fmt.Errorf("invalid context type %q: must be %q or %q",
+			s, appContextNone, appContextThread)
+	}
+}
+
+func normalizeAppContextType(s string) string {
+	if s == appContextNone {
+		return ""
+	}
+	return s
 }
 
 // Custom app visibility tiers.
@@ -43,6 +66,7 @@ type customApp struct {
 	Scope          string            `json:"scope,omitempty"`
 	Name           string            `json:"name"`
 	Description    *string           `json:"description,omitempty"`
+	ContextType    string            `json:"context_type,omitempty"`
 	Files          map[string]string `json:"files,omitempty"`
 	Entrypoint     string            `json:"entrypoint"`
 	IsEnabled      bool              `json:"is_enabled"`
@@ -87,12 +111,14 @@ func newAppsCmd() *cobra.Command {
 LangSmith API and run inside LangSmith.
 
 Pick a starter with --template (blank, annotation-queue,
-annotation-queue-grid).
+annotation-queue-grid, thread, ...).
 
 Examples:
   langsmith apps init --name my-app
   langsmith apps init --name my-queue-app --template annotation-queue
+  langsmith apps init --name my-thread-app --template thread
   langsmith apps dev
+  langsmith apps dev --thread-id THREAD_ID --project-id PROJECT_ID
   langsmith apps push
   langsmith apps pull my-app
   langsmith apps list

--- a/internal/cmd/apps_context_type_test.go
+++ b/internal/cmd/apps_context_type_test.go
@@ -1,0 +1,362 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- init: --context and the thread template ---
+
+func TestAppsInit_ContextTypeWrittenToLink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "my-app")
+
+	if _, err := scaffoldCustomAppStarter(target, "my-app", "", appContextThread, appTypes["blank"], false); err != nil {
+		t.Fatalf("scaffold: %v", err)
+	}
+
+	link, err := readAppLink(target)
+	if err != nil {
+		t.Fatalf("readAppLink: %v", err)
+	}
+	if link == nil || link.ContextType != appContextThread {
+		t.Errorf("expected context_type %q in link, got %+v", appContextThread, link)
+	}
+}
+
+func TestAppsInit_NoContextTypeLeavesLinkClean(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "my-app")
+
+	if _, err := scaffoldCustomAppStarter(target, "my-app", "", "", appTypes["blank"], false); err != nil {
+		t.Fatalf("scaffold: %v", err)
+	}
+	// "none" normalizes to empty and must not be persisted.
+	if _, err := scaffoldCustomAppStarter(filepath.Join(dir, "n"), "n", "", appContextNone, appTypes["blank"], false); err != nil {
+		t.Fatalf("scaffold none: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(target, appsLinkDir, appsLinkFile))
+	if err != nil {
+		t.Fatalf("read link: %v", err)
+	}
+	if strings.Contains(string(raw), "context_type") {
+		t.Errorf("expected no context_type key for a contextless app, got:\n%s", raw)
+	}
+}
+
+func TestAppsInit_ThreadTemplateScaffoldsFilesAndDefaultsContext(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "my-app")
+
+	// The thread template implies context thread even without --context.
+	resolved, err := resolveInitContextType("", appTypes["thread"])
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if resolved != appContextThread {
+		t.Fatalf("expected thread template to default context to %q, got %q", appContextThread, resolved)
+	}
+
+	written, err := scaffoldCustomAppStarter(target, "my-app", "", resolved, appTypes["thread"], false)
+	if err != nil {
+		t.Fatalf("scaffold: %v", err)
+	}
+	got := map[string]bool{}
+	for _, w := range written {
+		got[w] = true
+	}
+	for _, want := range []string{
+		"package.json",
+		"README.md",
+		"AGENTS.md",
+		"src/entry.tsx",
+		"src/App.tsx",
+		"src/global.d.ts",
+	} {
+		if !got[want] {
+			t.Errorf("expected thread template to scaffold %q; written: %v", want, written)
+		}
+	}
+
+	link, err := readAppLink(target)
+	if err != nil {
+		t.Fatalf("readAppLink: %v", err)
+	}
+	if link == nil || link.ContextType != appContextThread {
+		t.Errorf("expected thread link context_type, got %+v", link)
+	}
+
+	agentsMD, err := os.ReadFile(filepath.Join(target, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if !strings.Contains(string(agentsMD), "thread context") {
+		t.Errorf("expected the thread AGENTS.md fragment to be included:\n%s", agentsMD)
+	}
+}
+
+func TestResolveInitContextType_ConflictErrors(t *testing.T) {
+	// "none" normalizes to "" (the default / omitted), so it does not fight the
+	// template — the template's context wins.
+	if got, err := resolveInitContextType(appContextNone, appTypes["thread"]); err != nil || got != appContextThread {
+		t.Errorf("expected --context none to defer to the thread template, got %q err=%v", got, err)
+	}
+	// Matching is fine.
+	if _, err := resolveInitContextType(appContextThread, appTypes["thread"]); err != nil {
+		t.Errorf("expected thread+thread to be allowed, got %v", err)
+	}
+	// A contextless template accepts any explicit context.
+	if got, err := resolveInitContextType(appContextThread, appTypes["blank"]); err != nil || got != appContextThread {
+		t.Errorf("expected blank template to accept explicit thread context, got %q err=%v", got, err)
+	}
+}
+
+func TestValidateAppContextType(t *testing.T) {
+	for _, ok := range []string{"", appContextNone, appContextThread} {
+		if err := validateAppContextType(ok); err != nil {
+			t.Errorf("expected %q valid, got %v", ok, err)
+		}
+	}
+	// annotation_queue has no CLI workflow and must now be rejected.
+	if err := validateAppContextType("annotation_queue"); err == nil {
+		t.Error("expected annotation_queue to be rejected")
+	}
+	if err := validateAppContextType("bogus"); err == nil {
+		t.Error("expected an error for an unknown context type")
+	}
+}
+
+// --- push: sends on create, omits on update, guards immutability ---
+
+func TestAppsPush_SendsContextTypeOnCreate(t *testing.T) {
+	var postBody map[string]any
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/v1/platform/custom-apps" {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &postBody)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(customApp{
+				ID: "app_new", Name: "my-app", Entrypoint: "dist/bundle.js", ContextType: appContextThread,
+			})
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	seedAppDir(t, dir)
+	if err := writeAppLink(dir, appLink{Name: "my-app", ContextType: appContextThread}); err != nil {
+		t.Fatalf("seed link: %v", err)
+	}
+	t.Chdir(dir)
+
+	out := captureStdout(t, func() {
+		cmd := newAppsCmd()
+		cmd.SetArgs([]string{"push"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if postBody["context_type"] != appContextThread {
+		t.Errorf("expected context_type %q in create payload, got %v", appContextThread, postBody["context_type"])
+	}
+	if !strings.Contains(out, `"context_type": "thread"`) {
+		t.Errorf("expected context_type in output:\n%s", out)
+	}
+
+	// Server value round-trips back into the link.
+	link, _ := readAppLink(dir)
+	if link == nil || link.ContextType != appContextThread {
+		t.Errorf("expected link to record context_type thread, got %+v", link)
+	}
+}
+
+func TestAppsPush_OmitsContextTypeOnCreateWhenNone(t *testing.T) {
+	var postBody map[string]any
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/v1/platform/custom-apps" {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &postBody)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(customApp{ID: "app_new", Name: "my-app", Entrypoint: "dist/bundle.js"})
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	seedAppDir(t, dir)
+	t.Chdir(dir)
+
+	captureStdout(t, func() {
+		cmd := newAppsCmd()
+		cmd.SetArgs([]string{"push", "--name", "my-app"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if _, ok := postBody["context_type"]; ok {
+		t.Errorf("expected no context_type in create payload for a contextless app, got %v", postBody["context_type"])
+	}
+}
+
+func TestAppsPush_NeverSendsContextTypeOnUpdate(t *testing.T) {
+	var patchBody map[string]any
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PATCH" {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &patchBody)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(customApp{
+				ID: "app_existing", Name: "my-app", Entrypoint: "dist/bundle.js", ContextType: appContextThread,
+			})
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	seedAppDir(t, dir)
+	// Configured context matches the server's — no mismatch, and update must
+	// still not send the field.
+	if err := writeAppLink(dir, appLink{AppID: "app_existing", Name: "my-app", ContextType: appContextThread}); err != nil {
+		t.Fatalf("seed link: %v", err)
+	}
+	t.Chdir(dir)
+
+	captureStdout(t, func() {
+		cmd := newAppsCmd()
+		cmd.SetArgs([]string{"push"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if _, ok := patchBody["context_type"]; ok {
+		t.Errorf("expected update payload to never carry context_type, got %v", patchBody["context_type"])
+	}
+}
+
+func TestAppsPush_FailsOnContextTypeMismatch(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PATCH" {
+			w.Header().Set("Content-Type", "application/json")
+			// Server still reports the original context (none) even though the
+			// config now asks for thread — the update silently ignored it.
+			_ = json.NewEncoder(w).Encode(customApp{
+				ID: "app_existing", Name: "my-app", Entrypoint: "dist/bundle.js", ContextType: appContextNone,
+			})
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	})
+	defer setupTestEnv(t, srv.URL)()
+
+	dir := t.TempDir()
+	seedAppDir(t, dir)
+	if err := writeAppLink(dir, appLink{AppID: "app_existing", Name: "my-app", ContextType: appContextThread}); err != nil {
+		t.Fatalf("seed link: %v", err)
+	}
+	t.Chdir(dir)
+
+	var execErr error
+	captureStdout(t, func() {
+		cmd := newAppsCmd()
+		cmd.SetArgs([]string{"push"})
+		execErr = cmd.Execute()
+	})
+	if execErr == nil {
+		t.Fatal("expected push to fail when configured context type differs from the created app's")
+	}
+	msg := strings.ToLower(execErr.Error())
+	if !strings.Contains(msg, "context type is fixed") || !strings.Contains(msg, "delete and recreate") {
+		t.Errorf("expected a delete-and-recreate immutability error, got: %v", execErr)
+	}
+}
+
+func TestCheckContextTypeImmutable_SkipsWhenServerSilent(t *testing.T) {
+	// An older server that doesn't echo context_type: treat as unknown, don't
+	// produce a spurious mismatch.
+	if err := checkContextTypeImmutable(customApp{Name: "x"}, appContextThread); err != nil {
+		t.Errorf("expected no error when the server reports no context type, got %v", err)
+	}
+	// "none" configured vs "none" server (empty): no error.
+	if err := checkContextTypeImmutable(customApp{Name: "x", ContextType: appContextNone}, ""); err != nil {
+		t.Errorf("expected none==none to be fine, got %v", err)
+	}
+}
+
+// --- dev: --thread-id/--project-id supply render data ---
+
+func TestAppsDev_ThreadContextFlagsExist(t *testing.T) {
+	dev, _, err := newAppsCmd().Find([]string{"dev"})
+	if err != nil {
+		t.Fatalf("find dev: %v", err)
+	}
+	for _, name := range []string{"thread-id", "project-id"} {
+		if dev.Flags().Lookup(name) == nil {
+			t.Errorf("expected apps dev to have --%s", name)
+		}
+	}
+	// It must NOT gain a --project flag: --project-id here is thread context,
+	// not project selection, and pairing it would drag in resolveSessionID.
+	if dev.Flags().Lookup("project") != nil {
+		t.Error("apps dev should not have a --project flag; --project-id is thread context, not selection")
+	}
+}
+
+func TestRenderDevHostHTML_EmbedsThreadRenderData(t *testing.T) {
+	page := renderDevHostHTML(
+		map[string]string{"dist/bundle.js": "module.exports={render:function(){}}"},
+		"dist/bundle.js", "tok", "ws", "https://smith.langchain.com",
+		devContext{threadID: "thr_123", projectID: "prj_456"}.renderData(),
+	)
+	if !strings.Contains(page, `"threadId":"thr_123"`) {
+		t.Errorf("expected threadId embedded in render data:\n%s", page)
+	}
+	if !strings.Contains(page, `"projectId":"prj_456"`) {
+		t.Errorf("expected projectId embedded in render data:\n%s", page)
+	}
+	if strings.Contains(page, "var data = {};") {
+		t.Error("expected the hard-coded empty render data to be replaced")
+	}
+}
+
+func TestRenderDevHostHTML_EmptyContextStaysEmpty(t *testing.T) {
+	page := renderDevHostHTML(
+		map[string]string{"dist/bundle.js": "x"},
+		"dist/bundle.js", "tok", "ws", "https://smith.langchain.com",
+		devContext{}.renderData(),
+	)
+	if !strings.Contains(page, "var data = {};") {
+		t.Errorf("expected empty ({}) render data for a contextless app:\n%s", page)
+	}
+}
+
+func TestRenderDevHostHTML_EscapesScriptCloseInIDs(t *testing.T) {
+	// A malicious/odd ID must not break out of the <script> block. Go's
+	// json.Marshal is HTML-safe (escapes < and > as < / >), and
+	// escapeForScript is a further backstop against a literal </script>.
+	page := renderDevHostHTML(
+		map[string]string{"dist/bundle.js": "x"},
+		"dist/bundle.js", "tok", "ws", "https://smith.langchain.com",
+		devContext{threadID: "</script><script>alert(1)</script>"}.renderData(),
+	)
+	if strings.Contains(page, "</script><script>alert(1)") {
+		t.Errorf("thread id broke out of the script context (not escaped):\n%s", page)
+	}
+	if !strings.Contains(page, `</script>`) {
+		t.Errorf("expected the injected id to be \\u003c-escaped in the embedded JSON:\n%s", page)
+	}
+}

--- a/internal/cmd/apps_dev.go
+++ b/internal/cmd/apps_dev.go
@@ -44,6 +44,8 @@ var appsDevLogMode = logErrors
 func newAppsDevCmd() *cobra.Command {
 	var (
 		entrypoint string
+		threadID   string
+		projectID  string
 		noOpen     bool
 		quiet      bool
 		verbose    bool
@@ -63,7 +65,12 @@ Rebuilds automatically on save when package.json has a "watch" script.
 The app's failed API calls and errors stream to this terminal so problems
 show up without opening browser devtools. Use --verbose to also see every
 successful call and all console output, or --quiet to silence app output
-entirely (build output stays).`,
+entirely (build output stays).
+
+A "thread" context app is embedded in a project's thread view on LangSmith and
+receives { threadId, projectId } as render()'s data. Pass --thread-id and
+--project-id to supply that context locally; without them the app renders with
+empty context.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if quiet && verbose {
 				return fmt.Errorf("--quiet and --verbose cannot be used together")
@@ -90,19 +97,39 @@ entirely (build output stays).`,
 			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 			defer cancel()
 
-			return runAppsDev(ctx, c, dir, entrypoint, noOpen)
+			return runAppsDev(ctx, c, dir, entrypoint, devContext{threadID: threadID, projectID: projectID}, noOpen)
 		},
 	}
 
 	cmd.Flags().StringVar(&entrypoint, "entrypoint", "dist/bundle.js", "Path (relative to the current directory) of the file to render")
+	cmd.Flags().StringVar(&threadID, "thread-id", "", "Thread ID handed to a \"thread\" context app as render()'s data.threadId")
+	cmd.Flags().StringVar(&projectID, "project-id", "", "Tracing project (session) ID handed to a \"thread\" context app as render()'s data.projectId")
 	cmd.Flags().BoolVar(&noOpen, "no-open", false, "Print the local URL instead of opening a browser")
 	cmd.Flags().BoolVar(&quiet, "quiet", false, "Silence the app's console output and API call logging (build output still shows)")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Also log successful API calls and all console output, not just errors")
 	return cmd
 }
 
-func runAppsDev(ctx context.Context, c *client.Client, dir, entrypoint string, noOpen bool) error {
-	srv, ln, previewURL, err := prepareAppsDevServer(c, dir, entrypoint)
+type devContext struct {
+	threadID  string
+	projectID string
+}
+
+func (d devContext) renderData() map[string]any {
+	data := map[string]any{}
+	if d.threadID != "" {
+		data["threadId"] = d.threadID
+	}
+	if d.projectID != "" {
+		data["projectId"] = d.projectID
+	}
+	return data
+}
+
+func runAppsDev(ctx context.Context, c *client.Client, dir, entrypoint string, devCtx devContext, noOpen bool) error {
+	warnDevContextMismatch(dir, devCtx)
+
+	srv, ln, previewURL, err := prepareAppsDevServer(c, dir, entrypoint, devCtx)
 	if err != nil {
 		return err
 	}
@@ -147,6 +174,23 @@ func runAppsDev(ctx context.Context, c *client.Client, dir, entrypoint string, n
 		return fmt.Errorf("shutting down local server: %w", err)
 	}
 	return nil
+}
+
+func warnDevContextMismatch(dir string, devCtx devContext) {
+	link, err := readAppLink(dir)
+	if err != nil || link == nil {
+		return
+	}
+	configured := normalizeAppContextType(link.ContextType)
+	hasIDs := devCtx.threadID != "" || devCtx.projectID != ""
+
+	if configured == appContextThread && !hasIDs {
+		fmt.Fprintln(os.Stderr, `note: this app's context type is "thread" but no --thread-id/--project-id given — it will render with empty context`)
+		return
+	}
+	if configured != appContextThread && hasIDs {
+		fmt.Fprintf(os.Stderr, "note: --thread-id/--project-id given, but this app's context type is %q, not \"thread\" — the app may ignore them\n", contextTypeForOutput(configured))
+	}
 }
 
 // startWatchProcess runs package.json's "watch" script tied to ctx. Never
@@ -240,7 +284,7 @@ func resolveDevWorkspaceID(c *client.Client) string {
 // prepareAppsDevServer builds (but does not start) an HTTP server on
 // 127.0.0.1 serving the sandboxed preview ("/"), a rebuild-poll endpoint
 // ("/__ls_dev/mtime"), and the API proxy ("/__ls_dev/call").
-func prepareAppsDevServer(c *client.Client, dir, entrypoint string) (srv *http.Server, ln net.Listener, previewURL string, err error) {
+func prepareAppsDevServer(c *client.Client, dir, entrypoint string, devCtx devContext) (srv *http.Server, ln net.Listener, previewURL string, err error) {
 	token, err := newDevToken()
 	if err != nil {
 		return nil, nil, "", err
@@ -272,7 +316,7 @@ func prepareAppsDevServer(c *client.Client, dir, entrypoint string) (srv *http.S
 			_, _ = w.Write([]byte(devWaitingHTML(fmt.Sprintf("entrypoint %q does not exist yet in %s — waiting for the initial build to finish", entrypoint, dir))))
 			return
 		}
-		_, _ = w.Write([]byte(renderDevHostHTML(files, entrypoint, token, workspaceID, webOrigin)))
+		_, _ = w.Write([]byte(renderDevHostHTML(files, entrypoint, token, workspaceID, webOrigin, devCtx.renderData())))
 	})
 
 	mux.HandleFunc("/__ls_dev/mtime", func(w http.ResponseWriter, r *http.Request) {
@@ -556,11 +600,15 @@ setInterval(function() {
 
 // renderDevHostHTML builds the top-level host page: the sandboxed iframe
 // plus the postMessage bridge and a Light/Dark mode toolbar.
-func renderDevHostHTML(files map[string]string, entrypoint, token, workspaceID, webOrigin string) string {
+func renderDevHostHTML(files map[string]string, entrypoint, token, workspaceID, webOrigin string, renderData map[string]any) string {
 	filesJSON, _ := json.Marshal(files)
 	entrypointJSON, _ := json.Marshal(entrypoint)
 	workspaceIDJSON, _ := json.Marshal(workspaceID)
 	webOriginJSON, _ := json.Marshal(webOrigin)
+	if renderData == nil {
+		renderData = map[string]any{}
+	}
+	dataJSON, _ := json.Marshal(renderData)
 
 	inner := strings.NewReplacer(
 		"__FILES_JSON__", escapeForScript(filesJSON),
@@ -572,6 +620,7 @@ func renderDevHostHTML(files map[string]string, entrypoint, token, workspaceID, 
 		"__LS_DEV_TOKEN__", token,
 		"__LS_WORKSPACE_ID_JSON__", escapeForScript(workspaceIDJSON),
 		"__LS_WEB_ORIGIN_JSON__", escapeForScript(webOriginJSON),
+		"__LS_DATA_JSON__", escapeForScript(dataJSON),
 	).Replace(devHostHTMLTemplate)
 }
 
@@ -670,8 +719,7 @@ const devHostHTMLTemplate = `<!doctype html>
 <script>
 (function() {
   var iframe = document.getElementById('ls-app');
-  // Apps get no host context: the sandbox always receives {} as render data.
-  var data = {};
+  var data = __LS_DATA_JSON__;
 
   function post(msg) {
     iframe.contentWindow.postMessage(msg, '*');

--- a/internal/cmd/apps_dev_test.go
+++ b/internal/cmd/apps_dev_test.go
@@ -53,7 +53,7 @@ func TestPrepareAppsDevServer_ServesRealSandboxedIframe(t *testing.T) {
 		t.Fatalf("seed .env: %v", err)
 	}
 
-	srv, ln, previewURL, err := prepareAppsDevServer(nil, dir, "dist/bundle.js")
+	srv, ln, previewURL, err := prepareAppsDevServer(nil, dir, "dist/bundle.js", devContext{})
 	if err != nil {
 		t.Fatalf("prepareAppsDevServer: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestPrepareAppsDevServer_DoesNotClearRootBeforeSuccessfulRender(t *testing.
 	dir := t.TempDir()
 	seedDevApp(t, dir, "module.exports = { render: function(d, r) { r.textContent = 'ok'; } }")
 
-	srv, ln, previewURL, err := prepareAppsDevServer(nil, dir, "dist/bundle.js")
+	srv, ln, previewURL, err := prepareAppsDevServer(nil, dir, "dist/bundle.js", devContext{})
 	if err != nil {
 		t.Fatalf("prepareAppsDevServer: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestPrepareAppsDevServer_ServesModeToggle(t *testing.T) {
 	dir := t.TempDir()
 	seedDevApp(t, dir, "module.exports = { render: function(){} }")
 
-	srv, ln, previewURL, err := prepareAppsDevServer(nil, dir, "dist/bundle.js")
+	srv, ln, previewURL, err := prepareAppsDevServer(nil, dir, "dist/bundle.js", devContext{})
 	if err != nil {
 		t.Fatalf("prepareAppsDevServer: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestSandboxImplementsThemeMetadataContract(t *testing.T) {
 
 func TestPrepareAppsDevServer_ServesWaitingPageWhenEntrypointMissing(t *testing.T) {
 	dir := t.TempDir()
-	srv, ln, previewURL, err := prepareAppsDevServer(nil, dir, "dist/bundle.js")
+	srv, ln, previewURL, err := prepareAppsDevServer(nil, dir, "dist/bundle.js", devContext{})
 	if err != nil {
 		t.Fatalf("prepareAppsDevServer: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestPrepareAppsDevServer_ServesWaitingPageWhenEntrypointMissing(t *testing.
 
 func TestPrepareAppsDevServer_MtimeReflectsFileState(t *testing.T) {
 	dir := t.TempDir()
-	srv, ln, previewURL, err := prepareAppsDevServer(nil, dir, "dist/bundle.js")
+	srv, ln, previewURL, err := prepareAppsDevServer(nil, dir, "dist/bundle.js", devContext{})
 	if err != nil {
 		t.Fatalf("prepareAppsDevServer: %v", err)
 	}
@@ -593,7 +593,7 @@ func TestRunAppsDev_ExitsOnContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- runAppsDev(ctx, nil, dir, "dist/bundle.js", true)
+		errCh <- runAppsDev(ctx, nil, dir, "dist/bundle.js", devContext{}, true)
 	}()
 
 	time.Sleep(100 * time.Millisecond)

--- a/internal/cmd/apps_init.go
+++ b/internal/cmd/apps_init.go
@@ -32,6 +32,9 @@ var codingAgentDashboardStarterFS embed.FS
 //go:embed all:templates/experiment-comparison
 var experimentComparisonStarterFS embed.FS
 
+//go:embed all:templates/thread
+var threadStarterFS embed.FS
+
 //go:embed all:templates/agents-md
 var agentsMDFS embed.FS
 
@@ -58,6 +61,7 @@ type appType struct {
 	templateFS   embed.FS
 	templateRoot string
 	agentsMD     string // template-specific AGENTS.md fragment; "" = none (generic base only)
+	contextType  string
 }
 
 var appTypes = map[string]appType{
@@ -86,6 +90,12 @@ var appTypes = map[string]appType{
 		templateRoot: "templates/experiment-comparison",
 		agentsMD:     "experiment_comparison",
 	},
+	"thread": {
+		templateFS:   threadStarterFS,
+		templateRoot: "templates/thread",
+		agentsMD:     "thread",
+		contextType:  appContextThread,
+	},
 }
 
 // appTypeNames returns the valid --template values, sorted.
@@ -101,6 +111,38 @@ func appTypeNames() []string {
 	return names
 }
 
+func resolveInitContextType(flag string, at appType) (string, error) {
+	flag = normalizeAppContextType(flag)
+	tmpl := normalizeAppContextType(at.contextType)
+	if tmpl == "" {
+		return flag, nil
+	}
+	if flag == "" {
+		return tmpl, nil
+	}
+	if flag != tmpl {
+		return "", fmt.Errorf("--context %q conflicts with the %q template, which requires context type %q",
+			flag, templateNameFor(at), tmpl)
+	}
+	return tmpl, nil
+}
+
+func templateNameFor(at appType) string {
+	for name, t := range appTypes {
+		if t.templateRoot == at.templateRoot {
+			return name
+		}
+	}
+	return at.templateRoot
+}
+
+func contextTypeForOutput(ctx string) string {
+	if ctx == "" {
+		return appContextNone
+	}
+	return ctx
+}
+
 type customAppStarterVars struct {
 	Name        string
 	Description string
@@ -113,11 +155,12 @@ func newAppsInitCmd() *cobra.Command {
 		name         string
 		description  string
 		templateFlag string
+		contextType  string
 		force        bool
 	)
 
 	cmd := &cobra.Command{
-		Use:   "init --name NAME [--template annotation-queue|annotation-queue-grid|coding-agent-dashboard|experiment-comparison]",
+		Use:   "init --name NAME [--template annotation-queue|annotation-queue-grid|coding-agent-dashboard|experiment-comparison|thread] [--context none|thread]",
 		Short: "Scaffold a starter custom app in a new directory named after the app",
 		Long: `Scaffold a starter custom app into a new directory named after --name.
 
@@ -127,6 +170,11 @@ func newAppsInitCmd() *cobra.Command {
   annotation-queue-grid   Same review workflow, as an editable spreadsheet.
   coding-agent-dashboard  Charts over coding-agent runs: usage, cost, errors, activity over time.
   experiment-comparison   Compare evaluation experiments against a baseline.
+  thread                  Embedded in a project's thread view; gets { threadId, projectId }.
+
+--context declares what resource the app binds to at render time (default
+none). It is fixed when the app is first pushed and cannot be changed later.
+The "thread" template implies --context thread.
 
 Installs dependencies as the last step, so you can cd in and run
 "langsmith apps dev" next. Run "langsmith apps push" to upload.`,
@@ -141,6 +189,13 @@ Installs dependencies as the last step, so you can cd in and run
 			if !ok {
 				return fmt.Errorf("--template must be one of: %s", strings.Join(appTypeNames(), ", "))
 			}
+			if err := validateAppContextType(contextType); err != nil {
+				return err
+			}
+			resolvedContext, err := resolveInitContextType(contextType, at)
+			if err != nil {
+				return err
+			}
 			slug := slugifyAppName(name)
 			if slug == "" {
 				return fmt.Errorf("--name %q has no characters usable in a directory name", name)
@@ -153,7 +208,7 @@ Installs dependencies as the last step, so you can cd in and run
 			if err := os.MkdirAll(dir, 0o755); err != nil {
 				return fmt.Errorf("creating %s: %w", slug, err)
 			}
-			written, err := scaffoldCustomAppStarter(dir, name, description, at, force)
+			written, err := scaffoldCustomAppStarter(dir, name, description, resolvedContext, at, force)
 			if err != nil {
 				return err
 			}
@@ -165,11 +220,12 @@ Installs dependencies as the last step, so you can cd in and run
 			}
 			fmt.Fprintf(os.Stderr, "Next: cd %s && langsmith apps dev.\n", slug)
 			return output.OutputJSON(map[string]any{
-				"status":   "scaffolded",
-				"dir":      dir,
-				"name":     name,
-				"template": templateName,
-				"files":    written,
+				"status":       "scaffolded",
+				"dir":          dir,
+				"name":         name,
+				"template":     templateName,
+				"context_type": contextTypeForOutput(resolvedContext),
+				"files":        written,
 			}, "")
 		},
 	}
@@ -177,6 +233,7 @@ Installs dependencies as the last step, so you can cd in and run
 	cmd.Flags().StringVar(&name, "name", "", "Name for the app, written into package.json/README (required)")
 	cmd.Flags().StringVar(&description, "description", "", "One-line description written into README.md")
 	cmd.Flags().StringVar(&templateFlag, "template", "", "Starter template. Omittable for a blank starter.")
+	cmd.Flags().StringVar(&contextType, "context", "", "Resource the app binds to at render time: none (default) or thread. Fixed at first push.")
 	cmd.Flags().BoolVar(&force, "force", false, "Write even if the target directory already exists and is non-empty")
 	_ = cmd.MarkFlagRequired("name")
 	return cmd
@@ -219,7 +276,7 @@ func installAppDeps(dir string) error {
 	return nil
 }
 
-func scaffoldCustomAppStarter(dir, name, description string, at appType, force bool) ([]string, error) {
+func scaffoldCustomAppStarter(dir, name, description, contextType string, at appType, force bool) ([]string, error) {
 	if name == "" {
 		return nil, fmt.Errorf("--name is required")
 	}
@@ -330,7 +387,7 @@ func scaffoldCustomAppStarter(dir, name, description string, at appType, force b
 	written = append(written, "AGENTS.md")
 
 	// Record the name now so a later push reuses it, not the directory basename.
-	if err := writeAppLink(dir, appLink{Name: name}); err != nil {
+	if err := writeAppLink(dir, appLink{Name: name, ContextType: normalizeAppContextType(contextType)}); err != nil {
 		return nil, fmt.Errorf("writing .langsmith/app.json: %w", err)
 	}
 	written = append(written, filepath.ToSlash(filepath.Join(appsLinkDir, appsLinkFile)))

--- a/internal/cmd/apps_init_test.go
+++ b/internal/cmd/apps_init_test.go
@@ -13,7 +13,7 @@ func TestAppsInit_WritesPartialAppLinkForImmediateAppsDevUse(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "my-app")
 
-	if _, err := scaffoldCustomAppStarter(target, "my-app", "", appTypes["annotation-queue"], false); err != nil {
+	if _, err := scaffoldCustomAppStarter(target, "my-app", "", "", appTypes["annotation-queue"], false); err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
 
@@ -36,7 +36,7 @@ func TestAppsInit_BlankAlsoWritesPartialAppLink(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "my-app")
 
-	if _, err := scaffoldCustomAppStarter(target, "my-app", "", appTypes["blank"], false); err != nil {
+	if _, err := scaffoldCustomAppStarter(target, "my-app", "", "", appTypes["blank"], false); err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
 
@@ -54,7 +54,7 @@ func TestAppsInit_ScaffoldsAnnotationQueueGridFiles(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "my-app")
 
-	written, err := scaffoldCustomAppStarter(target, "my-app", "", appTypes["annotation-queue-grid"], false)
+	written, err := scaffoldCustomAppStarter(target, "my-app", "", "", appTypes["annotation-queue-grid"], false)
 	if err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestAppsInit_ScaffoldsCodingAgentDashboardFiles(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "my-app")
 
-	written, err := scaffoldCustomAppStarter(target, "my-app", "", appTypes["coding-agent-dashboard"], false)
+	written, err := scaffoldCustomAppStarter(target, "my-app", "", "", appTypes["coding-agent-dashboard"], false)
 	if err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestAppsInit_ScaffoldsExperimentComparisonFiles(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "my-app")
 
-	written, err := scaffoldCustomAppStarter(target, "my-app", "", appTypes["experiment-comparison"], false)
+	written, err := scaffoldCustomAppStarter(target, "my-app", "", "", appTypes["experiment-comparison"], false)
 	if err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestAppsInit_GridGetsDistinctAgentsMD(t *testing.T) {
 	dir := t.TempDir()
 
 	gridTarget := filepath.Join(dir, "grid-app")
-	if _, err := scaffoldCustomAppStarter(gridTarget, "grid-app", "", appTypes["annotation-queue-grid"], false); err != nil {
+	if _, err := scaffoldCustomAppStarter(gridTarget, "grid-app", "", "", appTypes["annotation-queue-grid"], false); err != nil {
 		t.Fatalf("scaffold grid: %v", err)
 	}
 	gridAgents, err := os.ReadFile(filepath.Join(gridTarget, "AGENTS.md"))
@@ -215,7 +215,7 @@ func TestAppsInit_GridGetsDistinctAgentsMD(t *testing.T) {
 	}
 
 	paneTarget := filepath.Join(dir, "pane-app")
-	if _, err := scaffoldCustomAppStarter(paneTarget, "pane-app", "", appTypes["annotation-queue"], false); err != nil {
+	if _, err := scaffoldCustomAppStarter(paneTarget, "pane-app", "", "", appTypes["annotation-queue"], false); err != nil {
 		t.Fatalf("scaffold 3-pane: %v", err)
 	}
 	paneAgents, err := os.ReadFile(filepath.Join(paneTarget, "AGENTS.md"))
@@ -234,7 +234,7 @@ func TestAppsInit_ScaffoldsAnnotationQueueFiles(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "my-app")
 
-	written, err := scaffoldCustomAppStarter(target, "my-app", "Does the thing", appTypes["annotation-queue"], false)
+	written, err := scaffoldCustomAppStarter(target, "my-app", "Does the thing", "", appTypes["annotation-queue"], false)
 	if err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestAppsInit_ScaffoldsBlankFiles(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "my-app")
 
-	written, err := scaffoldCustomAppStarter(target, "my-app", "", appTypes["blank"], false)
+	written, err := scaffoldCustomAppStarter(target, "my-app", "", "", appTypes["blank"], false)
 	if err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
@@ -314,7 +314,7 @@ func TestAppsInit_CopiesNonTemplatedFilesVerbatim(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "my-app")
 
-	if _, err := scaffoldCustomAppStarter(target, "my-app", "", appTypes["annotation-queue"], false); err != nil {
+	if _, err := scaffoldCustomAppStarter(target, "my-app", "", "", appTypes["annotation-queue"], false); err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
 
@@ -331,7 +331,7 @@ func TestAppsInit_DefaultsDescription(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "my-app")
 
-	if _, err := scaffoldCustomAppStarter(target, "my-app", "", appTypes["annotation-queue"], false); err != nil {
+	if _, err := scaffoldCustomAppStarter(target, "my-app", "", "", appTypes["annotation-queue"], false); err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
 	readme, err := os.ReadFile(filepath.Join(target, "README.md"))
@@ -348,7 +348,7 @@ func TestAppsInit_RejectsNonEmptyDirWithoutForce(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "existing.txt"), []byte("hi"), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	_, err := scaffoldCustomAppStarter(dir, "my-app", "", appTypes["annotation-queue"], false)
+	_, err := scaffoldCustomAppStarter(dir, "my-app", "", "", appTypes["annotation-queue"], false)
 	if err == nil || !strings.Contains(err.Error(), "not empty") {
 		t.Errorf("expected not-empty error, got %v", err)
 	}
@@ -359,7 +359,7 @@ func TestAppsInit_ForceWritesOverNonEmpty(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "existing.txt"), []byte("hi"), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	if _, err := scaffoldCustomAppStarter(dir, "my-app", "", appTypes["annotation-queue"], true); err != nil {
+	if _, err := scaffoldCustomAppStarter(dir, "my-app", "", "", appTypes["annotation-queue"], true); err != nil {
 		t.Fatalf("scaffold with force: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "package.json")); err != nil {
@@ -369,14 +369,14 @@ func TestAppsInit_ForceWritesOverNonEmpty(t *testing.T) {
 
 func TestAppsInit_RequiresName(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := scaffoldCustomAppStarter(filepath.Join(dir, "app"), "", "", appTypes["annotation-queue"], false); err == nil {
+	if _, err := scaffoldCustomAppStarter(filepath.Join(dir, "app"), "", "", "", appTypes["annotation-queue"], false); err == nil {
 		t.Fatal("expected error when --name is empty")
 	}
 }
 
 func TestAppsInit_RequiresValidType(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := scaffoldCustomAppStarter(dir, "my-app", "", appType{}, false); err == nil {
+	if _, err := scaffoldCustomAppStarter(dir, "my-app", "", "", appType{}, false); err == nil {
 		t.Fatal("expected error for a zero-value (invalid) app type")
 	}
 }
@@ -385,7 +385,7 @@ func TestAppsInit_WritesTemplateSpecificAgentsMD(t *testing.T) {
 	dir := t.TempDir()
 
 	blankTarget := filepath.Join(dir, "blank-app")
-	if _, err := scaffoldCustomAppStarter(blankTarget, "blank-app", "", appTypes["blank"], false); err != nil {
+	if _, err := scaffoldCustomAppStarter(blankTarget, "blank-app", "", "", appTypes["blank"], false); err != nil {
 		t.Fatalf("scaffold blank: %v", err)
 	}
 	blankAgents, err := os.ReadFile(filepath.Join(blankTarget, "AGENTS.md"))
@@ -397,7 +397,7 @@ func TestAppsInit_WritesTemplateSpecificAgentsMD(t *testing.T) {
 	}
 
 	aqTarget := filepath.Join(dir, "aq-app")
-	if _, err := scaffoldCustomAppStarter(aqTarget, "aq-app", "", appTypes["annotation-queue"], false); err != nil {
+	if _, err := scaffoldCustomAppStarter(aqTarget, "aq-app", "", "", appTypes["annotation-queue"], false); err != nil {
 		t.Fatalf("scaffold annotation-queue: %v", err)
 	}
 	aqAgents, err := os.ReadFile(filepath.Join(aqTarget, "AGENTS.md"))
@@ -692,7 +692,7 @@ func TestAppsInit_PullsInEverySharedFileATemplateImports(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "my-app")
 
-	written, err := scaffoldCustomAppStarter(target, "my-app", "", appTypes["annotation-queue-grid"], false)
+	written, err := scaffoldCustomAppStarter(target, "my-app", "", "", appTypes["annotation-queue-grid"], false)
 	if err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
@@ -728,7 +728,7 @@ func TestAppsInit_OnlyPullsInSharedFilesActuallyImported(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "my-app")
 
-	written, err := scaffoldCustomAppStarter(target, "my-app", "", appTypes["experiment-comparison"], false)
+	written, err := scaffoldCustomAppStarter(target, "my-app", "", "", appTypes["experiment-comparison"], false)
 	if err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}

--- a/internal/cmd/apps_push.go
+++ b/internal/cmd/apps_push.go
@@ -77,6 +77,11 @@ same app too.
 			// A link file can exist with no app_id yet (from "apps init").
 			notYetCreated := link == nil || link.AppID == ""
 
+			configuredContext := ""
+			if link != nil {
+				configuredContext = normalizeAppContextType(link.ContextType)
+			}
+
 			c := MustGetClient()
 			ctx := cmd.Context()
 
@@ -105,9 +110,13 @@ same app too.
 			}
 
 			if updated {
+				if err := checkContextTypeImmutable(app, configuredContext); err != nil {
+					return err
+				}
 				if err := writeAppLink(dir, appLink{
-					AppID: app.ID,
-					Name:  app.Name,
+					AppID:       app.ID,
+					Name:        app.Name,
+					ContextType: normalizeAppContextType(app.ContextType),
 				}); err != nil {
 					return err
 				}
@@ -125,6 +134,7 @@ same app too.
 					Entrypoint:    &entrypoint,
 					SourceArchive: optionalString(sourceArchive),
 					Description:   optionalString(description),
+					ContextType:   optionalString(configuredContext),
 				}
 				if err := c.RawPost(ctx, c.CustomAppsPath(), payload, &app); err != nil {
 					if isSourceArchiveRejection(err) {
@@ -136,8 +146,9 @@ same app too.
 					return fmt.Errorf("creating custom app: %w", err)
 				}
 				if err := writeAppLink(dir, appLink{
-					AppID: app.ID,
-					Name:  app.Name,
+					AppID:       app.ID,
+					Name:        app.Name,
+					ContextType: normalizeAppContextType(app.ContextType),
 				}); err != nil {
 					return err
 				}
@@ -154,11 +165,12 @@ same app too.
 				status = "updated"
 			}
 			result := map[string]any{
-				"status":     status,
-				"app_id":     app.ID,
-				"name":       app.Name,
-				"entrypoint": app.Entrypoint,
-				"files":      paths,
+				"status":       status,
+				"app_id":       app.ID,
+				"name":         app.Name,
+				"entrypoint":   app.Entrypoint,
+				"context_type": contextTypeForOutput(normalizeAppContextType(app.ContextType)),
+				"files":        paths,
 			}
 			if err := output.OutputJSON(result, ""); err != nil {
 				return err
@@ -180,6 +192,19 @@ same app too.
 	cmd.Flags().StringVar(&entrypoint, "entrypoint", "dist/bundle.js", "Path (relative to the current directory) of the file to render")
 	cmd.Flags().BoolVar(&noBuild, "no-build", false, "Skip building before uploading, even if package.json has a \"build\" script")
 	return cmd
+}
+
+func checkContextTypeImmutable(app customApp, configured string) error {
+	serverContext := normalizeAppContextType(app.ContextType)
+	configured = normalizeAppContextType(configured)
+	if app.ContextType == "" || serverContext == configured {
+		return nil
+	}
+	return fmt.Errorf(
+		"this app was created with context type %q, but .langsmith/app.json now asks for %q. "+
+			"Context type is fixed when the app is first pushed and cannot be changed. "+
+			"To change it, delete and recreate the app: `langsmith apps delete %q --yes` then `langsmith apps push`",
+		contextTypeForOutput(serverContext), contextTypeForOutput(configured), app.Name)
 }
 
 func optionalString(s string) *string {

--- a/internal/cmd/templates/agents-md/thread.md
+++ b/internal/cmd/templates/agents-md/thread.md
@@ -1,0 +1,29 @@
+## This template: thread context
+
+This app declares **context type `thread`**: it's embedded in a tracing
+project's thread view, and the host hands it `{ threadId, projectId }` as
+`render`'s `data` (the first argument). Everything else it fetches itself
+through `window.langsmith.call`.
+
+`data` is `{ threadId: string; projectId: string }`. Under
+`langsmith apps dev` both are empty strings unless you pass
+`--thread-id <id> --project-id <id>` — handle that empty case (this starter
+shows a hint instead of erroring).
+
+The starter loads the thread's chronological messages with:
+
+```ts
+await window.langsmith.call('POST /v1/trajectory', {
+  body: { project_id: projectId, thread_id: threadId, format: 'messages' },
+});
+```
+
+which returns `{ messages, next_cursor }`; page with `cursor` until
+`next_cursor` is null. (Don't use `GET /v2/threads/{id}/messages` — it's
+SSE-only.) See `src/App.tsx`.
+
+Context type is fixed when the app is first pushed and cannot be changed. To
+switch an app between context types, delete and recreate it.
+
+This is just a starting point, not a spec. Change the layout, fetch different
+thread-scoped data, or build whatever thread-view app you actually want.

--- a/internal/cmd/templates/thread/.gitignore
+++ b/internal/cmd/templates/thread/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/internal/cmd/templates/thread/README.md
+++ b/internal/cmd/templates/thread/README.md
@@ -1,0 +1,78 @@
+# {{.Name}}
+
+{{.Description}}
+
+A LangSmith **thread-context** custom app, scaffolded by `langsmith apps init
+--template thread`. It's embedded in a tracing project's thread view and is
+handed `{ threadId, projectId }` as `render`'s `data`; it fetches the thread's
+messages itself and lists them. **Read `AGENTS.md` first** — it documents the
+LangSmith API surface this app can call.
+
+## What this is
+
+A custom app is a small React/TS UI rendered inside LangSmith in a
+locked-down sandbox (`sandbox="allow-scripts"`, no `allow-same-origin`). It
+never gets direct network access or a real credential — everything goes
+through a `postMessage` bridge to the host page (`window.langsmith.call`),
+which proxies to the real LangSmith API under the viewer's own session (or
+your local `LANGSMITH_API_KEY` when running `langsmith apps dev`).
+
+Because this app declares **context type `thread`**, the host binds it to a
+specific thread at render time and passes `{ threadId, projectId }` as the
+first argument to `render(data, root, metadata)`. Context type is fixed when
+the app is first pushed and cannot be changed later.
+
+Since the sandbox has no bundler or npm access at runtime, this app is built
+with Vite in **library mode**: `npm run build` bundles everything (React
+included) into a single dependency-free file (`dist/bundle.js`) before it's
+pushed. Use npm dependencies freely — they all get inlined at build time.
+
+## Develop
+
+Install dependencies, then start the dev server with a real thread to bind to:
+
+```bash
+npm install
+langsmith apps dev --thread-id <thread-id> --project-id <project-id>
+```
+
+`apps dev` runs the app inside a real sandboxed iframe, identical restrictions
+to production, and automatically starts `npm run watch` for you — edit
+`src/App.tsx`, save, and the preview reloads on its own. Without
+`--thread-id`/`--project-id` the app renders with empty context and shows how
+to pass them.
+
+## The bridge contract
+
+`src/entry.tsx` exports a `render(data, root, metadata)` function that the
+host calls once on load and again whenever `data` or `metadata` changes. For a
+thread app, `data` is `{ threadId, projectId }` (both empty strings in dev
+until you pass the flags). `metadata.mode` is `"dark"` or `"light"`; the
+sandbox sets `html.dark` from it, so this token-based UI themes automatically.
+`src/App.tsx` is the actual UI; edit it freely.
+
+`window.langsmith`, injected by the host page, gives you:
+
+- `window.langsmith.call(operation, args)` — `operation` is a
+  `"<METHOD> <path>"` string (e.g. `"POST /v1/trajectory"`), forwarded as-is
+  to the real LangSmith API. See `AGENTS.md` for the available surface.
+- `window.langsmith.setData(patch)` — push a data mutation out for the host
+  to persist.
+- `window.langsmith.feedback.create(args)` — sugar over
+  `call('POST /api/v1/feedback', {body: args})`.
+
+This starter loads the thread's messages via `POST /v1/trajectory`
+(`format: "messages"`) using the `projectId` and `threadId` it's given — see
+`src/App.tsx`.
+
+## Deploy
+
+```bash
+npm run build
+langsmith apps push
+```
+
+The first `push` creates the app with `context_type: thread` (recorded in
+`.langsmith/app.json`) and writes the app's ID there — commit it so teammates'
+pushes update the same app. Every push after that updates it in place; the
+context type is fixed and cannot change.

--- a/internal/cmd/templates/thread/postcss.config.js
+++ b/internal/cmd/templates/thread/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/internal/cmd/templates/thread/src/App.tsx
+++ b/internal/cmd/templates/thread/src/App.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react';
+
+// A minimal thread viewer, wired to the { threadId, projectId } this app is
+// rendered with. It loads the thread's chronological messages via
+// POST /v1/trajectory (format: "messages") and lists them. This is a starting
+// point — rip it out and build whatever thread-scoped UI you actually want; see
+// AGENTS.md for the full LangSmith API surface.
+
+interface StandardMessage {
+  role: string;
+  content: string | Array<string | Record<string, unknown>>;
+}
+
+// Cap paging so a very long thread can't loop forever.
+const MAX_PAGES = 20;
+
+async function fetchThreadMessages(
+  threadId: string,
+  projectId: string
+): Promise<StandardMessage[]> {
+  const messages: StandardMessage[] = [];
+  let cursor: string | undefined;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const body: Record<string, string> = {
+      project_id: projectId,
+      thread_id: threadId,
+      format: 'messages',
+    };
+    if (cursor) body.cursor = cursor;
+    const resp = (await window.langsmith.call('POST /v1/trajectory', { body })) as {
+      messages?: StandardMessage[];
+      next_cursor?: string | null;
+    };
+    messages.push(...(resp.messages ?? []));
+    if (!resp.next_cursor) break;
+    cursor = resp.next_cursor;
+  }
+  return messages;
+}
+
+function messageText(content: StandardMessage['content']): string {
+  if (typeof content === 'string') return content;
+  return content
+    .map((part) => (typeof part === 'string' ? part : JSON.stringify(part)))
+    .join('\n');
+}
+
+export function App({ data }: { data: ThreadData; metadata?: RenderMetadata }) {
+  const { threadId, projectId } = data;
+  const [messages, setMessages] = useState<StandardMessage[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!threadId || !projectId) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchThreadMessages(threadId, projectId)
+      .then((msgs) => {
+        if (!cancelled) setMessages(msgs);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [threadId, projectId]);
+
+  // No context: happens under `langsmith apps dev` without --thread-id/--project-id.
+  if (!threadId || !projectId) {
+    return (
+      <Frame>
+        <h1 className="text-lg font-semibold text-primary">Thread app</h1>
+        <p className="mt-2 text-sm leading-relaxed text-tertiary">
+          This app renders inside a project's thread view and receives{' '}
+          <code className="text-secondary">{'{ threadId, projectId }'}</code>. To preview it
+          locally with real data, run:
+        </p>
+        <pre className="mt-3 overflow-x-auto rounded-lg border border-secondary bg-secondary p-3 text-xs leading-relaxed text-secondary">
+          {'langsmith apps dev \\\n  --thread-id <thread-id> \\\n  --project-id <project-id>'}
+        </pre>
+      </Frame>
+    );
+  }
+
+  return (
+    <Frame wide>
+      <div className="mb-4">
+        <h1 className="text-lg font-semibold text-primary">Thread</h1>
+        <p className="mt-1 font-mono text-xs text-quaternary">{threadId}</p>
+      </div>
+
+      {loading && <p className="text-sm text-tertiary">Loading messages…</p>}
+
+      {error && (
+        <div className="rounded-lg border border-error bg-error p-3 text-sm text-error-primary">
+          {error}
+        </div>
+      )}
+
+      {messages && messages.length === 0 && !loading && (
+        <p className="text-sm text-tertiary">No messages in this thread.</p>
+      )}
+
+      {messages && messages.length > 0 && (
+        <ul className="flex flex-col gap-3">
+          {messages.map((m, i) => (
+            <li
+              key={i}
+              className="rounded-lg border border-secondary bg-elevated p-3 shadow-sm"
+            >
+              <div className="text-xs font-medium uppercase tracking-wide text-quaternary">
+                {m.role}
+              </div>
+              <pre className="mt-1.5 whitespace-pre-wrap break-words text-sm leading-relaxed text-secondary">
+                {messageText(m.content)}
+              </pre>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Frame>
+  );
+}
+
+function Frame({ children, wide }: { children: React.ReactNode; wide?: boolean }) {
+  return (
+    <div className="min-h-screen bg-surface-level-1 p-6">
+      <div className={`mx-auto w-full ${wide ? 'max-w-3xl' : 'max-w-md'}`}>{children}</div>
+    </div>
+  );
+}

--- a/internal/cmd/templates/thread/src/entry.tsx
+++ b/internal/cmd/templates/thread/src/entry.tsx
@@ -1,0 +1,29 @@
+import { createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import css from './index.css?inline';
+import { App } from './App';
+
+let root: Root | null = null;
+let styleInjected = false;
+
+function ensureStyles() {
+  if (styleInjected) return;
+  const style = document.createElement('style');
+  style.textContent = css;
+  document.head.appendChild(style);
+  styleInjected = true;
+}
+
+// A "thread" context app: `data` is { threadId, projectId } (empty in
+// `langsmith apps dev` unless you pass --thread-id/--project-id). The host
+// re-calls render() whenever data or metadata changes.
+export function render(data: ThreadData, container: HTMLElement, metadata: RenderMetadata) {
+  ensureStyles();
+  if (!root) {
+    root = createRoot(container);
+  }
+  root.render(createElement(App, { data, metadata }));
+}
+
+// Some sandbox hosts call a bare default export; support both shapes.
+export default { render };

--- a/internal/cmd/templates/thread/src/global.d.ts
+++ b/internal/cmd/templates/thread/src/global.d.ts
@@ -1,0 +1,27 @@
+export {};
+
+declare global {
+  /** render()'s 3rd arg, an open/extensible dict. v1 has only `mode`
+   * ("dark"|"light"); the sandbox sets `html.dark` from it. */
+  type RenderMetadata = { mode: 'dark' | 'light' };
+
+  /** render()'s 1st arg for a "thread" context app: the thread this app is
+   * embedded in, plus the tracing project it belongs to. Everything else the
+   * app fetches itself via window.langsmith.call. When running
+   * `langsmith apps dev` without --thread-id/--project-id these are empty. */
+  type ThreadData = { threadId: string; projectId: string };
+
+  interface Window {
+    /** Injected by the host page (LangSmith, or `langsmith apps dev` locally) — see AGENTS.md. */
+    langsmith: {
+      call: (
+        operation: string,
+        args?: { params?: Record<string, string | string[]>; body?: unknown }
+      ) => Promise<unknown>;
+      setData: (patch: Record<string, unknown>) => void;
+      feedback: {
+        create: (args: Record<string, unknown>) => Promise<unknown>;
+      };
+    };
+  }
+}

--- a/internal/cmd/templates/thread/src/index.css
+++ b/internal/cmd/templates/thread/src/index.css
@@ -1,0 +1,386 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  html {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    color-scheme: light;
+  }
+
+  html.dark {
+    color-scheme: dark;
+  }
+
+  body {
+    background-color: var(--bg-surface-level-1);
+    color: var(--text-primary);
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 14px;
+    min-height: 100vh;
+  }
+
+  * {
+    outline-color: var(--brand-400);
+  }
+
+  :root {
+    /* gray */
+    --gray-25: #fcfcfc;
+    --gray-50: #fafafa;
+    --gray-100: #f4f4f5;
+    --gray-200: #e4e4e7;
+    --gray-300: #d1d1d6;
+    --gray-400: #a0a0ab;
+    --gray-500: #70707b;
+    --gray-600: #51525c;
+    --gray-700: #3f3f46;
+    --gray-800: #26272b;
+    --gray-900: #1a1a1e;
+    --gray-950: #131316;
+
+    /* neutral */
+    --neutral-25: #fafbfd;
+    --neutral-35: #f8fafc;
+    --neutral-50: #f5f8fb;
+    --neutral-100: #edf2f7;
+    --neutral-200: #e2e8f0;
+    --neutral-300: #cbd5e1;
+    --neutral-400: #94a3b8;
+    --neutral-500: #64748b;
+    --neutral-600: #475569;
+    --neutral-700: #334155;
+    --neutral-800: #1e293b;
+    --neutral-900: #0f172a;
+    --neutral-950: #080f1e;
+
+    --white: #ffffff;
+    --black: #000000;
+
+    /* brand */
+    --brand-10: #f2faff;
+    --brand-25: #e5f4ff;
+    --brand-50: #cce9ff;
+    --brand-75: #9dd2fc;
+    --brand-100: #5fbef8;
+    --brand-200: #008dff;
+    --brand-300: #0078f1;
+    --brand-400: #006ddd;
+    --brand-500: #1566b8;
+    --brand-600: #145095;
+    --brand-700: #0d3d77;
+    --brand-800: #0c336a;
+    --brand-900: #102656;
+    --brand-950: #101a30;
+
+    /* red */
+    --red-25: #fffbfa;
+    --red-50: #fef3f2;
+    --red-100: #fee4e2;
+    --red-200: #fecdca;
+    --red-300: #fda29b;
+    --red-400: #f97066;
+    --red-500: #f04438;
+    --red-600: #d92d20;
+    --red-700: #b42318;
+    --red-800: #912018;
+    --red-900: #7a271a;
+    --red-950: #55160c;
+
+    /* orange */
+    --orange-25: #fffcf5;
+    --orange-50: #fffaeb;
+    --orange-100: #fef0c7;
+    --orange-200: #fedf89;
+    --orange-300: #fec84b;
+    --orange-400: #fdb022;
+    --orange-500: #f79009;
+    --orange-600: #cd6002;
+    --orange-700: #ac5305;
+    --orange-800: #894101;
+    --orange-900: #6d3300;
+    --orange-950: #4c2400;
+
+    /* green */
+    --green-25: #f5fef9;
+    --green-50: #ecfdf3;
+    --green-100: #dcfae6;
+    --green-200: #acefc6;
+    --green-300: #75e0a7;
+    --green-400: #46cd89;
+    --green-500: #19b26b;
+    --green-600: #079455;
+    --green-700: #047647;
+    --green-800: #065d3a;
+    --green-900: #084d31;
+    --green-950: #053321;
+
+    /* acid */
+    --acid-10: #fafee8;
+    --acid-25: #f2fcc8;
+    --acid-50: #e3f797;
+    --acid-100: #cceb50;
+    --acid-200: #aecf1a;
+    --acid-300: #93b000;
+    --acid-400: #799200;
+    --acid-500: #607500;
+    --acid-600: #495a00;
+    --acid-700: #354200;
+    --acid-800: #232c00;
+    --acid-900: #141a00;
+    --acid-950: #0b1000;
+
+    /* purple */
+    --purple-10: #f9f7ff;
+    --purple-25: #f1ecff;
+    --purple-50: #e3d9ff;
+    --purple-100: #c5b4f0;
+    --purple-200: #a691df;
+    --purple-300: #8b71cc;
+    --purple-400: #7655b8;
+    --purple-500: #6244a0;
+    --purple-600: #4e3487;
+    --purple-700: #3b2560;
+    --purple-800: #291753;
+    --purple-900: #190d38;
+    --purple-950: #0f0822;
+
+    /* SEMANTIC TOKENS */
+
+    /* SURFACE */
+    --bg-surface-level-1: var(--white);
+    --bg-surface-level-1-hover: var(--neutral-25);
+    --bg-surface-level-2: var(--neutral-50);
+    --bg-surface-level-2-hover: var(--neutral-100);
+    --bg-surface-level-3: var(--neutral-100);
+    --bg-surface-level-4: var(--neutral-200);
+    --bg-disabled: var(--neutral-100);
+    --bg-elevated: var(--white);
+    --bg-elevated-hover: var(--neutral-25);
+    --bg-elevated-selected: var(--neutral-25);
+    --bg-overlay: rgba(0, 0, 0, 0.5);
+
+    /* BRAND */
+    --bg-brand: var(--brand-400);
+    --bg-brand-hover: var(--brand-500);
+    --bg-brand-subtle: var(--brand-25);
+    --bg-brand-subtle-hover: var(--brand-50);
+    --bg-brand-muted: var(--brand-10);
+    --bg-purple: var(--purple-50);
+
+    /* INTENT */
+    --bg-success: var(--green-50);
+    --bg-success-subtle: var(--green-100);
+    --bg-success-strong: var(--green-600);
+    --bg-error: var(--red-50);
+    --bg-error-subtle: var(--red-100);
+    --bg-error-strong: var(--red-600);
+    --bg-warning: var(--orange-50);
+    --bg-warning-subtle: var(--orange-100);
+    --bg-warning-strong: var(--orange-600);
+
+    /* CONTROL */
+    --bg-control-active: var(--brand-300);
+    --bg-control-active-hover: var(--brand-400);
+    --bg-control-thumb: var(--white);
+    --bg-control-disabled: var(--neutral-200);
+    --text-control-active-foreground: var(--bg-control-thumb);
+
+    /* SELECTED */
+    --bg-selected: var(--brand-25);
+    --bg-selected-hover: var(--brand-50);
+
+    /* BORDER */
+    --border-default: var(--neutral-300);
+    --border-subtle: var(--neutral-200);
+    --border-muted: var(--neutral-100);
+    --border-faint: var(--neutral-50);
+    --border-strong: var(--neutral-600);
+    --border-disabled: var(--neutral-200);
+    --border-focus: var(--brand-400);
+    --border-error: var(--red-300);
+    --border-error-strong: var(--red-600);
+    --border-brand: var(--brand-400);
+    --border-brand-strong: var(--brand-600);
+    --border-brand-subtle: var(--brand-100);
+    --border-warning: var(--orange-300);
+    --border-success: var(--green-200);
+    --border-purple: var(--purple-200);
+
+    /* TEXT */
+    --text-primary: var(--neutral-900);
+    --text-secondary: var(--neutral-700);
+    --text-secondary-hover: var(--neutral-800);
+    --text-tertiary: var(--neutral-600);
+    --text-tertiary-hover: var(--neutral-700);
+    --text-quaternary: var(--neutral-500);
+    --text-disabled: var(--neutral-300);
+    --text-placeholder: var(--neutral-400);
+    --text-error-primary: var(--red-700);
+    --text-error-secondary: var(--red-600);
+    --text-error-tertiary: var(--red-500);
+    --text-warning-primary: var(--orange-700);
+    --text-warning-secondary: var(--orange-600);
+    --text-warning-tertiary: var(--orange-500);
+    --text-success-primary: var(--green-700);
+    --text-success-secondary: var(--green-600);
+    --text-success-tertiary: var(--green-500);
+    --text-brand-primary: var(--brand-700);
+    --text-brand-secondary: var(--brand-600);
+    --text-brand-tertiary: var(--brand-500);
+    --text-brand-disabled: var(--brand-75);
+    --text-brand-on-fill: var(--white);
+    --text-link: var(--brand-300);
+    --text-link-hover: var(--brand-200);
+
+    /* ICON */
+    --icon-primary: var(--neutral-900);
+    --icon-secondary: var(--neutral-700);
+    --icon-tertiary: var(--neutral-500);
+    --icon-disabled: var(--neutral-300);
+    --icon-brand: var(--brand-400);
+    --icon-error: var(--red-600);
+    --icon-success: var(--green-600);
+    --icon-warning: var(--orange-600);
+
+    /* SHADOW */
+    --shadow-sm: 0 1px 3px rgba(16, 24, 40, 0.1), 0 1px 2px rgba(16, 24, 40, 0.06);
+    --shadow-md: 0 4px 6px -1px rgba(16, 24, 40, 0.1), 0 2px 4px -1px rgba(16, 24, 40, 0.06);
+    --shadow-lg: 0 10px 15px -3px rgba(16, 24, 40, 0.1), 0 4px 6px -2px rgba(16, 24, 40, 0.05);
+
+    /* RADIUS */
+    --radius-none: 0px;
+    --radius-xs: 3px;
+    --radius-sm: 4px;
+    --radius-md: 6px;
+    --radius-lg: 8px;
+    --radius-xl: 12px;
+    --radius-full: 9999px;
+
+    /* MOTION */
+    --duration-fast: 100ms;
+    --duration-normal: 200ms;
+    --duration-slow: 300ms;
+    --duration-slower: 500ms;
+
+    /* DEPRECATED ALIASES */
+    --bg-primary: var(--bg-surface-level-1);
+    --bg-primary-hover: var(--bg-surface-level-1-hover);
+    --bg-secondary: var(--bg-surface-level-2);
+    --bg-secondary-hover: var(--bg-surface-level-2-hover);
+    --bg-tertiary: var(--bg-surface-level-3);
+    --bg-quaternary: var(--bg-surface-level-4);
+    --bg-brand-primary: var(--bg-brand);
+    --bg-brand-primary_hover: var(--bg-brand-hover);
+    --bg-brand-secondary: var(--bg-brand-subtle);
+    --bg-brand-secondary_hover: var(--bg-brand-subtle-hover);
+    --bg-brand-tertiary: var(--bg-brand-muted);
+    --bg-success-primary: var(--bg-success);
+    --bg-success-secondary: var(--bg-success-subtle);
+    --bg-error-primary: var(--bg-error);
+    --bg-error-secondary: var(--bg-error-subtle);
+    --bg-warning-primary: var(--bg-warning);
+    --bg-warning-secondary: var(--bg-warning-subtle);
+    --border-primary: var(--border-default);
+    --border-secondary: var(--border-subtle);
+    --border-tertiary: var(--border-muted);
+    --border-quaternary: var(--border-faint);
+    --text-button-primary: var(--white);
+  }
+
+  html.dark {
+    --gray-25: #131316;
+    --gray-50: #1a1a1e;
+    --gray-100: #26272b;
+    --gray-200: #3f3f46;
+    --gray-300: #51525c;
+    --gray-400: #70707b;
+    --gray-500: #a0a0ab;
+    --gray-600: #d1d1d6;
+    --gray-700: #e4e4e7;
+    --gray-800: #f4f4f5;
+    --gray-900: #fafafa;
+    --gray-950: #fcfcfc;
+
+    --neutral-25: #09090f;
+    --neutral-35: #0d0f18;
+    --neutral-50: #111521;
+    --neutral-100: #1b2030;
+    --neutral-200: #282e42;
+    --neutral-300: #393f55;
+    --neutral-400: #555d78;
+    --neutral-500: #8790ab;
+    --neutral-600: #cbd5e1;
+    --neutral-700: #e2e8f0;
+    --neutral-800: #edf2f7;
+    --neutral-900: #f5f8fb;
+    --neutral-950: #fafbfd;
+
+    --white: #131316;
+    --black: #ffffff;
+
+    --brand-10: #101a30;
+    --brand-25: #102656;
+    --brand-50: #0c336a;
+    --brand-75: #0c3871;
+    --brand-100: #0d3d77;
+    --brand-200: #145095;
+    --brand-300: #1566b8;
+    --brand-400: #006ddd;
+    --brand-500: #0078f1;
+    --brand-600: #008dff;
+    --brand-700: #5fbef8;
+    --brand-800: #cce9ff;
+    --brand-900: #e5f4ff;
+    --brand-950: #f2faff;
+
+    --red-25: #55160c;
+    --red-50: #7a271a;
+    --red-100: #912018;
+    --red-200: #b42318;
+    --red-300: #d92d20;
+    --red-400: #f04438;
+    --red-500: #f97066;
+    --red-600: #fda29b;
+    --red-700: #fecdca;
+    --red-800: #fee4e2;
+    --red-900: #fef3f2;
+    --red-950: #fffbfa;
+
+    --orange-25: #4c2400;
+    --orange-50: #6d3300;
+    --orange-100: #894101;
+    --orange-200: #ac5305;
+    --orange-300: #cd6002;
+    --orange-400: #f79009;
+    --orange-500: #fdb022;
+    --orange-600: #fec84b;
+    --orange-700: #fedf89;
+    --orange-800: #fef0c7;
+    --orange-900: #fffaeb;
+    --orange-950: #fffcf5;
+
+    --green-25: #053321;
+    --green-50: #084d31;
+    --green-100: #065d3a;
+    --green-200: #047647;
+    --green-300: #079455;
+    --green-400: #19b26b;
+    --green-500: #46cd89;
+    --green-600: #75e0a7;
+    --green-700: #acefc6;
+    --green-800: #dcfae6;
+    --green-900: #ecfdf3;
+    --green-950: #f5fef9;
+  }
+}
+
+@keyframes linear-progress-indeterminate {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(800%);
+  }
+}

--- a/internal/cmd/templates/thread/src/vite-env.d.ts
+++ b/internal/cmd/templates/thread/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/internal/cmd/templates/thread/tailwind.config.js
+++ b/internal/cmd/templates/thread/tailwind.config.js
@@ -1,0 +1,128 @@
+const withAlpha = (cssVar) => ({ opacityValue }) =>
+  opacityValue !== undefined
+    ? `color-mix(in srgb, ${cssVar} calc(${opacityValue} * 100%), transparent)`
+    : cssVar;
+
+const spaceScale = {
+  'space-1': '0.25rem',
+  'space-2': '0.5rem',
+  'space-3': '0.75rem',
+  'space-4': '1rem',
+  'space-5': '1.25rem',
+  'space-6': '1.5rem',
+  'space-7': '2rem',
+  'space-8': '2.5rem',
+  'space-9': '4rem',
+};
+
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      backgroundColor: {
+        // Surfaces
+        'surface-level-1': withAlpha('var(--bg-surface-level-1)'),
+        'surface-level-2': withAlpha('var(--bg-surface-level-2)'),
+        'surface-level-3': withAlpha('var(--bg-surface-level-3)'),
+        'surface-level-4': withAlpha('var(--bg-surface-level-4)'),
+        'elevated': withAlpha('var(--bg-elevated)'),
+        'elevated-hover': withAlpha('var(--bg-elevated-hover)'),
+        'disabled': withAlpha('var(--bg-disabled)'),
+        // Brand
+        'brand': withAlpha('var(--bg-brand)'),
+        'brand-hover': withAlpha('var(--bg-brand-hover)'),
+        'brand-subtle': withAlpha('var(--bg-brand-subtle)'),
+        'brand-subtle-hover': withAlpha('var(--bg-brand-subtle-hover)'),
+        'brand-muted': withAlpha('var(--bg-brand-muted)'),
+        // Intent
+        'success': withAlpha('var(--bg-success)'),
+        'success-subtle': withAlpha('var(--bg-success-subtle)'),
+        'success-strong': withAlpha('var(--bg-success-strong)'),
+        'error': withAlpha('var(--bg-error)'),
+        'error-subtle': withAlpha('var(--bg-error-subtle)'),
+        'error-strong': withAlpha('var(--bg-error-strong)'),
+        'warning': withAlpha('var(--bg-warning)'),
+        'warning-subtle': withAlpha('var(--bg-warning-subtle)'),
+        'warning-strong': withAlpha('var(--bg-warning-strong)'),
+        // Controls
+        'control-active': withAlpha('var(--bg-control-active)'),
+        'control-thumb': withAlpha('var(--bg-control-thumb)'),
+        'control-disabled': withAlpha('var(--bg-control-disabled)'),
+        // Selected
+        'selected': withAlpha('var(--bg-selected)'),
+        'selected-hover': withAlpha('var(--bg-selected-hover)'),
+        // Deprecated aliases (for compatibility with existing classes)
+        'primary': withAlpha('var(--bg-surface-level-1)'),
+        'secondary': withAlpha('var(--bg-surface-level-2)'),
+        'tertiary': withAlpha('var(--bg-surface-level-3)'),
+        'quaternary': withAlpha('var(--bg-surface-level-4)'),
+      },
+      borderColor: {
+        'default': withAlpha('var(--border-default)'),
+        'subtle': withAlpha('var(--border-subtle)'),
+        'muted': withAlpha('var(--border-muted)'),
+        'faint': withAlpha('var(--border-faint)'),
+        'strong': withAlpha('var(--border-strong)'),
+        'disabled': withAlpha('var(--border-disabled)'),
+        'focus': withAlpha('var(--border-focus)'),
+        'error': withAlpha('var(--border-error)'),
+        'error-strong': withAlpha('var(--border-error-strong)'),
+        'brand': withAlpha('var(--border-brand)'),
+        'brand-strong': withAlpha('var(--border-brand-strong)'),
+        'brand-subtle': withAlpha('var(--border-brand-subtle)'),
+        'warning': withAlpha('var(--border-warning)'),
+        'success': withAlpha('var(--border-success)'),
+        // Deprecated aliases
+        'primary': withAlpha('var(--border-default)'),
+        'secondary': withAlpha('var(--border-subtle)'),
+        'tertiary': withAlpha('var(--border-muted)'),
+        'quaternary': withAlpha('var(--border-faint)'),
+      },
+      textColor: {
+        'primary': withAlpha('var(--text-primary)'),
+        'secondary': withAlpha('var(--text-secondary)'),
+        'tertiary': withAlpha('var(--text-tertiary)'),
+        'quaternary': withAlpha('var(--text-quaternary)'),
+        'disabled': withAlpha('var(--text-disabled)'),
+        'placeholder': withAlpha('var(--text-placeholder)'),
+        'error-primary': withAlpha('var(--text-error-primary)'),
+        'error-secondary': withAlpha('var(--text-error-secondary)'),
+        'warning-primary': withAlpha('var(--text-warning-primary)'),
+        'success-primary': withAlpha('var(--text-success-primary)'),
+        'brand-primary': withAlpha('var(--text-brand-primary)'),
+        'brand-secondary': withAlpha('var(--text-brand-secondary)'),
+        'brand-on-fill': withAlpha('var(--text-brand-on-fill)'),
+        'link': withAlpha('var(--text-link)'),
+        'link-hover': withAlpha('var(--text-link-hover)'),
+        'icon-primary': withAlpha('var(--icon-primary)'),
+        'icon-secondary': withAlpha('var(--icon-secondary)'),
+        'icon-tertiary': withAlpha('var(--icon-tertiary)'),
+        'icon-disabled': withAlpha('var(--icon-disabled)'),
+        'icon-brand': withAlpha('var(--icon-brand)'),
+        'icon-error': withAlpha('var(--icon-error)'),
+        'icon-success': withAlpha('var(--icon-success)'),
+        'icon-warning': withAlpha('var(--icon-warning)'),
+      },
+      borderRadius: {
+        'xs': 'var(--radius-xs)',
+        'sm': 'var(--radius-sm)',
+        'md': 'var(--radius-md)',
+        'lg': 'var(--radius-lg)',
+        'xl': 'var(--radius-xl)',
+        'full': 'var(--radius-full)',
+      },
+      boxShadow: {
+        'sm': 'var(--shadow-sm)',
+        'md': 'var(--shadow-md)',
+        'lg': 'var(--shadow-lg)',
+      },
+      gap: spaceScale,
+      padding: spaceScale,
+      margin: spaceScale,
+      space: spaceScale,
+    },
+  },
+  plugins: [],
+};

--- a/internal/cmd/templates/thread/tsconfig.json
+++ b/internal/cmd/templates/thread/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/internal/cmd/templates/thread/vite.config.ts
+++ b/internal/cmd/templates/thread/vite.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// Library-mode build: the sandbox this app runs in evaluates a single
+// dependency-free CJS file exporting { render(data, root, metadata) } — not a
+// self-mounting SPA. See src/entry.tsx and AGENTS.md.
+export default defineConfig({
+  plugins: [react()],
+  // Unlike Vite's normal app-mode build, library mode does NOT replace
+  // process.env.NODE_ENV on its own — React/ReactDOM's bundled source still
+  // references it internally. There's no `process` global in the sandboxed
+  // iframe (or any browser), so without this the bundle throws
+  // "ReferenceError: process is not defined" the moment it's required.
+  define: {
+    'process.env.NODE_ENV': '"production"',
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    lib: {
+      entry: 'src/entry.tsx',
+      formats: ['cjs'],
+      fileName: () => 'bundle.js',
+    },
+  },
+});


### PR DESCRIPTION
Add a new type of Custom Apps for Threads. This app would specifically render in the thread view and take thread_id, project_id as a parameter. This is a change to add --context thread to the CLI to enable this workflow and goes together with a change in LangSmith to actually render and manage thread level apps.